### PR TITLE
fix(vaults): return json response in legacy fallback

### DIFF
--- a/src/routes/vaults.ts
+++ b/src/routes/vaults.ts
@@ -160,6 +160,10 @@ vaultsRouter.get('/:id', authenticate, async (req: Request, res: Response) => {
     res.status(404).json({ error: 'Vault not found' })
     return
   }
+
+  // Return 200 + vault JSON when found in legacy fallback
+  // This ensures the response is always properly formatted JSON
+  return res.status(200).json(vault)
 })
 
 // ─── POST /api/vaults/:id/cancel ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #205 

---

- Ensure GET /api/vaults/:id returns 200 + vault JSON in legacy in-memory fallback path
- Add explicit status code and return statement to prevent hanging requests
- Add clear comments explaining the JSON response behavior
- Fixes issue where legacy fallback could return empty responses