### PR TITLE
feat: #217 migrate analytics storage to PostgreSQL (+ dual-write/backfill) and #245 add jobs enqueue contract tests

### DIFF
--- a/db/migrations/20260427114500_create_analytics_storage.cjs
+++ b/db/migrations/20260427114500_create_analytics_storage.cjs
@@ -1,0 +1,39 @@
+/**
+ * Analytics storage migration for PostgreSQL.
+ * Creates summary + rollup tables used by analytics dual-write/backfill.
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('analytics_vault_summary', (table) => {
+    table.specificType('id', 'smallint').primary()
+    table.integer('total_vaults').notNullable().defaultTo(0)
+    table.integer('active_vaults').notNullable().defaultTo(0)
+    table.integer('completed_vaults').notNullable().defaultTo(0)
+    table.integer('failed_vaults').notNullable().defaultTo(0)
+    table.decimal('total_locked_capital', 20, 7).notNullable().defaultTo(0)
+    table.decimal('active_capital', 20, 7).notNullable().defaultTo(0)
+    table.decimal('success_rate', 10, 4).notNullable().defaultTo(0)
+    table.timestamp('last_updated', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+  })
+
+  await knex.schema.createTable('analytics_vault_daily_rollups', (table) => {
+    table.date('bucket_date').primary()
+    table.integer('total_vaults').notNullable().defaultTo(0)
+    table.integer('active_vaults').notNullable().defaultTo(0)
+    table.integer('completed_vaults').notNullable().defaultTo(0)
+    table.integer('failed_vaults').notNullable().defaultTo(0)
+    table.decimal('total_locked_capital', 20, 7).notNullable().defaultTo(0)
+    table.decimal('active_capital', 20, 7).notNullable().defaultTo(0)
+    table.decimal('success_rate', 10, 4).notNullable().defaultTo(0)
+    table.timestamp('last_updated', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+  })
+
+  await knex.schema.raw(`
+    CREATE INDEX IF NOT EXISTS idx_analytics_rollups_last_updated
+    ON analytics_vault_daily_rollups(last_updated)
+  `)
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.dropTableIfExists('analytics_vault_daily_rollups')
+  await knex.schema.dropTableIfExists('analytics_vault_summary')
+}

--- a/docs/analytics-storage.md
+++ b/docs/analytics-storage.md
@@ -1,0 +1,58 @@
+# Analytics Storage Migration (SQLite -> PostgreSQL)
+
+## Goal
+
+Move analytics persistence to PostgreSQL for production workloads while keeping existing `/api/analytics` behavior stable.
+
+## Data model
+
+### `analytics_vault_summary`
+
+- Single-row summary keyed by `id=1`
+- `total_vaults`, `active_vaults`, `completed_vaults`, `failed_vaults`
+- `total_locked_capital`, `active_capital`, `success_rate`
+- `last_updated`
+
+### `analytics_vault_daily_rollups`
+
+- Daily materialized rollup keyed by `bucket_date`
+- Same aggregate fields as summary table
+- Supports historical analytics and backfill verification
+
+## Runtime storage modes
+
+Configure with environment variables:
+
+- `ANALYTICS_STORAGE=postgres` enables PostgreSQL reads for analytics summary.
+- `ANALYTICS_DUAL_WRITE=true` enables dual-write of summary/rollups to PostgreSQL while SQLite remains active.
+
+Recommended migration rollout:
+
+1. Deploy with `ANALYTICS_DUAL_WRITE=true`, `ANALYTICS_STORAGE` unset.
+2. Run backfill once and compare summary parity.
+3. Switch read path to `ANALYTICS_STORAGE=postgres`.
+4. Keep dual-write briefly for safety.
+5. Disable dual-write after confidence window.
+
+## Backfill strategy
+
+- Use `backfillAnalyticsStorage()` from `src/db/database.ts`.
+- It initializes analytics tables in PostgreSQL and recomputes:
+  - global summary row (`analytics_vault_summary`)
+  - daily rollups (`analytics_vault_daily_rollups`) from `vaults.created_at`.
+
+## Validation checklist
+
+1. Run migration: `npm run migrate:latest`
+2. Trigger summary recompute/backfill.
+3. Verify row counts and totals:
+   - SQLite `vault_analytics_summary` vs PostgreSQL `analytics_vault_summary`
+4. Run contract tests:
+   - `npm test -- tests/analytics.test.ts`
+   - `npm test -- tests/jobs.test.ts`
+
+## Security / privacy considerations
+
+- Analytics responses remain aggregate-only.
+- No additional PII fields are emitted by `/api/analytics`.
+- Audit logs and privacy logger behavior are unchanged.

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,0 +1,34 @@
+# Jobs Enqueue Contract
+
+`POST /api/jobs/enqueue` is admin-only and validates payload by job type using a discriminated schema.
+
+## Supported job types
+
+- `notification.send`
+- `deadline.check`
+- `oracle.call`
+- `analytics.recompute`
+
+## Enqueue options
+
+- `delayMs`: optional, must be `>= 0`
+- `maxAttempts`: optional integer, bounds `1..10`
+
+Options parsing behavior:
+
+- `delayMs` is floored before queue scheduling.
+- `maxAttempts` is used as provided after schema validation.
+
+## Error contract
+
+Invalid payloads return:
+
+- HTTP `400`
+- `VALIDATION_ERROR` response body from `formatValidationError`
+- field-level paths (for example `payload.scope`, `maxAttempts`, `delayMs`)
+
+## Security
+
+- Endpoint requires valid auth token and `ADMIN` role.
+- Non-admin users receive `403`.
+- On success, enqueue action writes `job.enqueue` audit logs.

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1,60 +1,87 @@
 import Database, { Database as DatabaseType } from 'better-sqlite3'
+import type { Pool } from 'pg'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import fs from 'fs'
 import { subDays, subYears } from 'date-fns'
 import { utcStartOfDay, utcEndOfDay } from '../utils/timestamps.js'
+import { getPgPool } from './pool.js'
 
-/**
- * MODULE SHIM: Handles ESM (Production) vs CommonJS (Jest/Testing) environments.
- * This prevents the "Cannot use import.meta outside a module" error in Jest.
- */
-let _filename: string;
-let _dirname: string;
+let _filename: string
+let _dirname: string
 
 try {
-    // @ts-ignore - Ignore TS error during transpilation for test environments
-    _filename = fileURLToPath(import.meta.url);
-    _dirname = path.dirname(_filename);
-} catch (e) {
-    // Fallback to CommonJS globals provided by Jest
-    _filename = __filename;
-    _dirname = __dirname;
+  // @ts-ignore test runtime shim
+  _filename = fileURLToPath(import.meta.url)
+  _dirname = path.dirname(_filename)
+} catch {
+  _filename = __filename
+  _dirname = __dirname
 }
 
 const dbPath = path.join(_dirname, '../../data/disciplr.db')
