### PR TITLE
chore: run cargo test for Soroban contracts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,37 @@ jobs:
         run: npm test
         env:
           NODE_ENV: test
+
+  contracts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contracts/accountability_vault/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('contracts/accountability_vault/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-contract
+        run: |
+          cargo install cargo-contract --locked
+          rustup target add wasm32-unknown-unknown
+
+      - name: Build Soroban contract
+        run: cargo contract build --manifest-path contracts/accountability_vault/Cargo.toml --release
+
+      - name: Run Soroban contract tests
+        run: cargo test --manifest-path contracts/accountability_vault/Cargo.toml --verbose

--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -90,6 +90,21 @@ jobs:
       - run: npm run build
 ```
 
+## Soroban contract CI coverage
+
+This repository also runs Soroban contract verification in CI through `.github/workflows/ci.yml`.
+
+The CI workflow now includes a separate `contracts` job that:
+
+- checks out the repository
+- sets up the Rust toolchain
+- caches the Cargo registry and the Soroban contract `target` artifacts
+- installs `cargo-contract`
+- builds `contracts/accountability_vault`
+- runs `cargo test` for `contracts/accountability_vault/src/test.rs`
+
+This keeps on-chain contract code verified alongside the existing Node/TypeScript suite.
+
 ## Rollback strategy
 
 - Immediate rollback path for the last batch:


### PR DESCRIPTION
Adds Soroban contract CI coverage for contracts/accountability_vault and documents it in docs/database-migrations.md.\n\nCloses #343.