### PR TITLE
feat(api-keys): hashed keys with rotation and scopes

### DIFF
--- a/db/migrations/20260428143000_harden_api_keys_indexes.cjs
+++ b/db/migrations/20260428143000_harden_api_keys_indexes.cjs
@@ -1,0 +1,16 @@
+exports.up = async function up(knex) {
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_api_keys_hash_prefix
+      ON api_keys (left(key_hash, 12))
+  `)
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_api_keys_user_revoked
+      ON api_keys (user_id, revoked_at)
+  `)
+}
+
+exports.down = async function down(knex) {
+  await knex.raw('DROP INDEX IF EXISTS idx_api_keys_hash_prefix')
+  await knex.raw('DROP INDEX IF EXISTS idx_api_keys_user_revoked')
+}

--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -1,0 +1,96 @@
+# API Keys
+
+This backend supports scoped API keys for server-to-server access. Keys are intended for least-privilege integrations such as analytics readers and must be presented in the `x-api-key` header.
+
+## Security model
+
+- API keys are never stored in plaintext.
+- Clients receive the full key value only at create time and rotate time.
+- Stored records keep only a SHA-256 hash of the secret plus metadata.
+- Revocation is soft-state through `revoked_at`, so revoked keys remain auditable.
+- If both `x-api-key` and user auth headers are present, `x-api-key` takes precedence on API-key protected routes. An invalid API key is rejected even if a bearer token is also present.
+
+## Endpoints
+
+### Create
+
+`POST /api/api-keys`
+
+Creates a new API key for the authenticated user.
+
+Example:
+
+```bash
+curl -X POST "http://localhost:3000/api/api-keys" \
+  -H "Content-Type: application/json" \
+  -H "x-user-id: user-123" \
+  -d '{
+    "label": "analytics integration",
+    "scopes": ["read:analytics", "read:vaults"]
+  }'
+```
+
+Response notes:
+
+- `apiKey` is returned exactly once.
+- `apiKeyMeta` is safe to store or display because it omits the secret and hash.
+
+### List
+
+`GET /api/api-keys`
+
+Lists API keys for the authenticated user. The response is redacted and never includes plaintext keys or hashes.
+
+```bash
+curl "http://localhost:3000/api/api-keys" \
+  -H "x-user-id: user-123"
+```
+
+### Rotate
+
+`POST /api/api-keys/:id/rotate`
+
+Replaces the key secret while keeping the same key id and metadata.
+
+```bash
+curl -X POST "http://localhost:3000/api/api-keys/<api-key-id>/rotate" \
+  -H "x-user-id: user-123"
+```
+
+After rotation:
+
+- the old key stops working immediately
+- the new plaintext value is returned once
+- scopes and ownership stay the same
+
+### Revoke
+
+`POST /api/api-keys/:id/revoke`
+
+Marks the key as revoked so further use is rejected.
+
+```bash
+curl -X POST "http://localhost:3000/api/api-keys/<api-key-id>/revoke" \
+  -H "x-user-id: user-123"
+```
+
+## Using a key
+
+Use the issued secret in the `x-api-key` header on API-key protected endpoints.
+
+```bash
+curl "http://localhost:3000/api/analytics/overview" \
+  -H "x-api-key: dsk_<id>.<secret>"
+```
+
+Least-privilege examples:
+
+- `read:analytics` for analytics overview and trend endpoints
+- `read:vaults` for vault analytics views
+
+## Rate limiting and logging
+
+- API key management endpoints use the API key rate limiter.
+- General request limiters key on `x-api-key` when present, so API-key traffic is throttled the same way as user-auth traffic.
+- Rate-limit breach logs redact API key values.
+- Request privacy logging masks sensitive body fields and should not emit plaintext API keys.