-
-// Ensure data directory exists
 const dataDir = path.dirname(dbPath)
 if (!fs.existsSync(dataDir)) {
-    fs.mkdirSync(dataDir, { recursive: true })
+  fs.mkdirSync(dataDir, { recursive: true })
 }
 
-const createFallbackDb = (): DatabaseType => ({
+const createFallbackDb = (): DatabaseType =>
+  ({
     pragma: () => undefined,
     exec: () => undefined,
     prepare: () => ({
-        get: () => null,
-        run: () => undefined,
+      get: () => null,
+      run: () => undefined,
+      all: () => [],
     }),
-} as unknown as DatabaseType)
+    close: () => undefined,
+  }) as unknown as DatabaseType
 
 export const db: DatabaseType = (() => {
-    try {
-        const database = new Database(dbPath)
-        database.pragma('journal_mode = WAL')
-        return database
-    } catch (error) {
-        console.warn('better-sqlite3 unavailable, using no-op analytics database fallback')
-        return createFallbackDb()
-    }
+  try {
+    const database = new Database(dbPath)
+    database.pragma('journal_mode = WAL')
+    return database
+  } catch {
+    console.warn('better-sqlite3 unavailable, using no-op analytics database fallback')
+    return createFallbackDb()
+  }
 })()
 
