### PR TITLE
feat(notifications): add inbox apis with authz

### DIFF
--- a/db/migrations/20260424000100_add_archived_at_to_notifications.cjs
+++ b/db/migrations/20260424000100_add_archived_at_to_notifications.cjs
@@ -1,0 +1,19 @@
+/**
+ * Add soft-delete archival support to notifications.
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('notifications', (table) => {
+    table.timestamp('archived_at', { useTz: true }).nullable()
+  })
+
+  await knex.schema.alterTable('notifications', (table) => {
+    table.index(['user_id', 'archived_at', 'created_at'], 'idx_notifications_user_archived_created')
+  })
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('notifications', (table) => {
+    table.dropIndex(['user_id', 'archived_at', 'created_at'], 'idx_notifications_user_archived_created')
+    table.dropColumn('archived_at')
+  })
+}

--- a/docs/notifications-api.md
+++ b/docs/notifications-api.md
@@ -1,0 +1,106 @@
+# Notifications API
+
+Authenticated inbox endpoints for end users.
+
+## Security rules
+
+- Every endpoint requires `Authorization: Bearer <jwt>`.
+- Each operation is scoped to `req.user.userId`.
+- Requests against another user's notification return `404` to avoid leaking record existence.
+- Notification metadata is sanitized before storage. Only safe reference fields such as `vaultId` are retained.
+- Generated notification messages should avoid embedding sensitive vault details directly in the message body.
+
+## Endpoints
+
+### `GET /api/notifications`
+
+Returns the authenticated user's inbox.
+
+Query parameters:
+
+- `page`: page number, default `1`
+- `pageSize`: page size, default `20`, max `100`
+- `sortBy`: one of `created_at`, `read_at`, `title`, `type`
+- `sortOrder`: `asc` or `desc`, default `desc`
+- `status`: `all`, `read`, or `unread`, default `all`
+- `includeArchived`: `true` to include archived notifications, default `false`
+
+Example response:
+
+```json
+{
+  "data": [
+    {
+      "id": "notif_123",
+      "user_id": "user_123",
+      "type": "vault_failure",
+      "title": "Vault Deadline Reached",
+      "message": "A vault in your account has expired and been marked as failed.",
+      "data": {
+        "vaultId": "vault_123"
+      },
+      "idempotency_key": null,
+      "read_at": null,
+      "archived_at": null,
+      "created_at": "2026-04-24T10:00:00.000Z"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "pageSize": 20,
+    "total": 1,
+    "totalPages": 1,
+    "hasNext": false,
+    "hasPrev": false
+  },
+  "sort": {
+    "sortBy": "created_at",
+    "sortOrder": "desc"
+  }
+}
+```
+
+### `PATCH /api/notifications/:id/read`
+
+Marks one notification as read for the authenticated user.
+
+- `200`: notification updated
+- `404`: notification missing, archived, or owned by another user
+
+### `POST /api/notifications/read-all`
+
+Marks all unread, non-archived notifications as read for the authenticated user.
+
+Example response:
+
+```json
+{
+  "updated": 4
+}
+```
+
+### `DELETE /api/notifications/:id`
+
+Soft-deletes a notification by setting `archived_at`.
+
+- The record remains in the database for auditability.
+- Archived notifications are hidden from the default inbox view.
+- Use `includeArchived=true` on list requests to retrieve them.
+
+Example response:
+
+```json
+{
+  "message": "Notification archived",
+  "notification": {
+    "id": "notif_123",
+    "archived_at": "2026-04-24T10:05:00.000Z"
+  }
+}
+```
+
+## Test expectations
+
+- Unauthenticated requests return `401`.
+- Cross-user read, archive, and list access is blocked.
+- Pagination and sorting behavior is covered by `src/tests/notification.test.ts`.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   lastLoginAt   DateTime?
   deletedAt     DateTime?
   vaults        Vault[]
+  notifications Notification[]
   refreshTokens RefreshToken[]
 
   @@index([deletedAt])
@@ -71,4 +72,24 @@ model Vault {
   @@index([status])
   @@index([endDate])
   @@map("vaults")
+}
+
+model Notification {
+  id             String    @id @default(uuid())
+  userId         String    @map("user_id")
+  user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  type           String
+  title          String
+  message        String
+  data           Json?
+  idempotencyKey String?   @map("idempotency_key")
+  readAt         DateTime? @map("read_at")
+  archivedAt     DateTime? @map("archived_at")
+  createdAt      DateTime  @default(now()) @map("created_at")
+
+  @@index([userId])
+  @@index([readAt])
+  @@index([userId, archivedAt, createdAt])
+  @@unique([userId, idempotencyKey])
+  @@map("notifications")
 }

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -1,49 +1,98 @@
-import { Router, Request, Response } from 'express'
+import { Router, type Request, type Response } from 'express'
 import { authenticate } from '../middleware/auth.js'
+import { queryParser } from '../middleware/queryParser.js'
+import type {
+  NotificationReadStatus,
+  NotificationSortField,
+} from '../types/notification.js'
 import {
+  archiveNotification,
   listUserNotifications,
-  markAsRead,
   markAllAsRead,
+  markAsRead,
 } from '../services/notification.js'
+
+const DEFAULT_SORT_BY: NotificationSortField = 'created_at'
+const DEFAULT_SORT_ORDER = 'desc' as const
+const ALLOWED_STATUSES: NotificationReadStatus[] = ['all', 'read', 'unread']
 
 export const notificationsRouter = Router()
 
-// All notifications routes require authentication
 notificationsRouter.use(authenticate)
 
-// GET /api/notifications - List current user's notifications
-notificationsRouter.get('/', async (req: Request, res: Response) => {
-  if (!req.user) {
-    res.status(401).json({ error: 'Unauthenticated' })
-    return
-  }
-  const notifications = await listUserNotifications(req.user.userId)
-  res.json(notifications)
-})
+notificationsRouter.get(
+  '/',
+  queryParser({
+    allowedSortFields: ['created_at', 'read_at', 'title', 'type'],
+  }),
+  async (req: Request, res: Response) => {
+    if (!req.user) {
+      res.status(401).json({ error: 'Unauthenticated' })
+      return
+    }
 
-// PATCH /api/notifications/:id/read - Mark a notification as read
+    const rawStatus = String(req.query.status ?? 'all').toLowerCase() as NotificationReadStatus
+    if (!ALLOWED_STATUSES.includes(rawStatus)) {
+      res.status(400).json({ error: 'Invalid status filter. Use all, read, or unread.' })
+      return
+    }
+
+    const includeArchived = ['true', '1'].includes(String(req.query.includeArchived ?? '').toLowerCase())
+
+    const notifications = await listUserNotifications(req.user.userId, {
+      page: req.pagination?.page ?? 1,
+      pageSize: req.pagination?.pageSize ?? 20,
+      sortBy: (req.sort?.sortBy as NotificationSortField | undefined) ?? DEFAULT_SORT_BY,
+      sortOrder: req.sort?.sortOrder ?? DEFAULT_SORT_ORDER,
+      includeArchived,
+      readStatus: rawStatus,
+    })
+
+    res.json(notifications)
+  },
+)
+
 notificationsRouter.patch('/:id/read', async (req: Request, res: Response) => {
   if (!req.user) {
     res.status(401).json({ error: 'Unauthenticated' })
     return
   }
-  const { id } = req.params
-  const notification = await markAsRead(id, req.user.userId)
-  
+
+  const notification = await markAsRead(req.params.id, req.user.userId)
+
   if (!notification) {
     res.status(404).json({ error: 'Notification not found' })
     return
   }
-  
+
   res.json(notification)
 })
 
-// POST /api/notifications/read-all - Mark all as read
 notificationsRouter.post('/read-all', async (req: Request, res: Response) => {
   if (!req.user) {
     res.status(401).json({ error: 'Unauthenticated' })
     return
   }
-  const count = await markAllAsRead(req.user.userId)
-  res.json({ message: `Marked ${count} notifications as read` })
+
+  const updated = await markAllAsRead(req.user.userId)
+  res.json({ updated })
+})
+
+notificationsRouter.delete('/:id', async (req: Request, res: Response) => {
+  if (!req.user) {
+    res.status(401).json({ error: 'Unauthenticated' })
+    return
+  }
+
+  const notification = await archiveNotification(req.params.id, req.user.userId)
+
+  if (!notification) {
+    res.status(404).json({ error: 'Notification not found' })
+    return
+  }
+
+  res.json({
+    message: 'Notification archived',
+    notification,
+  })
 })

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -1,7 +1,27 @@
 import { db } from '../db/index.js'
-import type { Notification, CreateNotificationInput } from '../types/notification.js'
+import type {
+  Notification,
+  CreateNotificationInput,
+  NotificationData,
+  NotificationListOptions,
+  NotificationListResult,
+  NotificationSortField,
+} from '../types/notification.js'
 
-// Minimal structured logger — emits JSON to stdout, no PII (no user_id, title, message)
+const DEFAULT_SORT_BY: NotificationSortField = 'created_at'
+const SAFE_DATA_KEYS = new Set([
+  'vaultId',
+  'milestoneId',
+  'transactionId',
+  'organizationId',
+  'verificationId',
+  'eventId',
+  'actionUrl',
+  'resourceId',
+  'resourceType',
+  'category',
+])
+
 const log = {
   debug: (event: string, fields: { idempotency_key: string; id: string }) => {
     try {
@@ -19,66 +39,184 @@ const log = {
   },
 }
 
+const redactSensitiveText = (value: string): string => {
+  return value
+    .replace(/\b[GS][A-Z2-7]{55}\b/g, '[redacted-account]')
+    .replace(
+      /\b(success_destination|failure_destination|privateKey|secretKey|seed|mnemonic|password|password_hash)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[redacted]',
+    )
+}
+
+const sanitizeNotificationData = (value: NotificationData | undefined): NotificationData => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+
+  const sanitized = Object.entries(value).reduce<Record<string, unknown>>((acc, [key, entry]) => {
+    if (SAFE_DATA_KEYS.has(key)) {
+      acc[key] = entry
+    }
+    return acc
+  }, {})
+
+  return Object.keys(sanitized).length > 0 ? sanitized : null
+}
+
+const normalizeNotification = (row: any): Notification => {
+  let parsedData: NotificationData = null
+
+  if (row?.data && typeof row.data === 'string') {
+    try {
+      parsedData = sanitizeNotificationData(JSON.parse(row.data))
+    } catch {
+      parsedData = null
+    }
+  } else {
+    parsedData = sanitizeNotificationData(row?.data)
+  }
+
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    type: row.type,
+    title: row.title,
+    message: row.message,
+    data: parsedData,
+    idempotency_key: row.idempotency_key ?? null,
+    read_at: row.read_at ?? null,
+    archived_at: row.archived_at ?? null,
+    created_at: row.created_at,
+  }
+}
+
 export const createNotification = async (input: CreateNotificationInput): Promise<Notification> => {
   const row: Record<string, unknown> = {
     user_id: input.user_id,
     type: input.type,
-    title: input.title,
-    message: input.message,
-    data: input.data ? JSON.stringify(input.data) : null,
+    title: redactSensitiveText(input.title),
+    message: redactSensitiveText(input.message),
+    data: sanitizeNotificationData(input.data),
   }
+
   if (input.idempotency_key !== undefined) {
     row.idempotency_key = input.idempotency_key
   }
 
   try {
     const [notification] = await db('notifications').insert(row).returning('*')
+
     if (input.idempotency_key) {
       log.debug('notification_created_with_key', {
         idempotency_key: input.idempotency_key,
         id: notification.id,
       })
     }
-    return notification
+
+    return normalizeNotification(notification)
   } catch (err: any) {
     if (err.code === '23505' && input.idempotency_key) {
       const existing = await db('notifications')
         .where({ user_id: input.user_id, idempotency_key: input.idempotency_key })
         .first()
+
       if (!existing) {
         throw err
       }
-      try {
-        log.info('notification_dedupe_suppressed', {
-          idempotency_key: input.idempotency_key,
-          id: existing.id,
-        })
-      } catch {
-        // swallow logger errors
-      }
-      return existing
+
+      log.info('notification_dedupe_suppressed', {
+        idempotency_key: input.idempotency_key,
+        id: existing.id,
+      })
+
+      return normalizeNotification(existing)
     }
+
     throw err
   }
 }
 
-export const listUserNotifications = async (userId: string): Promise<Notification[]> => {
-  return db('notifications')
-    .where({ user_id: userId })
-    .orderBy('created_at', 'desc')
+export const listUserNotifications = async (
+  userId: string,
+  options: NotificationListOptions,
+): Promise<NotificationListResult> => {
+  const sortBy = options.sortBy ?? DEFAULT_SORT_BY
+
+  const countQuery = db('notifications').where({ user_id: userId })
+  const dataQuery = db('notifications').where({ user_id: userId })
+
+  if (!options.includeArchived) {
+    countQuery.whereNull('archived_at')
+    dataQuery.whereNull('archived_at')
+  }
+
+  if (options.readStatus === 'read') {
+    countQuery.whereNotNull('read_at')
+    dataQuery.whereNotNull('read_at')
+  }
+
+  if (options.readStatus === 'unread') {
+    countQuery.whereNull('read_at')
+    dataQuery.whereNull('read_at')
+  }
+
+  const totalRow = await countQuery.count('* as total').first()
+  const total = parseInt(String(totalRow?.total ?? '0'), 10)
+
+  const offset = (options.page - 1) * options.pageSize
+  const rows = await dataQuery
+    .orderBy(sortBy, options.sortOrder)
+    .orderBy('id', options.sortOrder)
+    .limit(options.pageSize)
+    .offset(offset)
     .select('*')
+
+  const totalPages = total === 0 ? 0 : Math.ceil(total / options.pageSize)
+
+  return {
+    data: rows.map(normalizeNotification),
+    pagination: {
+      page: options.page,
+      pageSize: options.pageSize,
+      total,
+      totalPages,
+      hasNext: options.page < totalPages,
+      hasPrev: options.page > 1 && total > 0,
+    },
+    sort: {
+      sortBy,
+      sortOrder: options.sortOrder,
+    },
+  }
 }
 
 export const markAsRead = async (id: string, userId: string): Promise<Notification | null> => {
   const [notification] = await db('notifications')
     .where({ id, user_id: userId })
+    .whereNull('archived_at')
     .update({ read_at: new Date().toISOString() })
     .returning('*')
-  return notification || null
+
+  return notification ? normalizeNotification(notification) : null
 }
 
 export const markAllAsRead = async (userId: string): Promise<number> => {
   return db('notifications')
-    .where({ user_id: userId, read_at: null })
+    .where({ user_id: userId })
+    .whereNull('archived_at')
+    .whereNull('read_at')
     .update({ read_at: new Date().toISOString() })
+}
+
+export const archiveNotification = async (
+  id: string,
+  userId: string,
+): Promise<Notification | null> => {
+  const [notification] = await db('notifications')
+    .where({ id, user_id: userId })
+    .whereNull('archived_at')
+    .update({ archived_at: new Date().toISOString() })
+    .returning('*')
+
+  return notification ? normalizeNotification(notification) : null
 }

--- a/src/services/vault.ts
+++ b/src/services/vault.ts
@@ -73,7 +73,7 @@ export const markVaultExpiries = async (): Promise<number> => {
       user_id: vault.creator,
       type: 'vault_failure',
       title: 'Vault Deadline Reached',
-      message: `Vault ${vault.id} has expired and been marked as failed.`,
+      message: 'A vault in your account has expired and been marked as failed.',
       data: { vaultId: vault.id }
     })
   }

--- a/src/tests/notification.test.ts
+++ b/src/tests/notification.test.ts
@@ -1,446 +1,346 @@
-import request from 'supertest'
 import express from 'express'
-import { beforeAll, describe, it, expect, jest } from '@jest/globals'
-import fc from 'fast-check'
+import request from 'supertest'
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals'
 
-// ─── Mock DB ────────────────────────────────────────────────────────────────
+type MockBuilder = ReturnType<typeof createBuilder>
 
-const mockDb = {
-  insert: jest.fn<any>().mockReturnThis(),
-  returning: jest.fn<any>().mockReturnThis(),
-  where: jest.fn<any>().mockReturnThis(),
-  orderBy: jest.fn<any>().mockReturnThis(),
-  first: jest.fn<any>().mockResolvedValue({}),
-  select: jest.fn<any>().mockReturnThis(),
-  update: jest.fn<any>().mockReturnThis(),
-}
+const dbMock = jest.fn<any>()
+const validateSessionMock = jest.fn<any>().mockResolvedValue(true)
+const recordSessionMock = jest.fn<any>().mockResolvedValue(undefined)
 
 jest.unstable_mockModule('../db/index.js', () => ({
-  default: jest.fn<any>(() => mockDb),
+  db: dbMock,
 }))
 
 jest.unstable_mockModule('../services/session.js', () => ({
-  validateSession: jest.fn<any>().mockResolvedValue(true),
-  recordSession: jest.fn<any>().mockResolvedValue(undefined),
+  validateSession: validateSessionMock,
+  recordSession: recordSessionMock,
   revokeSession: jest.fn<any>().mockResolvedValue(undefined),
   revokeAllUserSessions: jest.fn<any>().mockResolvedValue(undefined),
   forceRevokeUserSessions: jest.fn<any>().mockResolvedValue(undefined),
 }))
 
-// ─── App bootstrap ───────────────────────────────────────────────────────────
+function createBuilder() {
+  const builder: Record<string, any> = {}
 
-let app: express.Express
-let signToken: any
-let createNotification: any
-let listUserNotifications: any
-let markAsRead: any
-let markAllAsRead: any
+  builder.insert = jest.fn<any>().mockReturnValue(builder)
+  builder.returning = jest.fn<any>()
+  builder.where = jest.fn<any>().mockReturnValue(builder)
+  builder.whereNull = jest.fn<any>().mockReturnValue(builder)
+  builder.whereNotNull = jest.fn<any>().mockReturnValue(builder)
+  builder.orderBy = jest.fn<any>().mockReturnValue(builder)
+  builder.limit = jest.fn<any>().mockReturnValue(builder)
+  builder.offset = jest.fn<any>().mockReturnValue(builder)
+  builder.select = jest.fn<any>()
+  builder.update = jest.fn<any>().mockReturnValue(builder)
+  builder.first = jest.fn<any>()
+  builder.count = jest.fn<any>().mockReturnValue(builder)
 
-beforeAll(async () => {
-  const authModule = await import('../middleware/auth.js')
-  const appModule = await import('../app.js')
-  const notifModule = await import('../services/notification.js')
-
-  app = appModule.app
-  signToken = authModule.signToken
-  createNotification = notifModule.createNotification
-  listUserNotifications = notifModule.listUserNotifications
-  markAsRead = notifModule.markAsRead
-  markAllAsRead = notifModule.markAllAsRead
-})
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-const makeInput = (overrides: Record<string, unknown> = {}) => ({
-  user_id: 'user-abc',
-  type: 'vault_created',
-  title: 'Vault Created',
-  message: 'Your vault was created',
-  ...overrides,
-})
+  return builder
+}
 
 const makeNotification = (overrides: Record<string, unknown> = {}) => ({
   id: 'notif-1',
-  user_id: 'user-abc',
-  type: 'vault_created',
-  title: 'Vault Created',
-  message: 'Your vault was created',
-  data: null,
+  user_id: 'user-1',
+  type: 'vault_failure',
+  title: 'Vault Deadline Reached',
+  message: 'A vault in your account has expired and been marked as failed.',
+  data: { vaultId: 'vault-1' },
   idempotency_key: null,
   read_at: null,
-  created_at: new Date().toISOString(),
+  archived_at: null,
+  created_at: '2026-04-24T10:00:00.000Z',
   ...overrides,
 })
 
-// ─── HTTP API tests ───────────────────────────────────────────────────────────
+let app: express.Express
+let signToken: any
+let createNotification: typeof import('../services/notification.js').createNotification
+let listUserNotifications: typeof import('../services/notification.js').listUserNotifications
+let markAsRead: typeof import('../services/notification.js').markAsRead
+let markAllAsRead: typeof import('../services/notification.js').markAllAsRead
+let archiveNotification: typeof import('../services/notification.js').archiveNotification
 
-describe('Notifications API', () => {
-  it('should list user notifications', async () => {
-    const userId = 'user-1'
-    const token = await signToken({ sub: userId, role: 'user' })
+const authHeaderFor = async (userId: string) => {
+  const token = await signToken({ userId, role: 'USER' })
+  return `Bearer ${token}`
+}
 
-    mockDb.select.mockResolvedValueOnce([
-      { id: '1', user_id: userId, title: 'Test', message: 'Hello', read_at: null },
-    ])
+beforeAll(async () => {
+  const { notificationsRouter } = await import('../routes/notifications.js')
+  const authModule = await import('../middleware/auth.js')
+  const notificationModule = await import('../services/notification.js')
 
-    const res = await request(app)
-      .get('/api/notifications')
-      .set('Authorization', `Bearer ${token}`)
+  signToken = authModule.signToken
+  createNotification = notificationModule.createNotification
+  listUserNotifications = notificationModule.listUserNotifications
+  markAsRead = notificationModule.markAsRead
+  markAllAsRead = notificationModule.markAllAsRead
+  archiveNotification = notificationModule.archiveNotification
 
-    expect(res.status).toBe(200)
-    expect(Array.isArray(res.body)).toBe(true)
-    expect(res.body[0].title).toBe('Test')
+  app = express()
+  app.use(express.json())
+  app.use('/api/notifications', notificationsRouter)
+})
+
+beforeEach(() => {
+  dbMock.mockReset()
+  validateSessionMock.mockClear()
+  recordSessionMock.mockClear()
+  jest.restoreAllMocks()
+})
+
+describe('Notifications API authz', () => {
+  it('requires authentication for inbox access', async () => {
+    const response = await request(app).get('/api/notifications')
+
+    expect(response.status).toBe(401)
+    expect(response.body.error).toMatch(/Authorization/i)
   })
 
-  it('should mark a notification as read', async () => {
-    const userId = 'user-2'
-    const token = await signToken({ sub: userId, role: 'user' })
-    const notificationId = 'notif-1'
-
-    mockDb.returning.mockResolvedValueOnce([
-      { id: notificationId, read_at: new Date().toISOString() },
+  it('lists only the authenticated user inbox with pagination and sorting metadata', async () => {
+    const countBuilder = createBuilder()
+    const dataBuilder = createBuilder()
+    dbMock.mockReturnValueOnce(countBuilder).mockReturnValueOnce(dataBuilder)
+    countBuilder.first.mockResolvedValueOnce({ total: '2' })
+    dataBuilder.select.mockResolvedValueOnce([
+      makeNotification({ id: 'notif-b', title: 'B notice', user_id: 'user-1' }),
     ])
 
-    const res = await request(app)
-      .patch(`/api/notifications/${notificationId}/read`)
-      .set('Authorization', `Bearer ${token}`)
+    const response = await request(app)
+      .get('/api/notifications?page=2&pageSize=1&sortBy=title&sortOrder=asc&status=unread')
+      .set('Authorization', await authHeaderFor('user-1'))
 
-    expect(res.status).toBe(200)
-    expect(res.body.id).toBe(notificationId)
-    expect(res.body.read_at).not.toBeNull()
+    expect(response.status).toBe(200)
+    expect(response.body.pagination).toEqual({
+      page: 2,
+      pageSize: 1,
+      total: 2,
+      totalPages: 2,
+      hasNext: false,
+      hasPrev: true,
+    })
+    expect(response.body.sort).toEqual({ sortBy: 'title', sortOrder: 'asc' })
+    expect(response.body.data).toHaveLength(1)
+    expect(countBuilder.where).toHaveBeenCalledWith({ user_id: 'user-1' })
+    expect(dataBuilder.where).toHaveBeenCalledWith({ user_id: 'user-1' })
+    expect(countBuilder.whereNull).toHaveBeenCalledWith('archived_at')
+    expect(dataBuilder.whereNull).toHaveBeenCalledWith('archived_at')
+    expect(countBuilder.whereNull).toHaveBeenCalledWith('read_at')
+    expect(dataBuilder.whereNull).toHaveBeenCalledWith('read_at')
+    expect(dataBuilder.orderBy).toHaveBeenNthCalledWith(1, 'title', 'asc')
+    expect(dataBuilder.orderBy).toHaveBeenNthCalledWith(2, 'id', 'asc')
+    expect(dataBuilder.limit).toHaveBeenCalledWith(1)
+    expect(dataBuilder.offset).toHaveBeenCalledWith(1)
   })
 
-  it('should mark all notifications as read', async () => {
-    const userId = 'user-3'
-    const token = await signToken({ sub: userId, role: 'user' })
+  it('rejects invalid sort fields', async () => {
+    const response = await request(app)
+      .get('/api/notifications?sortBy=user_id')
+      .set('Authorization', await authHeaderFor('user-1'))
 
-    mockDb.update.mockResolvedValueOnce(5)
+    expect(response.status).toBe(400)
+    expect(response.body.error).toMatch(/Invalid sort field/i)
+  })
 
-    const res = await request(app)
+  it('marks only the authenticated user notification as read', async () => {
+    const builder = createBuilder()
+    dbMock.mockReturnValueOnce(builder)
+    builder.returning.mockResolvedValueOnce([
+      makeNotification({ id: 'notif-read', user_id: 'user-1', read_at: '2026-04-24T10:05:00.000Z' }),
+    ])
+
+    const response = await request(app)
+      .patch('/api/notifications/notif-read/read')
+      .set('Authorization', await authHeaderFor('user-1'))
+
+    expect(response.status).toBe(200)
+    expect(response.body.id).toBe('notif-read')
+    expect(builder.where).toHaveBeenCalledWith({ id: 'notif-read', user_id: 'user-1' })
+    expect(builder.whereNull).toHaveBeenCalledWith('archived_at')
+  })
+
+  it('does not allow a user to mark another user notification as read', async () => {
+    const builder = createBuilder()
+    dbMock.mockReturnValueOnce(builder)
+    builder.returning.mockResolvedValueOnce([])
+
+    const response = await request(app)
+      .patch('/api/notifications/notif-other/read')
+      .set('Authorization', await authHeaderFor('user-1'))
+
+    expect(response.status).toBe(404)
+    expect(response.body.error).toBe('Notification not found')
+    expect(builder.where).toHaveBeenCalledWith({ id: 'notif-other', user_id: 'user-1' })
+  })
+
+  it('marks all unread notifications as read for the authenticated user only', async () => {
+    const builder = createBuilder()
+    dbMock.mockReturnValueOnce(builder)
+    builder.update.mockResolvedValueOnce(3)
+
+    const response = await request(app)
       .post('/api/notifications/read-all')
-      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization', await authHeaderFor('user-7'))
 
-    expect(res.status).toBe(200)
-    expect(res.body.message).toMatch(/Marked 5 notifications as read/)
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({ updated: 3 })
+    expect(builder.where).toHaveBeenCalledWith({ user_id: 'user-7' })
+    expect(builder.whereNull).toHaveBeenNthCalledWith(1, 'archived_at')
+    expect(builder.whereNull).toHaveBeenNthCalledWith(2, 'read_at')
   })
 
-  it('should fail unauthenticated requests', async () => {
-    const res = await request(app).get('/api/notifications')
-    expect(res.status).toBe(401)
-  })
-})
+  it('archives only the authenticated user notification', async () => {
+    const builder = createBuilder()
+    dbMock.mockReturnValueOnce(builder)
+    builder.returning.mockResolvedValueOnce([
+      makeNotification({ id: 'notif-archive', user_id: 'user-1', archived_at: '2026-04-24T10:06:00.000Z' }),
+    ])
 
-// ─── createNotification unit tests ───────────────────────────────────────────
+    const response = await request(app)
+      .delete('/api/notifications/notif-archive')
+      .set('Authorization', await authHeaderFor('user-1'))
 
-describe('createNotification', () => {
-  describe('without idempotency_key (backward compatibility)', () => {
-    it('inserts a new row and returns it', async () => {
-      const input = makeInput()
-      const expected = makeNotification()
-      mockDb.returning.mockResolvedValueOnce([expected])
-
-      const result = await createNotification(input)
-
-      expect(mockDb.insert).toHaveBeenCalled()
-      expect(result).toEqual(expected)
-    })
-
-    it('does not include idempotency_key in the inserted row', async () => {
-      const input = makeInput()
-      const expected = makeNotification()
-      mockDb.returning.mockResolvedValueOnce([expected])
-
-      await createNotification(input)
-
-      const insertedRow = mockDb.insert.mock.calls[mockDb.insert.mock.calls.length - 1][0]
-      expect(insertedRow).not.toHaveProperty('idempotency_key')
-    })
-
-    it('propagates non-23505 errors', async () => {
-      const input = makeInput()
-      const dbError = Object.assign(new Error('connection lost'), { code: '08006' })
-      mockDb.returning.mockRejectedValueOnce(dbError)
-
-      await expect(createNotification(input)).rejects.toThrow('connection lost')
-    })
+    expect(response.status).toBe(200)
+    expect(response.body.message).toBe('Notification archived')
+    expect(response.body.notification.archived_at).toBe('2026-04-24T10:06:00.000Z')
+    expect(builder.where).toHaveBeenCalledWith({ id: 'notif-archive', user_id: 'user-1' })
+    expect(builder.whereNull).toHaveBeenCalledWith('archived_at')
   })
 
-  describe('with idempotency_key (deduplication)', () => {
-    it('inserts and returns a new notification on first call', async () => {
-      const input = makeInput({ idempotency_key: 'evt-001' })
-      const expected = makeNotification({ idempotency_key: 'evt-001' })
-      mockDb.returning.mockResolvedValueOnce([expected])
+  it('does not allow a user to archive another user notification', async () => {
+    const builder = createBuilder()
+    dbMock.mockReturnValueOnce(builder)
+    builder.returning.mockResolvedValueOnce([])
 
-      const result = await createNotification(input)
+    const response = await request(app)
+      .delete('/api/notifications/notif-other')
+      .set('Authorization', await authHeaderFor('user-1'))
 
-      expect(result.idempotency_key).toBe('evt-001')
-      expect(mockDb.insert).toHaveBeenCalled()
-    })
-
-    it('returns existing notification on duplicate (23505 constraint violation)', async () => {
-      const input = makeInput({ idempotency_key: 'evt-dup' })
-      const existing = makeNotification({ id: 'notif-existing', idempotency_key: 'evt-dup' })
-
-      const uniqueViolation = Object.assign(new Error('unique violation'), { code: '23505' })
-      mockDb.returning.mockRejectedValueOnce(uniqueViolation)
-      mockDb.first.mockResolvedValueOnce(existing)
-
-      const result = await createNotification(input)
-
-      expect(result).toEqual(existing)
-      expect(result.id).toBe('notif-existing')
-    })
-
-    it('does not insert a second row on duplicate', async () => {
-      const input = makeInput({ idempotency_key: 'evt-dup2' })
-      const existing = makeNotification({ idempotency_key: 'evt-dup2' })
-
-      const uniqueViolation = Object.assign(new Error('unique violation'), { code: '23505' })
-      mockDb.returning.mockRejectedValueOnce(uniqueViolation)
-      mockDb.first.mockResolvedValueOnce(existing)
-
-      const insertCallsBefore = mockDb.insert.mock.calls.length
-      await createNotification(input)
-      // insert was called once (the original attempt), not twice
-      expect(mockDb.insert.mock.calls.length).toBe(insertCallsBefore + 1)
-    })
-
-    it('re-throws 23505 when existing row cannot be found (race edge case)', async () => {
-      const input = makeInput({ idempotency_key: 'evt-race' })
-      const uniqueViolation = Object.assign(new Error('unique violation'), { code: '23505' })
-      mockDb.returning.mockRejectedValueOnce(uniqueViolation)
-      mockDb.first.mockResolvedValueOnce(undefined) // row disappeared
-
-      await expect(createNotification(input)).rejects.toMatchObject({ code: '23505' })
-    })
-
-    it('propagates non-23505 errors even when idempotency_key is set', async () => {
-      const input = makeInput({ idempotency_key: 'evt-err' })
-      const dbError = Object.assign(new Error('disk full'), { code: '53100' })
-      mockDb.returning.mockRejectedValueOnce(dbError)
-
-      await expect(createNotification(input)).rejects.toThrow('disk full')
-    })
-  })
-
-  describe('observability — no PII in logs', () => {
-    it('does not log user_id when creating with key', async () => {
-      const input = makeInput({ user_id: 'sensitive-user-id', idempotency_key: 'evt-log1' })
-      const expected = makeNotification({ idempotency_key: 'evt-log1' })
-      mockDb.returning.mockResolvedValueOnce([expected])
-
-      const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
-      await createNotification(input)
-
-      for (const call of debugSpy.mock.calls) {
-        const output = String(call[0])
-        expect(output).not.toContain('sensitive-user-id')
-        expect(output).not.toContain('Your vault was created')
-      }
-      debugSpy.mockRestore()
-    })
-
-    it('does not log user_id when suppressing duplicate', async () => {
-      const input = makeInput({ user_id: 'sensitive-user-id', idempotency_key: 'evt-log2' })
-      const existing = makeNotification({ idempotency_key: 'evt-log2' })
-
-      const uniqueViolation = Object.assign(new Error('unique violation'), { code: '23505' })
-      mockDb.returning.mockRejectedValueOnce(uniqueViolation)
-      mockDb.first.mockResolvedValueOnce(existing)
-
-      const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
-      await createNotification(input)
-
-      for (const call of infoSpy.mock.calls) {
-        const output = String(call[0])
-        expect(output).not.toContain('sensitive-user-id')
-        expect(output).not.toContain('Your vault was created')
-      }
-      infoSpy.mockRestore()
-    })
-
-    it('logs idempotency_key and id at debug level on new creation', async () => {
-      const input = makeInput({ idempotency_key: 'evt-logkey' })
-      const expected = makeNotification({ id: 'notif-logid', idempotency_key: 'evt-logkey' })
-      mockDb.returning.mockResolvedValueOnce([expected])
-
-      const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
-      await createNotification(input)
-
-      const logged = debugSpy.mock.calls.map(c => JSON.parse(String(c[0])))
-      const entry = logged.find(l => l.event === 'notification_created_with_key')
-      expect(entry).toBeDefined()
-      expect(entry.idempotency_key).toBe('evt-logkey')
-      expect(entry.id).toBe('notif-logid')
-      expect(entry.level).toBe('debug')
-      debugSpy.mockRestore()
-    })
-
-    it('logs idempotency_key and id at info level on dedup suppression', async () => {
-      const input = makeInput({ idempotency_key: 'evt-suppressed' })
-      const existing = makeNotification({ id: 'notif-orig', idempotency_key: 'evt-suppressed' })
-
-      const uniqueViolation = Object.assign(new Error('unique violation'), { code: '23505' })
-      mockDb.returning.mockRejectedValueOnce(uniqueViolation)
-      mockDb.first.mockResolvedValueOnce(existing)
-
-      const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
-      await createNotification(input)
-
-      const logged = infoSpy.mock.calls.map(c => JSON.parse(String(c[0])))
-      const entry = logged.find(l => l.event === 'notification_dedupe_suppressed')
-      expect(entry).toBeDefined()
-      expect(entry.idempotency_key).toBe('evt-suppressed')
-      expect(entry.id).toBe('notif-orig')
-      expect(entry.level).toBe('info')
-      infoSpy.mockRestore()
-    })
-
-    it('does not throw when logger fails', async () => {
-      const input = makeInput({ idempotency_key: 'evt-logfail' })
-      const expected = makeNotification({ idempotency_key: 'evt-logfail' })
-      mockDb.returning.mockResolvedValueOnce([expected])
-
-      // Force JSON.stringify to throw inside the logger
-      jest.spyOn(console, 'debug').mockImplementationOnce(() => { throw new Error('logger broken') })
-
-      await expect(createNotification(input)).resolves.toEqual(expected)
-    })
-  })
-
-  describe('listUserNotifications', () => {
-    it('returns notifications ordered by created_at desc', async () => {
-      const notifications = [
-        makeNotification({ id: 'n2', created_at: '2026-02-26T02:00:00Z' }),
-        makeNotification({ id: 'n1', created_at: '2026-02-26T01:00:00Z' }),
-      ]
-      mockDb.select.mockResolvedValueOnce(notifications)
-
-      const result = await listUserNotifications('user-abc')
-      expect(result).toEqual(notifications)
-    })
-  })
-
-  describe('markAsRead', () => {
-    it('returns updated notification', async () => {
-      const updated = makeNotification({ read_at: new Date().toISOString() })
-      mockDb.returning.mockResolvedValueOnce([updated])
-
-      const result = await markAsRead('notif-1', 'user-abc')
-      expect(result).toEqual(updated)
-    })
-
-    it('returns null when notification not found', async () => {
-      mockDb.returning.mockResolvedValueOnce([])
-
-      const result = await markAsRead('notif-missing', 'user-abc')
-      expect(result).toBeNull()
-    })
-  })
-
-  describe('markAllAsRead', () => {
-    it('returns count of updated notifications', async () => {
-      mockDb.update.mockResolvedValueOnce(3)
-
-      const result = await markAllAsRead('user-abc')
-      expect(result).toBe(3)
-    })
+    expect(response.status).toBe(404)
+    expect(builder.where).toHaveBeenCalledWith({ id: 'notif-other', user_id: 'user-1' })
   })
 })
 
-// ─── Property-based tests ─────────────────────────────────────────────────────
+describe('Notification service', () => {
+  it('sanitizes notification messages and metadata before insert', async () => {
+    const insertBuilder = createBuilder()
+    dbMock.mockReturnValueOnce(insertBuilder)
+    insertBuilder.returning.mockResolvedValueOnce([
+      makeNotification({
+        title: 'Vault Deadline Reached',
+        message: 'Contact success_destination=GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ23 immediately.',
+        data: { vaultId: 'vault-1', successDestination: 'GSECRETVALUE', amount: '1000' },
+      }),
+    ])
 
-describe('createNotification — property-based', () => {
-  const arbitraryKey = () =>
-    fc.string({ minLength: 1, maxLength: 255 }).filter(s => s.trim().length > 0)
-
-  const arbitraryInput = () =>
-    fc.record({
-      user_id: fc.uuid(),
-      type: fc.constantFrom('vault_created', 'vault_completed', 'milestone_validated'),
-      title: fc.string({ minLength: 1, maxLength: 255 }),
-      message: fc.string({ minLength: 1, maxLength: 1000 }),
-      idempotency_key: arbitraryKey(),
+    await createNotification({
+      user_id: 'user-1',
+      type: 'vault_failure',
+      title: 'Vault Deadline Reached',
+      message: 'Contact success_destination=GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ23 immediately.',
+      data: {
+        vaultId: 'vault-1',
+        successDestination: 'GSECRETVALUE',
+        amount: '1000',
+      },
     })
 
-  it('idempotence: second call with same key returns equivalent notification', async () => {
-    await fc.assert(
-      fc.asyncProperty(arbitraryInput(), async (input) => {
-        const notification = makeNotification({
-          user_id: input.user_id,
-          type: input.type,
-          title: input.title,
-          message: input.message,
-          idempotency_key: input.idempotency_key,
-        })
-
-        // First call — insert succeeds
-        mockDb.returning.mockResolvedValueOnce([notification])
-        const first = await createNotification(input)
-
-        // Second call — unique constraint fires, fetch returns same row
-        const uniqueViolation = Object.assign(new Error('unique violation'), { code: '23505' })
-        mockDb.returning.mockRejectedValueOnce(uniqueViolation)
-        mockDb.first.mockResolvedValueOnce(notification)
-        const second = await createNotification(input)
-
-        expect(second.id).toBe(first.id)
-        expect(second.idempotency_key).toBe(first.idempotency_key)
+    expect(insertBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        data: { vaultId: 'vault-1' },
       }),
-      { numRuns: 20 }
     )
+    const insertedRow = insertBuilder.insert.mock.calls[0][0]
+    expect(insertedRow.message).toContain('success_destination=[redacted]')
+    expect(insertedRow.message).not.toContain('GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXYZ23')
   })
 
-  it('backward compatibility: calls without key always insert a new row', async () => {
-    await fc.assert(
-      fc.asyncProperty(
-        fc.record({
-          user_id: fc.uuid(),
-          type: fc.constantFrom('vault_created', 'vault_completed'),
-          title: fc.string({ minLength: 1, maxLength: 100 }),
-          message: fc.string({ minLength: 1, maxLength: 500 }),
-        }),
-        async (input) => {
-          const notification = makeNotification({ user_id: input.user_id })
-          mockDb.returning.mockResolvedValueOnce([notification])
-
-          const insertsBefore = mockDb.insert.mock.calls.length
-          await createNotification(input) // no idempotency_key
-          expect(mockDb.insert.mock.calls.length).toBe(insertsBefore + 1)
-        }
-      ),
-      { numRuns: 20 }
+  it('deduplicates idempotent notification creation without leaking user ownership', async () => {
+    const insertBuilder = createBuilder()
+    const lookupBuilder = createBuilder()
+    dbMock.mockReturnValueOnce(insertBuilder).mockReturnValueOnce(lookupBuilder)
+    insertBuilder.returning.mockRejectedValueOnce(Object.assign(new Error('duplicate'), { code: '23505' }))
+    lookupBuilder.first.mockResolvedValueOnce(
+      makeNotification({ id: 'notif-existing', idempotency_key: 'evt-1', user_id: 'user-99' }),
     )
+
+    const result = await createNotification({
+      user_id: 'user-99',
+      type: 'vault_failure',
+      title: 'Vault Deadline Reached',
+      message: 'A vault in your account has expired and been marked as failed.',
+      data: { vaultId: 'vault-99' },
+      idempotency_key: 'evt-1',
+    })
+
+    expect(result.id).toBe('notif-existing')
+    expect(lookupBuilder.where).toHaveBeenCalledWith({
+      user_id: 'user-99',
+      idempotency_key: 'evt-1',
+    })
   })
 
-  it('PII safety: log output never contains user_id or message content', async () => {
-    await fc.assert(
-      fc.asyncProperty(arbitraryInput(), async (input) => {
-        const notification = makeNotification({
-          user_id: input.user_id,
-          idempotency_key: input.idempotency_key,
-        })
+  it('lists notifications with includeArchived support and read filters', async () => {
+    const countBuilder = createBuilder()
+    const dataBuilder = createBuilder()
+    dbMock.mockReturnValueOnce(countBuilder).mockReturnValueOnce(dataBuilder)
+    countBuilder.first.mockResolvedValueOnce({ total: '1' })
+    dataBuilder.select.mockResolvedValueOnce([
+      makeNotification({ id: 'notif-archived', archived_at: '2026-04-24T10:06:00.000Z', read_at: '2026-04-24T10:07:00.000Z' }),
+    ])
 
-        const logLines: string[] = []
-        const debugSpy = jest.spyOn(console, 'debug').mockImplementation((...args) => {
-          logLines.push(String(args[0]))
-        })
-        const infoSpy = jest.spyOn(console, 'info').mockImplementation((...args) => {
-          logLines.push(String(args[0]))
-        })
+    const result = await listUserNotifications('user-1', {
+      page: 1,
+      pageSize: 10,
+      sortBy: 'created_at',
+      sortOrder: 'desc',
+      includeArchived: true,
+      readStatus: 'read',
+    })
 
-        mockDb.returning.mockResolvedValueOnce([notification])
-        await createNotification(input)
+    expect(result.pagination.total).toBe(1)
+    expect(result.data[0].archived_at).toBe('2026-04-24T10:06:00.000Z')
+    expect(countBuilder.whereNull).not.toHaveBeenCalledWith('archived_at')
+    expect(dataBuilder.whereNull).not.toHaveBeenCalledWith('archived_at')
+    expect(countBuilder.whereNotNull).toHaveBeenCalledWith('read_at')
+    expect(dataBuilder.whereNotNull).toHaveBeenCalledWith('read_at')
+  })
 
-        debugSpy.mockRestore()
-        infoSpy.mockRestore()
+  it('returns null when markAsRead cannot find a notification owned by the user', async () => {
+    const builder = createBuilder()
+    dbMock.mockReturnValueOnce(builder)
+    builder.returning.mockResolvedValueOnce([])
 
-        for (const line of logLines) {
-          expect(line).not.toContain(input.user_id)
-          expect(line).not.toContain(input.message)
-        }
-      }),
-      { numRuns: 20 }
-    )
+    const result = await markAsRead('notif-missing', 'user-1')
+
+    expect(result).toBeNull()
+    expect(builder.where).toHaveBeenCalledWith({ id: 'notif-missing', user_id: 'user-1' })
+  })
+
+  it('returns the number of owned unread notifications updated by markAllAsRead', async () => {
+    const builder = createBuilder()
+    dbMock.mockReturnValueOnce(builder)
+    builder.update.mockResolvedValueOnce(2)
+
+    const result = await markAllAsRead('user-1')
+
+    expect(result).toBe(2)
+    expect(builder.where).toHaveBeenCalledWith({ user_id: 'user-1' })
+    expect(builder.whereNull).toHaveBeenNthCalledWith(1, 'archived_at')
+    expect(builder.whereNull).toHaveBeenNthCalledWith(2, 'read_at')
+  })
+
+  it('returns null when archiveNotification targets another user record', async () => {
+    const builder = createBuilder()
+    dbMock.mockReturnValueOnce(builder)
+    builder.returning.mockResolvedValueOnce([])
+
+    const result = await archiveNotification('notif-2', 'user-1')
+
+    expect(result).toBeNull()
+    expect(builder.where).toHaveBeenCalledWith({ id: 'notif-2', user_id: 'user-1' })
+    expect(builder.whereNull).toHaveBeenCalledWith('archived_at')
   })
 })

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,12 +1,15 @@
+export type NotificationData = Record<string, unknown> | null
+
 export interface Notification {
   id: string
   user_id: string
   type: string
   title: string
   message: string
-  data?: any
+  data: NotificationData
   idempotency_key: string | null
   read_at: string | null
+  archived_at: string | null
   created_at: string
 }
 
@@ -15,6 +18,34 @@ export interface CreateNotificationInput {
   type: string
   title: string
   message: string
-  data?: any
+  data?: NotificationData
   idempotency_key?: string
+}
+
+export type NotificationSortField = 'created_at' | 'read_at' | 'title' | 'type'
+export type NotificationReadStatus = 'all' | 'read' | 'unread'
+
+export interface NotificationListOptions {
+  page: number
+  pageSize: number
+  sortBy?: NotificationSortField
+  sortOrder: 'asc' | 'desc'
+  includeArchived?: boolean
+  readStatus?: NotificationReadStatus
+}
+
+export interface NotificationListResult {
+  data: Notification[]
+  pagination: {
+    page: number
+    pageSize: number
+    total: number
+    totalPages: number
+    hasNext: boolean
+    hasPrev: boolean
+  }
+  sort: {
+    sortBy: NotificationSortField
+    sortOrder: 'asc' | 'desc'
+  }
 }


### PR DESCRIPTION
closes #232 



## What Changed

- Completed [src/routes/notifications.ts](/c:/Users/User/Desktop/Disciplr-backend/src/routes/notifications.ts)
- Expanded [src/services/notification.ts](/c:/Users/User/Desktop/Disciplr-backend/src/services/notification.ts)
- Added notification archival support with `archived_at`
- Updated [src/types/notification.ts](/c:/Users/User/Desktop/Disciplr-backend/src/types/notification.ts)
- Added DB migration: [db/migrations/20260424000100_add_archived_at_to_notifications.cjs](/c:/Users/User/Desktop/Disciplr-backend/db/migrations/20260424000100_add_archived_at_to_notifications.cjs)
- Added Prisma model updates in [prisma/schema.prisma](/c:/Users/User/Desktop/Disciplr-backend/prisma/schema.prisma)
- Added API docs in [docs/notifications-api.md](/c:/Users/User/Desktop/Disciplr-backend/docs/notifications-api.md)
- Reworked tests in [src/tests/notification.test.ts](/c:/Users/User/Desktop/Disciplr-backend/src/tests/notification.test.ts)

## API Behavior

- `GET /api/notifications`
  - requires authentication
  - returns only the authenticated user’s notifications
  - supports `page`, `pageSize`, `sortBy`, `sortOrder`
  - supports `status=all|read|unread`
  - supports `includeArchived=true`

- `PATCH /api/notifications/:id/read`
  - marks a single notification as read
  - returns `404` if the notification does not exist, is archived, or belongs to another user

- `POST /api/notifications/read-all`
  - marks all unread, non-archived notifications as read for the authenticated user

- `DELETE /api/notifications/:id`
  - performs soft-delete archival by setting `archived_at`
  - archived notifications are hidden from the default inbox view

## Security Notes

- All notification endpoints require JWT authentication
- All notification queries and mutations are scoped by `req.user.userId`
- Cross-user notification access returns `404` to avoid leaking resource existence
- Notification metadata is sanitized before storage
- Vault expiry notification message content was adjusted to avoid exposing vault details in the body

## Testing

Ran:

```bash
node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.ts src/tests/notification.test.ts --runInBand
```

Result:

- 14/14 tests passing

Coverage in this PR focuses on:

- unauthenticated access
- per-user isolation
- cross-user read/update/archive denial
- pagination and sorting behavior
- archival semantics
- sanitized notification payload handling

Thank you!