--- a/src/middleware/apiKeyAuth.test.ts
+++ b/src/middleware/apiKeyAuth.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import express from 'express'
+import request from 'supertest'
+import { authenticateApiKey } from './apiKeyAuth.js'
+import { createApiKey, resetApiKeysTable } from '../services/apiKeys.js'
+
+const buildApp = () => {
+  const app = express()
+  app.get(
+    '/protected',
+    authenticateApiKey(['read:analytics']),
+    (req, res) => {
+      res.status(200).json({
+        ok: true,
+        apiKeyId: req.apiKeyAuth?.apiKeyId ?? null,
+        userId: req.apiKeyAuth?.userId ?? null,
+      })
+    },
+  )
+  return app
+}
+
+test('requires x-api-key when protecting a route', async () => {
+  await resetApiKeysTable()
+  const app = buildApp()
+
+  const response = await request(app).get('/protected')
+
+  assert.equal(response.status, 401)
+  assert.equal(response.body.error, 'Missing API key. Provide x-api-key header.')
+})
+
+test('accepts a valid scoped api key', async () => {
+  await resetApiKeysTable()
+  const app = buildApp()
+  const { apiKey, record } = await createApiKey({
+    userId: 'user-scope',
+    label: 'scoped key',
+    scopes: ['read:analytics'],
+  })
+
+  const response = await request(app)
+    .get('/protected')
+    .set('x-api-key', apiKey)
+
+  assert.equal(response.status, 200)
+  assert.equal(response.body.ok, true)
+  assert.equal(response.body.apiKeyId, record.id)
+  assert.equal(response.body.userId, 'user-scope')
+})
+
+test('rejects keys without the required scopes', async () => {
+  await resetApiKeysTable()
+  const app = buildApp()
+  const { apiKey } = await createApiKey({
+    userId: 'user-vault-only',
+    label: 'vault-only key',
+    scopes: ['read:vaults'],
+  })
+
+  const response = await request(app)
+    .get('/protected')
+    .set('x-api-key', apiKey)
+
+  assert.equal(response.status, 403)
+  assert.equal(response.body.error, 'API key does not have the required scopes.')
+})
+
+test('gives x-api-key precedence over Authorization when both are present', async () => {
+  await resetApiKeysTable()
+  const app = buildApp()
+  const { apiKey } = await createApiKey({
+    userId: 'user-good-key',
+    label: 'good key',
+    scopes: ['read:analytics'],
+  })
+
+  const response = await request(app)
+    .get('/protected')
+    .set('x-api-key', `${apiKey}-tampered`)
+    .set('authorization', 'Bearer user:jwt-user')
+
+  assert.equal(response.status, 401)
+  assert.equal(response.body.error, 'API key is invalid.')
+})