-// Initialize database schema
-export function initializeDatabase(): void {
-    const db = getDb()
-    // Create vaults table
-    db.exec(`
+type AnalyticsStatsRow = {
+  total_vaults: number
+  active_vaults: number
+  completed_vaults: number
+  failed_vaults: number
+  total_locked_capital: number | null
+  active_capital: number | null
+}
+
+export type AnalyticsSummaryRow = {
+  total_vaults: number
+  active_vaults: number
+  completed_vaults: number
+  failed_vaults: number
+  total_locked_capital: string
+  active_capital: string
+  success_rate: number
+  last_updated: string
+}
+
+const analyticsStorage = (process.env.ANALYTICS_STORAGE ?? '').toLowerCase()
+const dualWriteEnabled = process.env.ANALYTICS_DUAL_WRITE === 'true'
+const shouldUsePostgres = analyticsStorage === 'postgres'
+
+const getPoolIfEnabled = (): Pool | null => {
+  if (!shouldUsePostgres && !dualWriteEnabled) {
+    return null
+  }
+  return getPgPool()
+}
+
+const initializeSqliteSchema = (): void => {
+  const sqliteDb = getDb()
+  sqliteDb.exec(`
     CREATE TABLE IF NOT EXISTS vaults (
       id TEXT PRIMARY KEY,
       creator TEXT NOT NULL,
@@ -66,19 +93,13 @@ export function initializeDatabase(): void {
       status TEXT NOT NULL DEFAULT 'active',
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
-    )
-  `)
+    );
 
-    // Create indexes for efficient queries
-    db.exec(`
     CREATE INDEX IF NOT EXISTS idx_vaults_status ON vaults(status);
     CREATE INDEX IF NOT EXISTS idx_vaults_created_at ON vaults(created_at);
     CREATE INDEX IF NOT EXISTS idx_vaults_start_timestamp ON vaults(start_timestamp);
     CREATE INDEX IF NOT EXISTS idx_vaults_status_created_at ON vaults(status, created_at);
-  `)
 
-    // Create materialized view for vault analytics summary
-    db.exec(`
     CREATE TABLE IF NOT EXISTS vault_analytics_summary (
       id INTEGER PRIMARY KEY CHECK (id = 1),
       total_vaults INTEGER NOT NULL DEFAULT 0,
@@ -89,32 +110,59 @@ export function initializeDatabase(): void {
       active_capital TEXT NOT NULL DEFAULT '0',
       success_rate REAL NOT NULL DEFAULT 0,
       last_updated TEXT NOT NULL
-    )
+    );
   `)
 
-    // Initialize summary if not exists
-    const summary = db.prepare('SELECT * FROM vault_analytics_summary WHERE id = 1').get()
-    if (!summary) {
-        db.prepare(`
-      INSERT INTO vault_analytics_summary (id, total_vaults, active_vaults, completed_vaults, failed_vaults, total_locked_capital, active_capital, success_rate, last_updated)
-      VALUES (1, 0, 0, 0, 0, '0', '0', 0, datetime('now'))
-    `).run()
-    }
-
-    console.log('Database initialized successfully')
+  const summary = sqliteDb.prepare('SELECT id FROM vault_analytics_summary WHERE id = 1').get()
+  if (!summary) {
+    sqliteDb
+      .prepare(`
+        INSERT INTO vault_analytics_summary (
+          id, total_vaults, active_vaults, completed_vaults, failed_vaults,
+          total_locked_capital, active_capital, success_rate, last_updated
+        )
+        VALUES (1, 0, 0, 0, 0, '0', '0', 0, datetime('now'))
+      `)
+      .run()
+  }
 }
 
-// Function to close database connection
-export function closeDatabase(): void {
-    db.close()
-    console.log('Database connection closed')
+const initializePostgresSchema = async (pool: Pool): Promise<void> => {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS analytics_vault_summary (
+      id SMALLINT PRIMARY KEY,
+      total_vaults INTEGER NOT NULL DEFAULT 0,
+      active_vaults INTEGER NOT NULL DEFAULT 0,
+      completed_vaults INTEGER NOT NULL DEFAULT 0,
+      failed_vaults INTEGER NOT NULL DEFAULT 0,
+      total_locked_capital NUMERIC(20,7) NOT NULL DEFAULT 0,
+      active_capital NUMERIC(20,7) NOT NULL DEFAULT 0,
+      success_rate NUMERIC(10,4) NOT NULL DEFAULT 0,
+      last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS analytics_vault_daily_rollups (
+      bucket_date DATE PRIMARY KEY,
+      total_vaults INTEGER NOT NULL DEFAULT 0,
+      active_vaults INTEGER NOT NULL DEFAULT 0,
+      completed_vaults INTEGER NOT NULL DEFAULT 0,
+      failed_vaults INTEGER NOT NULL DEFAULT 0,
+      total_locked_capital NUMERIC(20,7) NOT NULL DEFAULT 0,
+      active_capital NUMERIC(20,7) NOT NULL DEFAULT 0,
+      success_rate NUMERIC(10,4) NOT NULL DEFAULT 0,
+      last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_analytics_rollups_last_updated
+    ON analytics_vault_daily_rollups(last_updated);
+  `)
 }
 
-// Function to update analytics summary (can be called after vault changes)
-export function updateAnalyticsSummary(): void {
-    const db = getDb()
-    const stats = db.prepare(`
-    SELECT 
+const getSQLiteStats = (startDate?: string, endDate?: string): AnalyticsStatsRow => {
+  const sqliteDb = getDb()
+  const where = startDate && endDate ? 'WHERE created_at >= ? AND created_at <= ?' : ''
+  const stmt = sqliteDb.prepare(`
+    SELECT
       COUNT(*) as total_vaults,
       SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) as active_vaults,
       SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed_vaults,
@@ -122,70 +170,319 @@ export function updateAnalyticsSummary(): void {
       SUM(CAST(amount AS REAL)) as total_locked_capital,
       SUM(CASE WHEN status = 'active' THEN CAST(amount AS REAL) ELSE 0 END) as active_capital
     FROM vaults
-  `).get() as {
-        total_vaults: number
-        active_vaults: number
-        completed_vaults: number
-        failed_vaults: number
-        total_locked_capital: number | null
-        active_capital: number | null
-    } | undefined | null
+    ${where}
+  `)
+  const stats = (startDate && endDate ? stmt.get(startDate, endDate) : stmt.get()) as AnalyticsStatsRow | null
+  return {
+    total_vaults: stats?.total_vaults ?? 0,
+    active_vaults: stats?.active_vaults ?? 0,
+    completed_vaults: stats?.completed_vaults ?? 0,
+    failed_vaults: stats?.failed_vaults ?? 0,
+    total_locked_capital: stats?.total_locked_capital ?? 0,
+    active_capital: stats?.active_capital ?? 0,
+  }
+}
 
-    if (!stats) {
-        return
-    }
+const writeSQLiteSummary = (): void => {
+  const sqliteDb = getDb()
+  const stats = getSQLiteStats()
+  const totalCompleted = stats.completed_vaults
+  const totalFailed = stats.failed_vaults
+  const successRate = totalCompleted + totalFailed > 0 ? (totalCompleted / (totalCompleted + totalFailed)) * 100 : 0
 
-    const totalCompleted = stats.completed_vaults || 0
-    const totalFailed = stats.failed_vaults || 0
-    const successRate = (totalCompleted + totalFailed) > 0
-        ? (totalCompleted / (totalCompleted + totalFailed)) * 100
-        : 0
-
-    db.prepare(`
-    UPDATE vault_analytics_summary SET
-      total_vaults = ?,
-      active_vaults = ?,
-      completed_vaults = ?,
-      failed_vaults = ?,
-      total_locked_capital = ?,
-      active_capital = ?,
-      success_rate = ?,
-      last_updated = datetime('now')
-    WHERE id = 1
-  `).run(
-        stats.total_vaults || 0,
-        stats.active_vaults || 0,
-        stats.completed_vaults || 0,
-        stats.failed_vaults || 0,
-        (stats.total_locked_capital || 0).toString(),
-        (stats.active_capital || 0).toString(),
-        successRate
+  sqliteDb
+    .prepare(`
+      UPDATE vault_analytics_summary SET
+        total_vaults = ?,
+        active_vaults = ?,
+        completed_vaults = ?,
+        failed_vaults = ?,
+        total_locked_capital = ?,
+        active_capital = ?,
+        success_rate = ?,
+        last_updated = datetime('now')
+      WHERE id = 1
+    `)
+    .run(
+      stats.total_vaults,
+      stats.active_vaults,
+      stats.completed_vaults,
+      stats.failed_vaults,
+      (stats.total_locked_capital ?? 0).toString(),
+      (stats.active_capital ?? 0).toString(),
+      successRate,
     )
 }
 
-// Helper function to get time-range filter aligned to UTC boundaries
-export function getTimeRangeFilter(period: string): { startDate: string; endDate: string } {
-    const now = new Date()
-    const endDate = utcEndOfDay(now)
-    let startDate: string
+const writePostgresSummary = async (pool: Pool): Promise<void> => {
+  const { rows } = await pool.query<AnalyticsStatsRow>(`
+    SELECT
+      COUNT(*)::int as total_vaults,
+      SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END)::int as active_vaults,
+      SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END)::int as completed_vaults,
+      SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)::int as failed_vaults,
+      SUM(CAST(amount AS numeric))::float as total_locked_capital,
+      SUM(CASE WHEN status = 'active' THEN CAST(amount AS numeric) ELSE 0 END)::float as active_capital
+    FROM vaults
+  `)
 
-    switch (period) {
-        case '7d':
-            startDate = utcStartOfDay(subDays(now, 7))
-            break
-        case '30d':
-            startDate = utcStartOfDay(subDays(now, 30))
-            break
-        case '90d':
-            startDate = utcStartOfDay(subDays(now, 90))
-            break
-        case '1y':
-            startDate = utcStartOfDay(subYears(now, 1))
-            break
-        default:
-            // Default to all time
-            return { startDate: new Date(0).toISOString(), endDate }
+  const stats = rows[0] ?? {
+    total_vaults: 0,
+    active_vaults: 0,
+    completed_vaults: 0,
+    failed_vaults: 0,
+    total_locked_capital: 0,
+    active_capital: 0,
+  }
+  const totalCompleted = stats.completed_vaults
+  const totalFailed = stats.failed_vaults
+  const successRate = totalCompleted + totalFailed > 0 ? (totalCompleted / (totalCompleted + totalFailed)) * 100 : 0
+
+  await pool.query(
+    `
+      INSERT INTO analytics_vault_summary (
+        id, total_vaults, active_vaults, completed_vaults, failed_vaults,
+        total_locked_capital, active_capital, success_rate, last_updated
+      )
+      VALUES (1, $1, $2, $3, $4, $5, $6, $7, NOW())
+      ON CONFLICT (id) DO UPDATE
+      SET total_vaults = EXCLUDED.total_vaults,
+          active_vaults = EXCLUDED.active_vaults,
+          completed_vaults = EXCLUDED.completed_vaults,
+          failed_vaults = EXCLUDED.failed_vaults,
+          total_locked_capital = EXCLUDED.total_locked_capital,
+          active_capital = EXCLUDED.active_capital,
+          success_rate = EXCLUDED.success_rate,
+          last_updated = NOW()
+    `,
+    [
+      stats.total_vaults,
+      stats.active_vaults,
+      stats.completed_vaults,
+      stats.failed_vaults,
+      stats.total_locked_capital ?? 0,
+      stats.active_capital ?? 0,
+      successRate,
+    ],
+  )
+
+  await pool.query(`
+    INSERT INTO analytics_vault_daily_rollups (
+      bucket_date, total_vaults, active_vaults, completed_vaults, failed_vaults,
+      total_locked_capital, active_capital, success_rate, last_updated
+    )
+    SELECT
+      DATE(created_at) as bucket_date,
+      COUNT(*)::int as total_vaults,
+      SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END)::int as active_vaults,
+      SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END)::int as completed_vaults,
+      SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)::int as failed_vaults,
+      SUM(CAST(amount AS numeric))::numeric(20,7) as total_locked_capital,
+      SUM(CASE WHEN status = 'active' THEN CAST(amount AS numeric) ELSE 0 END)::numeric(20,7) as active_capital,
+      CASE
+        WHEN SUM(CASE WHEN status IN ('completed', 'failed') THEN 1 ELSE 0 END) = 0 THEN 0
+        ELSE (
+          SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END)::numeric
+          / SUM(CASE WHEN status IN ('completed', 'failed') THEN 1 ELSE 0 END)::numeric
+        ) * 100
+      END as success_rate,
+      NOW() as last_updated
+    FROM vaults
+    GROUP BY DATE(created_at)
+    ON CONFLICT (bucket_date) DO UPDATE
+    SET total_vaults = EXCLUDED.total_vaults,
+        active_vaults = EXCLUDED.active_vaults,
+        completed_vaults = EXCLUDED.completed_vaults,
+        failed_vaults = EXCLUDED.failed_vaults,
+        total_locked_capital = EXCLUDED.total_locked_capital,
+        active_capital = EXCLUDED.active_capital,
+        success_rate = EXCLUDED.success_rate,
+        last_updated = NOW()
+  `)
+}
+
+export function initializeDatabase(): void {
+  initializeSqliteSchema()
+  const pool = getPoolIfEnabled()
+  if (pool) {
+    void initializePostgresSchema(pool).catch((error) => {
+      console.warn('PostgreSQL analytics schema initialization failed:', error)
+    })
+  }
+}
+
+export function closeDatabase(): void {
+  db.close()
+  const pool = getPoolIfEnabled()
+  if (pool) {
+    void pool.end().catch(() => undefined)
+  }
+}
+
+export function updateAnalyticsSummary(): void {
+  writeSQLiteSummary()
+  const pool = getPoolIfEnabled()
+  if (pool) {
+    void writePostgresSummary(pool).catch((error) => {
+      console.warn('PostgreSQL analytics summary update failed:', error)
+    })
+  }
+}
+
+const mapSummary = (row: Record<string, unknown>): AnalyticsSummaryRow => ({
+  total_vaults: Number(row.total_vaults ?? 0),
+  active_vaults: Number(row.active_vaults ?? 0),
+  completed_vaults: Number(row.completed_vaults ?? 0),
+  failed_vaults: Number(row.failed_vaults ?? 0),
+  total_locked_capital: String(row.total_locked_capital ?? '0'),
+  active_capital: String(row.active_capital ?? '0'),
+  success_rate: Number(row.success_rate ?? 0),
+  last_updated: String(row.last_updated ?? new Date().toISOString()),
+})
+
+export async function readAnalyticsSummary(): Promise<AnalyticsSummaryRow> {
+  const pool = shouldUsePostgres ? getPoolIfEnabled() : null
+  if (pool) {
+    const { rows } = await pool.query<Record<string, unknown>>(`
+      SELECT
+        total_vaults,
+        active_vaults,
+        completed_vaults,
+        failed_vaults,
+        total_locked_capital::text,
+        active_capital::text,
+        success_rate::float,
+        last_updated::text
+      FROM analytics_vault_summary
+      WHERE id = 1
+    `)
+    if (rows[0]) {
+      return mapSummary(rows[0])
     }
+  }
 
-    return { startDate, endDate }
+  const sqliteDb = getDb()
+  const summary = sqliteDb.prepare(`
+    SELECT
+      total_vaults,
+      active_vaults,
+      completed_vaults,
+      failed_vaults,
+      total_locked_capital,
+      active_capital,
+      success_rate,
+      last_updated
+    FROM vault_analytics_summary
+    WHERE id = 1
+  `).get() as Record<string, unknown> | undefined
+
+  return mapSummary(summary ?? {})
+}
+
+export async function queryVaultStatsByPeriod(startDate: string, endDate: string): Promise<AnalyticsStatsRow> {
+  const pool = shouldUsePostgres ? getPoolIfEnabled() : null
+  if (pool) {
+    const { rows } = await pool.query<AnalyticsStatsRow>(
+      `
+        SELECT
+          COUNT(*)::int as total_vaults,
+          SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END)::int as active_vaults,
+          SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END)::int as completed_vaults,
+          SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END)::int as failed_vaults,
+          SUM(CAST(amount AS numeric))::float as total_locked_capital,
+          SUM(CASE WHEN status = 'active' THEN CAST(amount AS numeric) ELSE 0 END)::float as active_capital
+        FROM vaults
+        WHERE created_at >= $1 AND created_at <= $2
+      `,
+      [startDate, endDate],
+    )
+    return rows[0] ?? getSQLiteStats(startDate, endDate)
+  }
+  return getSQLiteStats(startDate, endDate)
+}
+
+export async function queryVaultStatusBreakdownByPeriod(
+  startDate: string,
+  endDate: string,
+): Promise<Array<{ status: string; count: number }>> {
+  const pool = shouldUsePostgres ? getPoolIfEnabled() : null
+  if (pool) {
+    const { rows } = await pool.query<{ status: string; count: string }>(
+      `
+        SELECT status, COUNT(*)::text as count
+        FROM vaults
+        WHERE created_at >= $1 AND created_at <= $2
+        GROUP BY status
+      `,
+      [startDate, endDate],
+    )
+    return rows.map((row) => ({ status: row.status, count: Number(row.count) }))
+  }
+
+  const rows = getDb()
+    .prepare(
+      `
+        SELECT status, COUNT(*) as count
+        FROM vaults
+        WHERE created_at >= ? AND created_at <= ?
+        GROUP BY status
+      `,
+    )
+    .all(startDate, endDate) as Array<{ status: string; count: number }>
+  return rows
+}
+
+export async function queryVaultStatusBreakdownAllTime(): Promise<Array<{ status: string; count: number }>> {
+  const pool = shouldUsePostgres ? getPoolIfEnabled() : null
+  if (pool) {
+    const { rows } = await pool.query<{ status: string; count: string }>(`
+      SELECT status, COUNT(*)::text as count
+      FROM vaults
+      GROUP BY status
+    `)
+    return rows.map((row) => ({ status: row.status, count: Number(row.count) }))
+  }
+
+  return getDb().prepare('SELECT status, COUNT(*) as count FROM vaults GROUP BY status').all() as Array<{
+    status: string
+    count: number
+  }>
+}
+
+export async function backfillAnalyticsStorage(): Promise<void> {
+  const pool = getPoolIfEnabled()
+  if (!pool) {
+    return
+  }
+  await initializePostgresSchema(pool)
+  await writePostgresSummary(pool)
+}
+
+export function getTimeRangeFilter(period: string): { startDate: string; endDate: string } {
+  const now = new Date()
+  const endDate = utcEndOfDay(now)
+  let startDate: string
+
+  switch (period) {
+    case '7d':
+      startDate = utcStartOfDay(subDays(now, 7))
+      break
+    case '30d':
+      startDate = utcStartOfDay(subDays(now, 30))
+      break
+    case '90d':
+      startDate = utcStartOfDay(subDays(now, 90))
+      break
+    case '1y':
+      startDate = utcStartOfDay(subYears(now, 1))
+      break
+    default:
+      return { startDate: new Date(0).toISOString(), endDate }
+  }
+
+  return { startDate, endDate }
+}
+
+function getDb(): DatabaseType {
+  return db
 }

--- a/src/jobs/enqueueOptions.ts
+++ b/src/jobs/enqueueOptions.ts
@@ -1,0 +1,13 @@
+import type { EnqueueOptions } from './types.js'
+
+export interface EnqueueOptionInput {
+  delayMs?: number
+  maxAttempts?: number
+}
+
+export const parseEnqueueOptions = (input: EnqueueOptionInput): EnqueueOptions => {
+  return {
+    delayMs: input.delayMs !== undefined ? Math.floor(input.delayMs) : undefined,
+    maxAttempts: input.maxAttempts,
+  }
+}

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -3,6 +3,7 @@ import { authenticate } from '../middleware/auth.js'
 import { authenticateApiKey } from '../middleware/apiKeyAuth.js'
 import { listMilestoneEvents } from '../services/milestones.js'
 import { utcNow } from '../utils/timestamps.js'
+import { readAnalyticsSummary } from '../db/database.js'
 
 export const analyticsRouter = Router()
 
@@ -85,17 +86,14 @@ const buildTrendBuckets = (
   return Array.from(buckets.values())
 }
 
-analyticsRouter.get('/summary', authenticate, (_req, res) => {
-  res.status(200).json({
-    total_vaults: 10,
-    active_vaults: 5,
-    completed_vaults: 3,
-    failed_vaults: 2,
-    total_locked_capital: '5000.0000000',
-    active_capital: '2500.0000000',
-    success_rate: 60.0,
-    last_updated: utcNow(),
-  })
+analyticsRouter.get('/summary', authenticate, async (_req, res) => {
+  try {
+    const summary = await readAnalyticsSummary()
+    res.status(200).json(summary)
+  } catch (error) {
+    console.error('Failed to read analytics summary', error)
+    res.status(500).json({ error: 'Failed to load analytics summary.' })
+  }
 })
 
 analyticsRouter.get('/overview', authenticateApiKey(['read:analytics']), (_req, res) => {

--- a/src/routes/jobs.ts
+++ b/src/routes/jobs.ts
@@ -7,6 +7,7 @@ import {
   type JobPayloadByType,
   type JobType,
 } from '../jobs/types.js'
+import { parseEnqueueOptions } from '../jobs/enqueueOptions.js'
 import { authenticate, authorize } from '../middleware/auth.js'
 import { strictRateLimiter } from '../middleware/rateLimiter.js'
 import { createAuditLog } from '../lib/audit-logs.js'
@@ -136,10 +137,10 @@ export const createJobsRouter = (jobSystem: BackgroundJobSystem, options: JobsRo
 
     try {
       const { payload, type } = parseResult.data
-      const options: EnqueueOptions = {
-        delayMs: parseResult.data.delayMs !== undefined ? Math.floor(parseResult.data.delayMs) : undefined,
+      const options: EnqueueOptions = parseEnqueueOptions({
+        delayMs: parseResult.data.delayMs,
         maxAttempts: parseResult.data.maxAttempts,
-      }
+      })
       const queuedJob = enqueueTypedJob(jobSystem, type, payload as JobPayloadByType[JobType], options)
 
       createAuditLog({

--- a/src/tests/analytics.storage.test.ts
+++ b/src/tests/analytics.storage.test.ts
@@ -1,0 +1,23 @@
+import { initializeDatabase, readAnalyticsSummary, updateAnalyticsSummary } from '../db/database.js'
+
+describe('analytics storage compatibility', () => {
+  beforeAll(() => {
+    initializeDatabase()
+  })
+
+  it('returns a stable summary payload shape for /api/analytics consumers', async () => {
+    updateAnalyticsSummary()
+    const summary = await readAnalyticsSummary()
+
+    expect(summary).toEqual({
+      total_vaults: expect.any(Number),
+      active_vaults: expect.any(Number),
+      completed_vaults: expect.any(Number),
+      failed_vaults: expect.any(Number),
+      total_locked_capital: expect.any(String),
+      active_capital: expect.any(String),
+      success_rate: expect.any(Number),
+      last_updated: expect.any(String),
+    })
+  })
+})

--- a/src/tests/enqueueOptions.test.ts
+++ b/src/tests/enqueueOptions.test.ts
@@ -1,0 +1,24 @@
+import { parseEnqueueOptions } from '../jobs/enqueueOptions.js'
+
+describe('parseEnqueueOptions', () => {
+  it('returns undefined defaults', () => {
+    expect(parseEnqueueOptions({})).toEqual({
+      delayMs: undefined,
+      maxAttempts: undefined,
+    })
+  })
+
+  it('floors decimal delay values', () => {
+    expect(parseEnqueueOptions({ delayMs: 1234.99 })).toEqual({
+      delayMs: 1234,
+      maxAttempts: undefined,
+    })
+  })
+
+  it('keeps maxAttempts value', () => {
+    expect(parseEnqueueOptions({ maxAttempts: 9 })).toEqual({
+      delayMs: undefined,
+      maxAttempts: 9,
+    })
+  })
+})

--- a/src/tests/jobs.enqueue.contract.test.ts
+++ b/src/tests/jobs.enqueue.contract.test.ts
@@ -1,0 +1,90 @@
+import express, { type NextFunction, type Request, type Response } from 'express'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { createJobsRouter } from '../routes/jobs.js'
+import { BackgroundJobSystem } from '../jobs/system.js'
+import { UserRole } from '../types/user.js'
+import { clearAuditLogs, listAuditLogs } from '../lib/audit-logs.js'
+import { JWT_AUDIENCE, JWT_ISSUER } from '../lib/auth-utils.js'
+
+const noopLimiter = (_req: Request, _res: Response, next: NextFunction) => next()
+
+let adminToken = ''
+let userToken = ''
+
+const validBody = {
+  type: 'deadline.check',
+  payload: { triggerSource: 'manual' },
+} as const
+
+describe('POST /api/jobs/enqueue contract', () => {
+  const jobSystem = new BackgroundJobSystem()
+  const app = express()
+  app.use(express.json())
+  app.use('/api/jobs', createJobsRouter(jobSystem, { enqueueLimiter: noopLimiter }))
+
+  beforeAll(() => {
+    jobSystem.start()
+  })
+
+  beforeAll(async () => {
+    adminToken = jwt.sign(
+      { userId: 'admin-contract', sub: 'admin-contract', role: UserRole.ADMIN },
+      process.env.JWT_ACCESS_SECRET || 'fallback-access-secret',
+      { audience: JWT_AUDIENCE, issuer: JWT_ISSUER, expiresIn: '15m' },
+    )
+    userToken = jwt.sign(
+      { userId: 'user-contract', sub: 'user-contract', role: UserRole.USER },
+      process.env.JWT_ACCESS_SECRET || 'fallback-access-secret',
+      { audience: JWT_AUDIENCE, issuer: JWT_ISSUER, expiresIn: '15m' },
+    )
+  })
+
+  beforeEach(() => {
+    clearAuditLogs()
+  })
+
+  afterAll(async () => {
+    await jobSystem.stop()
+  })
+
+  it('rejects non-admin callers', async () => {
+    const response = await request(app)
+      .post('/api/jobs/enqueue')
+      .set('Authorization', `Bearer ${userToken}`)
+      .send(validBody)
+
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects invalid options consistently', async () => {
+    const response = await request(app)
+      .post('/api/jobs/enqueue')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ ...validBody, delayMs: -1, maxAttempts: 2.5 })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error.code).toBe('VALIDATION_ERROR')
+    expect(response.body.error.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: 'delayMs' }),
+        expect.objectContaining({ path: 'maxAttempts' }),
+      ]),
+    )
+  })
+
+  it('accepts valid payload and records an audit log', async () => {
+    const response = await request(app)
+      .post('/api/jobs/enqueue')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ ...validBody, delayMs: 1000, maxAttempts: 5 })
+
+    expect(response.status).toBe(202)
+    expect(response.body.job.type).toBe('deadline.check')
+    expect(response.body.job.maxAttempts).toBe(5)
+
+    const auditLogs = listAuditLogs({ action: 'job.enqueue', target_id: response.body.job.id, limit: 10 })
+    expect(auditLogs).toHaveLength(1)
+    expect(auditLogs[0]?.actor_user_id).toBe('admin-contract')
+  })
+})

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -4,6 +4,7 @@ import { generateAccessToken } from '../src/lib/auth-utils.js'
 import { UserRole } from '../src/types/user.js'
 import { createJobsRouter } from '../src/routes/jobs.js'
 import { BackgroundJobSystem } from '../src/jobs/system.js'
+import { clearAuditLogs, listAuditLogs } from '../src/lib/audit-logs.js'
 
 // ---------------------------------------------------------------------------
 // Test app – minimal Express instance with the jobs router mounted.
@@ -59,6 +60,10 @@ const validBodies = {
 // ---------------------------------------------------------------------------
 
 describe('Jobs API', () => {
+  beforeEach(() => {
+    clearAuditLogs()
+  })
+
   // -------------------------------------------------------------------------
   describe('Authentication', () => {
     const routes = [
@@ -355,6 +360,18 @@ describe('Jobs API', () => {
       expect(new Date(res.body.job.runAt).getTime()).toBeGreaterThanOrEqual(now + 59_000)
     })
 
+    it('floors decimal delayMs as part of options parsing', async () => {
+      const now = Date.now()
+      const res = await request(testApp)
+        .post('/api/jobs/enqueue')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ ...validBodies['deadline.check'], delayMs: 1500.9 })
+        .expect(202)
+
+      expect(new Date(res.body.job.runAt).getTime()).toBeGreaterThanOrEqual(now + 1400)
+      expect(new Date(res.body.job.runAt).getTime()).toBeLessThanOrEqual(now + 2500)
+    })
+
     it('respects maxAttempts option', async () => {
       const res = await request(testApp)
         .post('/api/jobs/enqueue')
@@ -373,6 +390,23 @@ describe('Jobs API', () => {
         .expect(202)
 
       expect(res.body.job.maxAttempts).toBe(3)
+    })
+
+    it('writes an audit log entry for successful enqueue', async () => {
+      const res = await request(testApp)
+        .post('/api/jobs/enqueue')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(validBodies['analytics.recompute'])
+        .expect(202)
+
+      const logs = listAuditLogs({ action: 'job.enqueue', target_id: res.body.job.id, limit: 10 })
+      expect(logs).toHaveLength(1)
+      expect(logs[0]).toMatchObject({
+        actor_user_id: 'admin-jobs-test',
+        action: 'job.enqueue',
+        target_type: 'job',
+        target_id: res.body.job.id,
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

This PR resolves two backend issues:

1. #217 Analytics storage migration path
- Added PostgreSQL analytics schema support with migration:
  - `analytics_vault_summary`
  - `analytics_vault_daily_rollups`
- Added optional runtime storage controls:
  - `ANALYTICS_STORAGE=postgres` for PG reads
  - `ANALYTICS_DUAL_WRITE=true` for safe dual-write rollout
- Implemented backfill capability via `backfillAnalyticsStorage()` in `src/db/database.ts`
- Updated `/api/analytics/summary` to read from storage layer while preserving response shape
- Added documentation: `docs/analytics-storage.md`

2. #245 Jobs enqueue API contract coverage
- Extracted enqueue options parsing into `src/jobs/enqueueOptions.ts`
- Added explicit contract tests for:
  - Admin-only enforcement
  - Invalid enqueue options (`delayMs`, `maxAttempts`) and consistent validation errors
  - Successful enqueue and audit log creation checks
- Added docs for enqueue contract and option parsing:
  - `docs/jobs.md`
- Added tests:
  - `src/tests/enqueueOptions.test.ts`
  - `src/tests/jobs.enqueue.contract.test.ts`
  - `src/tests/analytics.storage.test.ts`

## Validation Performed

- Ran targeted test suites:
  - `src/tests/enqueueOptions.test.ts`
  - `src/tests/jobs.enqueue.contract.test.ts`
  - `src/tests/analytics.storage.test.ts`
- All passed.

## Notes

- `/api/analytics` summary behavior remains stable (same aggregate fields).
- No PII fields were added to analytics responses.
- Dual-write and backfill support are included for migration safety.

Closes #217
Closes #245