### PR TITLE
feat: add vault status and milestone view functions

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -31,12 +31,19 @@ Implements the vault lifecycle that the backend models off-chain in
 | `claim` | When all milestones are verified, release funds to `success_destination`; `Active` -> `Completed`. |
 | `withdraw` | Cancel/refund an unfunded or unstarted vault to the creator; -> `Cancelled`. |
 | `get_vault` | Read-only accessor for the current vault record. |
+| `get_status` | Read-only accessor for the current `VaultStatus`, useful for cheap off-chain reconciliation. |
+| `get_milestone_status` | Read-only accessor for a milestone's `verified` flag and `due_date`; rejects out-of-range indexes. |
 
 The `VaultStatus` enum (`Draft`/`Active`/`Completed`/`Failed`/`Cancelled`)
 mirrors `PersistedVault.status` in `src/types/vaults.ts`. Emitted events
 (`vault_created`, `vault_staked`, `milestone_checked_in`, `vault_slashed`,
 `vault_completed`, `vault_cancelled`, `vault_withdrawn`) align with the topics
 consumed by the backend event parser.
+
+`get_status` and `get_milestone_status(index)` do not require authentication
+and do not mutate storage. They return compact Soroban contract types with
+stable field names so backend callers can decode them with `scValToNative`
+without reconstructing the entire vault from events.
 
 ## Build & test
 

--- a/contracts/accountability_vault/src/lib.rs
+++ b/contracts/accountability_vault/src/lib.rs
@@ -56,6 +56,16 @@ pub struct Milestone {
     pub verified: bool,
 }
 
+/// Lightweight milestone state for off-chain reconciliation.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MilestoneStatus {
+    /// Whether the verifier has confirmed this milestone.
+    pub verified: bool,
+    /// UNIX timestamp (seconds) by which the milestone must be checked in.
+    pub due_date: u64,
+}
+
 /// Full on-chain vault record.
 #[contracttype]
 #[derive(Clone)]
@@ -223,9 +233,10 @@ impl AccountabilityVault {
 
         milestone.verified = true;
         vault.milestones.set(milestone_index, milestone);
-        env.storage()
-            .instance()
-            .set(&DataKey::CheckIn(milestone_index), &env.ledger().timestamp());
+        env.storage().instance().set(
+            &DataKey::CheckIn(milestone_index),
+            &env.ledger().timestamp(),
+        );
         env.storage().instance().set(&DataKey::Vault, &vault);
         env.events().publish(
             (String::from_str(&env, "milestone_checked_in"), verifier),
@@ -353,6 +364,26 @@ impl AccountabilityVault {
     /// Read-only accessor returning the current vault record.
     pub fn get_vault(env: Env) -> Result<Vault, Error> {
         Self::load(&env)
+    }
+
+    /// Read-only accessor returning the current vault lifecycle status.
+    pub fn get_status(env: Env) -> Result<VaultStatus, Error> {
+        let vault = Self::load(&env)?;
+        Ok(vault.status)
+    }
+
+    /// Read-only accessor returning verification and deadline state for one milestone.
+    pub fn get_milestone_status(env: Env, milestone_index: u32) -> Result<MilestoneStatus, Error> {
+        let vault = Self::load(&env)?;
+        if milestone_index >= vault.milestones.len() {
+            return Err(Error::MilestoneIndexOutOfRange);
+        }
+
+        let milestone = vault.milestones.get(milestone_index).unwrap();
+        Ok(MilestoneStatus {
+            verified: milestone.verified,
+            due_date: milestone.due_date,
+        })
     }
 
     // ── internal helpers ────────────────────────────────────────────────

--- a/contracts/accountability_vault/src/test.rs
+++ b/contracts/accountability_vault/src/test.rs
@@ -81,14 +81,58 @@ fn test_create_and_stake() {
     let s = setup(&[100], &[500]);
     let vault = s.contract.get_vault();
     assert_eq!(vault.status, VaultStatus::Draft);
+    assert_eq!(s.contract.get_status(), VaultStatus::Draft);
 
     s.contract.stake(&s.creator);
     let vault = s.contract.get_vault();
     assert_eq!(vault.status, VaultStatus::Active);
+    assert_eq!(s.contract.get_status(), VaultStatus::Active);
     assert_eq!(vault.staked, 500);
 
     let token_client = token::Client::new(&s.env, &s.token);
     assert_eq!(token_client.balance(&s.creator), 0);
+}
+
+#[test]
+fn test_get_milestone_status_returns_read_friendly_state() {
+    let s = setup(&[100, 200], &[300, 700]);
+
+    let first = s.contract.get_milestone_status(&0);
+    assert_eq!(
+        first,
+        MilestoneStatus {
+            verified: false,
+            due_date: 1_100,
+        }
+    );
+
+    s.contract.stake(&s.creator);
+    s.contract.check_in(&s.verifier, &0);
+
+    let first = s.contract.get_milestone_status(&0);
+    assert_eq!(
+        first,
+        MilestoneStatus {
+            verified: true,
+            due_date: 1_100,
+        }
+    );
+
+    let second = s.contract.get_milestone_status(&1);
+    assert_eq!(
+        second,
+        MilestoneStatus {
+            verified: false,
+            due_date: 1_200,
+        }
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_get_milestone_status_rejects_out_of_range_index() {
+    let s = setup(&[100], &[500]);
+    s.contract.get_milestone_status(&1);
 }
 
 #[test]
@@ -102,6 +146,7 @@ fn test_check_in_and_claim_success() {
     s.contract.claim(&s.creator);
     let vault = s.contract.get_vault();
     assert_eq!(vault.status, VaultStatus::Completed);
+    assert_eq!(s.contract.get_status(), VaultStatus::Completed);
 
     let token_client = token::Client::new(&s.env, &s.token);
     assert_eq!(token_client.balance(&s.success), 1000);


### PR DESCRIPTION
Closes #360

---

## Summary

Adds lightweight read-only view functions to `accountability_vault` so the backend can reconcile off-chain vault state without reconstructing everything from events or fetching the full vault record.

## Changes

- Added `get_status()` to return the current `VaultStatus`
- Added `get_milestone_status(index)` to return compact milestone read state:
  - `verified`
  - `due_date`
- Added `MilestoneStatus` contract type for `scValToNative`-friendly named fields
- Added index bounds checking for milestone reads using `MilestoneIndexOutOfRange`
- Added read-path tests for:
  - vault status reads
  - milestone status before and after check-in
  - out-of-range milestone index
- Documented the new views in `contracts/README.md`

## Security

Both new functions are read-only:
- no `require_auth`
- no token transfers
- no storage mutation
- use existing vault loading path
- validate milestone index before reading

## Tests

Ran from `contracts/`:

```bash
cargo fmt --check
cargo test


Result:
cargo fmt --check: passed
running 8 tests
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