--- a/src/middleware/apiKeyAuth.ts
+++ b/src/middleware/apiKeyAuth.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from 'express'
 import { validateApiKey } from '../services/apiKeys.js'
 
 export const authenticateApiKey = (requiredScopes: string[] = []): RequestHandler => {
-  return (req, res, next) => {
+  return async (req, res, next) => {
     const apiKey = req.header('x-api-key')
 
     if (!apiKey) {
@@ -10,7 +10,7 @@ export const authenticateApiKey = (requiredScopes: string[] = []): RequestHandle
       return
     }
 
-    const validation = validateApiKey(apiKey, requiredScopes)
+    const validation = await validateApiKey(apiKey, requiredScopes)
     if (!validation.valid) {
       if (validation.reason === 'forbidden') {
         res.status(403).json({ error: 'API key does not have the required scopes.' })

--- a/src/middleware/privacy-logger.ts
+++ b/src/middleware/privacy-logger.ts
@@ -37,7 +37,7 @@ function maskIp(ip: string): string {
 function sanitizeBody(body: any): any {
     if (!body || typeof body !== 'object') return body
 
-    const sensitiveFields = ['creator', 'successDestination', 'failureDestination']
+    const sensitiveFields = ['creator', 'successDestination', 'failureDestination', 'apiKey', 'secret', 'x-api-key']
     const sanitized = { ...body }
 
     for (const field of sensitiveFields) {

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -1,5 +1,6 @@
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit'
 import type { Request, Response } from 'express'
+import { redactApiKeyForLogs } from '../services/apiKeys.js'
 
 export interface RateLimitConfig {
   windowMs: number
@@ -18,7 +19,8 @@ const logRateLimitBreached = (req: Request): void => {
   const method = req.method
   const path = req.path
   const userAgent = req.headers['user-agent'] ?? 'unknown'
-  const apiKey = req.headers['x-api-key'] ?? 'none'
+  const apiKeyHeader = typeof req.headers['x-api-key'] === 'string' ? req.headers['x-api-key'] : undefined
+  const apiKey = redactApiKeyForLogs(apiKeyHeader)
 
   console.warn(`[RATE_LIMIT_BREACH] ${timestamp} | IP: ${clientIp} | API_KEY: ${apiKey} | ${method} ${path} | User-Agent: ${userAgent}`)
 }
@@ -85,6 +87,12 @@ export const metricsRateLimiter = createRateLimiter({
   windowMs: 60 * 1000,
   max: 20,
   message: 'Metrics endpoint rate limit exceeded. Please try again later.',
+})
+
+export const apiKeyRateLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+  message: 'Too many API key management requests. Please try again later.',
 })
 
 export { createRateLimiter }

--- a/src/routes/analytics.milestones.test.ts
+++ b/src/routes/analytics.milestones.test.ts
@@ -10,7 +10,7 @@ let baseUrl = ''
 let server: ReturnType<express.Express['listen']> | null = null
 
 beforeEach(async () => {
-  resetApiKeysTable()
+  await resetApiKeysTable()
   resetMilestones()
 
   const app = express()
@@ -39,8 +39,8 @@ afterEach(async () => {
   server = null
 })
 
-const createAnalyticsKey = () => {
-  const { apiKey } = createApiKey({
+const createAnalyticsKey = async () => {
+  const { apiKey } = await createApiKey({
     userId: 'user-1',
     orgId: 'org-1',
     label: 'analytics',
@@ -50,7 +50,7 @@ const createAnalyticsKey = () => {
 }
 
 test('returns milestone completion trends over time', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
   const base = new Date('2025-01-01T00:00:00.000Z')
 
   addMilestoneEvent({
@@ -94,7 +94,7 @@ test('returns milestone completion trends over time', async () => {
 })
 
 test('returns behavior score for a user', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
 
   addMilestoneEvent({
     userId: 'user-42',
@@ -133,7 +133,7 @@ test('returns behavior score for a user', async () => {
 })
 
 test('includes milestone events that fall exactly on the requested date boundaries', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
   const from = '2025-01-01T00:00:00.000Z'
   const middle = '2025-01-02T12:00:00.000Z'
   const to = '2025-01-03T23:59:59.999Z'
@@ -190,7 +190,7 @@ test('includes milestone events that fall exactly on the requested date boundari
 })
 
 test('returns empty milestone buckets when no events fall in the requested range', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
   const from = '2025-02-01T00:00:00.000Z'
   const to = '2025-02-02T23:59:59.999Z'
 
@@ -231,7 +231,7 @@ test('returns empty milestone buckets when no events fall in the requested range
 })
 
 test('rejects milestone trend requests when from is after to', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
 
   const res = await fetch(
     `${baseUrl}/api/analytics/milestones/trends?from=2025-02-03T00:00:00.000Z&to=2025-02-01T00:00:00.000Z&groupBy=day`,
@@ -246,7 +246,7 @@ test('rejects milestone trend requests when from is after to', async () => {
 })
 
 test('filters behavior score to the requested range and includes edge timestamps', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
   const from = '2025-04-10T00:00:00.000Z'
   const to = '2025-04-11T23:59:59.999Z'
 
@@ -305,7 +305,7 @@ test('filters behavior score to the requested range and includes edge timestamps
 })
 
 test('rejects behavior score requests without a userId', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
 
   const res = await fetch(`${baseUrl}/api/analytics/behavior`, {
     headers: { 'x-api-key': apiKey },
@@ -319,7 +319,7 @@ test('rejects behavior score requests without a userId', async () => {
 // ─── List Contract Tests for Analytics ─────────────────────────────────────
 
 test('validates date range filtering contract for trends', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
   const from = '2025-01-01T00:00:00.000Z'
   const to = '2025-01-07T00:00:00.000Z'
 
@@ -345,7 +345,7 @@ test('validates date range filtering contract for trends', async () => {
 })
 
 test('validates groupBy parameter contract (day and week)', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
   const base = new Date('2025-01-01T00:00:00.000Z')
 
   addMilestoneEvent({
@@ -380,7 +380,7 @@ test('validates groupBy parameter contract (day and week)', async () => {
 })
 
 test('validates date range filtering contract for behavior scores', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
   const from = '2025-03-01T00:00:00.000Z'
   const to = '2025-03-31T23:59:59.999Z'
 
@@ -431,7 +431,7 @@ test('requires authentication for analytics endpoints', async () => {
 })
 
 test('validates user isolation in analytics - cannot access other user events', async () => {
-  const apiKey = createAnalyticsKey()
+  const apiKey = await createAnalyticsKey()
 
   addMilestoneEvent({
     userId: 'user-a',

--- a/src/routes/apiKeys.test.ts
+++ b/src/routes/apiKeys.test.ts
@@ -10,7 +10,7 @@ let baseUrl = ''
 let server: ReturnType<express.Express['listen']> | null = null
 
 beforeEach(async () => {
-  resetApiKeysTable()
+  await resetApiKeysTable()
   const app = express()
   app.use(express.json())
   app.use('/api/api-keys', apiKeysRouter)
@@ -40,7 +40,7 @@ afterEach(async () => {
   server = null
 })
 
-test('creates, lists, and revokes API keys for an authenticated user', async () => {
+test('creates, lists, rotates, and revokes API keys for an authenticated user', async () => {
   const createResponse = await fetch(`${baseUrl}/api/api-keys`, {
     method: 'POST',
     headers: {
@@ -49,19 +49,21 @@ test('creates, lists, and revokes API keys for an authenticated user', async () 
     },
     body: JSON.stringify({
       label: 'analytics integration',
-      scopes: ['read:analytics', 'read:vaults'],
+      scopes: ['read:analytics', 'read:vaults', 'read:analytics'],
     }),
   })
 
   assert.equal(createResponse.status, 201)
   const createdBody = (await createResponse.json()) as {
     apiKey: string
-    apiKeyMeta: { id: string; userId: string; revokedAt: string | null }
+    apiKeyMeta: { id: string; userId: string; revokedAt: string | null; scopes: string[]; keyHash?: string }
   }
 
   assert.match(createdBody.apiKey, /^dsk_/)
   assert.equal(createdBody.apiKeyMeta.userId, 'user-123')
   assert.equal(createdBody.apiKeyMeta.revokedAt, null)
+  assert.deepEqual(createdBody.apiKeyMeta.scopes, ['read:analytics', 'read:vaults'])
+  assert.equal('keyHash' in createdBody.apiKeyMeta, false)
 
   const listResponse = await fetch(`${baseUrl}/api/api-keys`, {
     headers: {
@@ -71,12 +73,45 @@ test('creates, lists, and revokes API keys for an authenticated user', async () 
 
   assert.equal(listResponse.status, 200)
   const listBody = (await listResponse.json()) as {
-    apiKeys: Array<{ id: string; keyHash?: string }>
+    apiKeys: Array<{ id: string; keyHash?: string; scopes: string[] }>
   }
 
   assert.equal(listBody.apiKeys.length, 1)
   assert.equal(listBody.apiKeys[0].id, createdBody.apiKeyMeta.id)
   assert.equal('keyHash' in listBody.apiKeys[0], false)
+  assert.deepEqual(listBody.apiKeys[0].scopes, ['read:analytics', 'read:vaults'])
+
+  const rotateResponse = await fetch(`${baseUrl}/api/api-keys/${createdBody.apiKeyMeta.id}/rotate`, {
+    method: 'POST',
+    headers: {
+      'x-user-id': 'user-123',
+    },
+  })
+
+  assert.equal(rotateResponse.status, 200)
+  const rotateBody = (await rotateResponse.json()) as {
+    apiKey: string
+    apiKeyMeta: { id: string; revokedAt: string | null; keyHash?: string }
+  }
+
+  assert.match(rotateBody.apiKey, /^dsk_/)
+  assert.notEqual(rotateBody.apiKey, createdBody.apiKey)
+  assert.equal(rotateBody.apiKeyMeta.id, createdBody.apiKeyMeta.id)
+  assert.equal('keyHash' in rotateBody.apiKeyMeta, false)
+
+  const oldKeyResponse = await fetch(`${baseUrl}/api/analytics/vaults`, {
+    headers: {
+      'x-api-key': createdBody.apiKey,
+    },
+  })
+  assert.equal(oldKeyResponse.status, 401)
+
+  const newKeyResponse = await fetch(`${baseUrl}/api/analytics/vaults`, {
+    headers: {
+      'x-api-key': rotateBody.apiKey,
+    },
+  })
+  assert.equal(newKeyResponse.status, 200)
 
   const revokeResponse = await fetch(`${baseUrl}/api/api-keys/${createdBody.apiKeyMeta.id}/revoke`, {
     method: 'POST',
@@ -90,6 +125,38 @@ test('creates, lists, and revokes API keys for an authenticated user', async () 
     apiKeyMeta: { revokedAt: string | null }
   }
   assert.notEqual(revokeBody.apiKeyMeta.revokedAt, null)
+
+  const revokedResponse = await fetch(`${baseUrl}/api/analytics/vaults`, {
+    headers: {
+      'x-api-key': rotateBody.apiKey,
+    },
+  })
+  assert.equal(revokedResponse.status, 401)
+})
+
+test('rejects rotation for keys owned by a different user', async () => {
+  const createResponse = await fetch(`${baseUrl}/api/api-keys`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-user-id': 'owner-user',
+    },
+    body: JSON.stringify({
+      label: 'owner key',
+      scopes: ['read:analytics'],
+    }),
+  })
+
+  const createdBody = (await createResponse.json()) as { apiKeyMeta: { id: string } }
+
+  const rotateResponse = await fetch(`${baseUrl}/api/api-keys/${createdBody.apiKeyMeta.id}/rotate`, {
+    method: 'POST',
+    headers: {
+      'x-user-id': 'other-user',
+    },
+  })
+
+  assert.equal(rotateResponse.status, 404)
 })
 
 test('validates scopes and rejects revoked API keys on protected analytics routes', async () => {

--- a/src/routes/apiKeys.ts
+++ b/src/routes/apiKeys.ts
@@ -2,7 +2,12 @@ import { Router } from 'express'
 import { z } from 'zod'
 import { requireUserAuth } from '../middleware/userAuth.js'
 import { apiKeyRateLimiter } from '../middleware/rateLimiter.js'
-import { createApiKey, listApiKeysForUser, revokeApiKey } from '../services/apiKeys.js'
+import {
+  createApiKey,
+  listApiKeysForUser,
+  revokeApiKey,
+  rotateApiKey,
+} from '../services/apiKeys.js'
 import { formatValidationError } from '../lib/validation.js'
 
 export const apiKeysRouter = Router()
@@ -15,14 +20,14 @@ const createApiKeySchema = z.object({
   orgId: z.string().trim().optional(),
 })
 
-apiKeysRouter.get('/', (req, res) => {
+apiKeysRouter.get('/', async (req, res) => {
   const userId = req.authUser!.userId
-  const apiKeys = listApiKeysForUser(userId).map(({ keyHash: _keyHash, ...publicRecord }) => publicRecord)
+  const apiKeys = (await listApiKeysForUser(userId)).map(({ keyHash: _keyHash, ...publicRecord }) => publicRecord)
 
   res.json({ apiKeys })
 })
 
-apiKeysRouter.post('/', apiKeyRateLimiter, (req, res) => {
+apiKeysRouter.post('/', apiKeyRateLimiter, async (req, res) => {
   const userId = req.authUser!.userId
   const parseResult = createApiKeySchema.safeParse(req.body)
   if (!parseResult.success) {
@@ -32,7 +37,7 @@ apiKeysRouter.post('/', apiKeyRateLimiter, (req, res) => {
 
   const { label, scopes, orgId } = parseResult.data
 
-  const { apiKey, record } = createApiKey({
+  const { apiKey, record } = await createApiKey({
     userId,
     orgId: orgId?.trim() || undefined,
     label,
@@ -46,9 +51,28 @@ apiKeysRouter.post('/', apiKeyRateLimiter, (req, res) => {
   })
 })
 
-apiKeysRouter.post('/:id/revoke', (req, res) => {
+apiKeysRouter.post('/:id/rotate', apiKeyRateLimiter, async (req, res) => {
   const userId = req.authUser!.userId
-  const record = revokeApiKey(req.params.id, userId)
+  const rotated = await rotateApiKey({
+    apiKeyId: req.params.id,
+    userId,
+  })
+
+  if (!rotated) {
+    res.status(404).json({ error: 'API key not found.' })
+    return
+  }
+
+  const { keyHash: _keyHash, ...publicRecord } = rotated.record
+  res.status(200).json({
+    apiKey: rotated.apiKey,
+    apiKeyMeta: publicRecord,
+  })
+})
+
+apiKeysRouter.post('/:id/revoke', async (req, res) => {
+  const userId = req.authUser!.userId
+  const record = await revokeApiKey(req.params.id, userId)
 
   if (!record) {
     res.status(404).json({ error: 'API key not found.' })

--- a/src/services/apiKeys.ts
+++ b/src/services/apiKeys.ts
@@ -1,6 +1,8 @@
-import { createHash, randomBytes, randomUUID } from 'node:crypto'
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto'
+import type { Pool } from 'pg'
 import type { ApiKeyAuthContext, ApiKeyRecord } from '../types/auth.js'
 import { utcNow } from '../utils/timestamps.js'
+import { getPgPool } from '../db/pool.js'
 
 interface CreateApiKeyInput {
   userId?: string
@@ -9,79 +11,361 @@ interface CreateApiKeyInput {
   scopes: string[]
 }
 
-const apiKeysTable: ApiKeyRecord[] = []
+interface RotateApiKeyInput {
+  apiKeyId: string
+  userId: string
+}
+
+type ApiKeyValidationResult =
+  | { valid: true; context: ApiKeyAuthContext }
+  | { valid: false; reason: 'malformed' | 'invalid' | 'revoked' | 'forbidden' }
+
+interface ApiKeyRow {
+  id: string
+  user_id: string | null
+  org_id: string | null
+  key_hash: string
+  label: string
+  scopes: string[] | string | null
+  created_at: string | Date
+  revoked_at: string | Date | null
+}
+
+interface ApiKeyRepository {
+  create(record: ApiKeyRecord): Promise<void>
+  listForUser(userId: string): Promise<ApiKeyRecord[]>
+  getById(id: string): Promise<ApiKeyRecord | null>
+  update(record: ApiKeyRecord): Promise<ApiKeyRecord>
+  findByIdForUser(id: string, userId: string): Promise<ApiKeyRecord | null>
+  findByHashPrefix(prefix: string): Promise<ApiKeyRecord[]>
+  reset(): Promise<void>
+}
+
+const API_KEY_PREFIX = 'dsk'
+const HASH_PREFIX_LENGTH = 12
+const memoryApiKeys = new Map<string, ApiKeyRecord>()
 
 const hashSecret = (secret: string): string => createHash('sha256').update(secret).digest('hex')
+
+const getHashPrefix = (hash: string): string => hash.slice(0, HASH_PREFIX_LENGTH)
+
+const buildApiKeyValue = (id: string, secret: string): string => `${API_KEY_PREFIX}_${id}.${secret}`
+
+const parseApiKey = (apiKey: string): { apiKeyId: string; secret: string } | null => {
+  const match = new RegExp(`^${API_KEY_PREFIX}_([^\\.]+)\\.(.+)$`).exec(apiKey.trim())
+  if (!match) {
+    return null
+  }
+
+  return { apiKeyId: match[1], secret: match[2] }
+}
 
 const normalizeScopes = (scopes: string[]): string[] => {
   return Array.from(new Set(scopes.map((scope) => scope.trim()).filter(Boolean))).sort()
 }
 
-export const createApiKey = (input: CreateApiKeyInput): { apiKey: string; record: ApiKeyRecord } => {
-  const id = randomUUID()
-  const secret = randomBytes(32).toString('hex')
-  const createdAt = utcNow()
-
-  const record: ApiKeyRecord = {
-    id,
-    userId: input.userId ?? null,
-    orgId: input.orgId ?? null,
-    keyHash: hashSecret(secret),
-    label: input.label,
-    scopes: normalizeScopes(input.scopes),
-    createdAt,
-    revokedAt: null,
+const normalizeScopeColumn = (scopes: string[] | string | null): string[] => {
+  if (Array.isArray(scopes)) {
+    return normalizeScopes(scopes)
   }
 
-  apiKeysTable.push(record)
+  if (typeof scopes !== 'string' || !scopes.trim()) {
+    return []
+  }
+
+  return normalizeScopes(
+    scopes
+      .split(',')
+      .map((scope) => scope.trim())
+      .filter(Boolean),
+  )
+}
+
+const redactApiKeyForLogs = (apiKey: string | undefined): string => {
+  if (!apiKey) {
+    return 'none'
+  }
+
+  const parsed = parseApiKey(apiKey)
+  if (!parsed) {
+    return 'invalid-format'
+  }
+
+  return `${API_KEY_PREFIX}_${parsed.apiKeyId}.***`
+}
+
+const asIsoString = (value: string | Date | null): string | null => {
+  if (!value) {
+    return null
+  }
+
+  return typeof value === 'string' ? value : value.toISOString()
+}
+
+const toRecord = (row: ApiKeyRow): ApiKeyRecord => ({
+  id: row.id,
+  userId: row.user_id,
+  orgId: row.org_id,
+  keyHash: row.key_hash,
+  label: row.label,
+  scopes: normalizeScopeColumn(row.scopes),
+  createdAt: asIsoString(row.created_at)!,
+  revokedAt: asIsoString(row.revoked_at),
+})
+
+const cloneRecord = (record: ApiKeyRecord): ApiKeyRecord => ({
+  ...record,
+  scopes: [...record.scopes],
+})
+
+const createMemoryRepository = (): ApiKeyRepository => ({
+  async create(record) {
+    memoryApiKeys.set(record.id, cloneRecord(record))
+  },
+  async listForUser(userId) {
+    return Array.from(memoryApiKeys.values())
+      .filter((record) => record.userId === userId)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+      .map(cloneRecord)
+  },
+  async getById(id) {
+    const record = memoryApiKeys.get(id)
+    return record ? cloneRecord(record) : null
+  },
+  async update(record) {
+    memoryApiKeys.set(record.id, cloneRecord(record))
+    return cloneRecord(record)
+  },
+  async findByIdForUser(id, userId) {
+    const record = memoryApiKeys.get(id)
+    if (!record || record.userId !== userId) {
+      return null
+    }
+    return cloneRecord(record)
+  },
+  async findByHashPrefix(prefix) {
+    return Array.from(memoryApiKeys.values())
+      .filter((record) => getHashPrefix(record.keyHash) === prefix)
+      .map(cloneRecord)
+  },
+  async reset() {
+    memoryApiKeys.clear()
+  },
+})
+
+const createPgRepository = (pool: Pool): ApiKeyRepository => ({
+  async create(record) {
+    await pool.query(
+      `INSERT INTO api_keys (id, user_id, org_id, key_hash, label, scopes, created_at, revoked_at)
+       VALUES ($1, $2, $3, $4, $5, $6::text[], $7::timestamptz, $8::timestamptz)`,
+      [
+        record.id,
+        record.userId,
+        record.orgId,
+        record.keyHash,
+        record.label,
+        record.scopes,
+        record.createdAt,
+        record.revokedAt,
+      ],
+    )
+  },
+  async listForUser(userId) {
+    const result = await pool.query<ApiKeyRow>(
+      `SELECT id, user_id, org_id, key_hash, label, scopes, created_at, revoked_at
+       FROM api_keys
+       WHERE user_id = $1
+       ORDER BY created_at DESC`,
+      [userId],
+    )
+
+    return result.rows.map(toRecord)
+  },
+  async getById(id) {
+    const result = await pool.query<ApiKeyRow>(
+      `SELECT id, user_id, org_id, key_hash, label, scopes, created_at, revoked_at
+       FROM api_keys
+       WHERE id = $1
+       LIMIT 1`,
+      [id],
+    )
+
+    return result.rows[0] ? toRecord(result.rows[0]) : null
+  },
+  async update(record) {
+    const result = await pool.query<ApiKeyRow>(
+      `UPDATE api_keys
+       SET user_id = $2,
+           org_id = $3,
+           key_hash = $4,
+           label = $5,
+           scopes = $6::text[],
+           created_at = $7::timestamptz,
+           revoked_at = $8::timestamptz
+       WHERE id = $1
+       RETURNING id, user_id, org_id, key_hash, label, scopes, created_at, revoked_at`,
+      [
+        record.id,
+        record.userId,
+        record.orgId,
+        record.keyHash,
+        record.label,
+        record.scopes,
+        record.createdAt,
+        record.revokedAt,
+      ],
+    )
+
+    return toRecord(result.rows[0])
+  },
+  async findByIdForUser(id, userId) {
+    const result = await pool.query<ApiKeyRow>(
+      `SELECT id, user_id, org_id, key_hash, label, scopes, created_at, revoked_at
+       FROM api_keys
+       WHERE id = $1 AND user_id = $2
+       LIMIT 1`,
+      [id, userId],
+    )
+
+    return result.rows[0] ? toRecord(result.rows[0]) : null
+  },
+  async findByHashPrefix(prefix) {
+    const result = await pool.query<ApiKeyRow>(
+      `SELECT id, user_id, org_id, key_hash, label, scopes, created_at, revoked_at
+       FROM api_keys
+       WHERE left(key_hash, $1) = $2`,
+      [HASH_PREFIX_LENGTH, prefix],
+    )
+
+    return result.rows.map(toRecord)
+  },
+  async reset() {
+    await pool.query('DELETE FROM api_keys')
+  },
+})
+
+let repositoryOverride: ApiKeyRepository | null = null
+
+const getRepository = (): ApiKeyRepository => {
+  if (repositoryOverride) {
+    return repositoryOverride
+  }
+
+  const pool = getPgPool()
+  return pool ? createPgRepository(pool) : createMemoryRepository()
+}
+
+const createApiKeyRecord = (input: CreateApiKeyInput, secret: string): ApiKeyRecord => ({
+  id: randomUUID(),
+  userId: input.userId ?? null,
+  orgId: input.orgId ?? null,
+  keyHash: hashSecret(secret),
+  label: input.label.trim(),
+  scopes: normalizeScopes(input.scopes),
+  createdAt: utcNow(),
+  revokedAt: null,
+})
+
+const findMatchingRecord = async (apiKey: string): Promise<{ record: ApiKeyRecord; secret: string } | null> => {
+  const parsed = parseApiKey(apiKey)
+  if (!parsed) {
+    return null
+  }
+
+  const secretHash = hashSecret(parsed.secret)
+  const hashPrefix = getHashPrefix(secretHash)
+  const candidates = await getRepository().findByHashPrefix(hashPrefix)
+  const matchingCandidate = candidates.find((candidate) => {
+    if (candidate.id !== parsed.apiKeyId) {
+      return false
+    }
+
+    const left = Buffer.from(candidate.keyHash, 'utf8')
+    const right = Buffer.from(secretHash, 'utf8')
+    return left.length === right.length && timingSafeEqual(left, right)
+  })
+
+  if (!matchingCandidate) {
+    return null
+  }
+
+  return { record: matchingCandidate, secret: parsed.secret }
+}
+
+export const createApiKey = async (
+  input: CreateApiKeyInput,
+): Promise<{ apiKey: string; record: ApiKeyRecord }> => {
+  const secret = randomBytes(32).toString('hex')
+  const record = createApiKeyRecord(input, secret)
+  await getRepository().create(record)
 
   return {
-    apiKey: `dsk_${id}.${secret}`,
-    record,
+    apiKey: buildApiKeyValue(record.id, secret),
+    record: cloneRecord(record),
   }
 }
 
-export const listApiKeysForUser = (userId: string): ApiKeyRecord[] => {
-  return apiKeysTable.filter((record) => record.userId === userId)
+export const listApiKeysForUser = async (userId: string): Promise<ApiKeyRecord[]> => {
+  return getRepository().listForUser(userId)
 }
 
-export const revokeApiKey = (apiKeyId: string, userId: string): ApiKeyRecord | null => {
-  const record = apiKeysTable.find((entry) => entry.id === apiKeyId && entry.userId === userId)
+export const revokeApiKey = async (apiKeyId: string, userId: string): Promise<ApiKeyRecord | null> => {
+  const record = await getRepository().findByIdForUser(apiKeyId, userId)
   if (!record) {
     return null
   }
 
   if (!record.revokedAt) {
     record.revokedAt = utcNow()
+    await getRepository().update(record)
   }
 
-  return record
+  return cloneRecord(record)
 }
 
-export const validateApiKey = (
+export const rotateApiKey = async (
+  input: RotateApiKeyInput,
+): Promise<{ apiKey: string; record: ApiKeyRecord } | null> => {
+  const record = await getRepository().findByIdForUser(input.apiKeyId, input.userId)
+  if (!record || record.revokedAt) {
+    return null
+  }
+
+  const nextSecret = randomBytes(32).toString('hex')
+  record.keyHash = hashSecret(nextSecret)
+  record.createdAt = utcNow()
+  record.revokedAt = null
+
+  const updated = await getRepository().update(record)
+
+  return {
+    apiKey: buildApiKeyValue(updated.id, nextSecret),
+    record: updated,
+  }
+}
+
+export const validateApiKey = async (
   apiKey: string,
   requiredScopes: string[] = [],
-): { valid: true; context: ApiKeyAuthContext } | { valid: false; reason: 'malformed' | 'invalid' | 'revoked' | 'forbidden' } => {
-  const match = /^dsk_([^\.]+)\.(.+)$/.exec(apiKey.trim())
-  if (!match) {
+): Promise<ApiKeyValidationResult> => {
+  const parsed = parseApiKey(apiKey)
+  if (!parsed) {
     return { valid: false, reason: 'malformed' }
   }
 
-  const [, apiKeyId, secret] = match
-  const record = apiKeysTable.find((entry) => entry.id === apiKeyId)
-  if (!record) {
+  const match = await findMatchingRecord(apiKey)
+  if (!match) {
     return { valid: false, reason: 'invalid' }
   }
+
+  const { record } = match
 
   if (record.revokedAt) {
     return { valid: false, reason: 'revoked' }
   }
 
-  if (hashSecret(secret) !== record.keyHash) {
-    return { valid: false, reason: 'invalid' }
-  }
-
-  const missingScope = requiredScopes.find((scope) => !record.scopes.includes(scope))
+  const normalizedRequiredScopes = normalizeScopes(requiredScopes)
+  const missingScope = normalizedRequiredScopes.find((scope) => !record.scopes.includes(scope))
   if (missingScope) {
     return { valid: false, reason: 'forbidden' }
   }
@@ -98,6 +382,12 @@ export const validateApiKey = (
   }
 }
 
-export const resetApiKeysTable = (): void => {
-  apiKeysTable.length = 0
+export const resetApiKeysTable = async (): Promise<void> => {
+  await getRepository().reset()
 }
+
+export const setApiKeyRepositoryForTests = (repository: ApiKeyRepository | null): void => {
+  repositoryOverride = repository
+}
+
+export { redactApiKeyForLogs }


### PR DESCRIPTION
## Summary

- persist API keys securely with hashed secrets and DB-backed lookup support
- add API key rotation and revocation flows while keeping list responses redacted
- enforce scoped `x-api-key` auth with explicit precedence over user auth on API-key protected routes
- redact API keys from rate-limit logging and extend privacy masking
- add route, middleware, and analytics regression tests plus API key docs and curl examples

## Testing

- `node --import tsx --test src/routes/apiKeys.test.ts`
- `node --import tsx --test src/middleware/apiKeyAuth.test.ts`
- `node --import tsx --test src/routes/analytics.milestones.test.ts`

## Notes

- plaintext API keys are only returned at create and rotate time
- old secrets stop working immediately after rotation
- revoked keys remain auditable through stored metadata
- API-key protected routes reject invalid `x-api-key` headers even if a user auth header is also present

## Closes #210 