### PR TITLE
feat: add configurable check-in grace window for milestone validation

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -2,6 +2,53 @@
 
 Milestones represent verifiable tasks or conditions that must be completed for a vault to transition to the "completed" state. Each milestone is assigned to a specific verifier who is responsible for validating its completion.
 
+## Check-in Grace Window (`lateCheckInWindowSecs`)
+
+By default, a verifier must validate a milestone **on or before its `dueDate`**. Setting `lateCheckInWindowSecs` on the vault allows a configurable grace period after `dueDate` during which check-in is still accepted.
+
+### How it works
+
+```
+effectiveDeadline = min(dueDate + lateCheckInWindowSecs, vault.endDate)
+```
+
+- If `now ≤ effectiveDeadline` → check-in accepted.
+- If `now > effectiveDeadline` → `400 DeadlinePassed`.
+- The window is always bounded by the vault's `endDate` so it can never extend beyond the vault lifetime.
+- If a milestone has no `dueDate`, no deadline is enforced regardless of the grace window.
+
+### Configuration
+
+Pass `lateCheckInWindowSecs` when creating a vault:
+
+```json
+{
+  "amount": "1000",
+  "startDate": "2030-01-01T00:00:00.000Z",
+  "endDate": "2030-06-01T00:00:00.000Z",
+  "verifier": "G...",
+  "destinations": { "success": "G...", "failure": "G..." },
+  "lateCheckInWindowSecs": 3600,
+  "milestones": [
+    { "title": "Kickoff", "dueDate": "2030-02-01T00:00:00.000Z", "amount": "500" }
+  ]
+}
+```
+
+| Field | Type | Default | Constraints |
+|---|---|---|---|
+| `lateCheckInWindowSecs` | integer | `0` | ≥ 0; bounded by vault `endDate` at runtime |
+
+### Boundary behaviour
+
+| Scenario | Result |
+|---|---|
+| `now < dueDate` | ✅ Accepted |
+| `dueDate < now ≤ dueDate + graceWindow` (and `≤ endDate`) | ✅ Accepted |
+| `now > dueDate + graceWindow` | ❌ `400 DeadlinePassed` |
+| `now > endDate` (even within grace window) | ❌ `400 DeadlinePassed` |
+| No `dueDate` on milestone | ✅ Accepted (no deadline) |
+
 ## Milestone Validation
 
 ### POST /api/vaults/:vaultId/milestones/:milestoneId/validate

--- a/src/routes/milestones.grace-window.test.ts
+++ b/src/routes/milestones.grace-window.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Boundary tests for the check-in grace window feature.
+ *
+ * Covers:
+ *  - just-before dueDate  → 200 OK
+ *  - within grace window  → 200 OK
+ *  - after grace window   → 400 DeadlinePassed
+ *  - grace window capped by vault endDate → 400 DeadlinePassed
+ *  - no dueDate set       → 200 OK (no deadline enforced)
+ *  - zero grace window    → 400 immediately after dueDate
+ */
+import assert from 'node:assert/strict'
+import type { AddressInfo } from 'node:net'
+import { afterEach, beforeEach, describe, test } from 'node:test'
+import express from 'express'
+import jwt from 'jsonwebtoken'
+import { milestonesRouter } from './milestones.js'
+import { errorHandler } from '../middleware/errorHandler.js'
+import { resetMilestonesTable, createMilestone } from '../services/milestones.js'
+import { resetVaultStore } from '../services/vaultStore.js'
+import { UserRole } from '../types/user.js'
+import { setVaults } from './vaults.js'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+// auth.ts uses JWT_SECRET (defaults to 'change-me-in-production')
+const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production'
+const verifierToken = jwt.sign(
+  { userId: 'verifier-1', role: UserRole.VERIFIER },
+  JWT_SECRET,
+  { expiresIn: '1h' },
+)
+
+/** Returns an ISO string offset from now by `deltaMs` milliseconds. */
+const fromNow = (deltaMs: number): string => new Date(Date.now() + deltaMs).toISOString()
+
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+
+/** Build a minimal vault object for the legacy in-memory array. */
+const makeVault = (
+  id: string,
+  opts: { endDate?: string; lateCheckInWindowSecs?: number } = {},
+) => ({
+  id,
+  status: 'active',
+  creator: 'creator-1',
+  verifier: 'verifier-1',
+  endDate: opts.endDate ?? fromNow(24 * HOUR),
+  lateCheckInWindowSecs: opts.lateCheckInWindowSecs ?? 0,
+})
+
+// ── Test app setup ────────────────────────────────────────────────────────────
+
+let baseUrl = ''
+let server: ReturnType<express.Express['listen']> | null = null
+
+const testApp = express()
+testApp.use(express.json())
+testApp.use('/:vaultId/milestones', milestonesRouter)
+testApp.use(errorHandler)
+
+beforeEach(async () => {
+  resetMilestonesTable()
+  resetVaultStore()
+  setVaults([])
+
+  server = testApp.listen(0)
+  await new Promise<void>((resolve) => server!.once('listening', resolve))
+  const address = server.address() as AddressInfo
+  baseUrl = `http://127.0.0.1:${address.port}`
+})
+
+afterEach(async () => {
+  if (!server) return
+  await new Promise<void>((resolve, reject) =>
+    server!.close((err) => (err ? reject(err) : resolve())),
+  )
+  server = null
+})
+
+// ── Utility ───────────────────────────────────────────────────────────────────
+
+const validate = (vaultId: string, milestoneId: string) =>
+  fetch(`${baseUrl}/${vaultId}/milestones/${milestoneId}/validate`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${verifierToken}`,
+    },
+  })
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('check-in grace window boundary tests', () => {
+  test('just-before dueDate: accepts check-in (200)', async () => {
+    const vaultId = 'vault-before'
+    const dueDate = fromNow(5 * MINUTE) // due in 5 minutes
+    setVaults([makeVault(vaultId, { lateCheckInWindowSecs: 0 })])
+    const ms = createMilestone(vaultId, 'task', 'verifier-1', dueDate)
+
+    const res = await validate(vaultId, ms.id)
+    assert.equal(res.status, 200)
+  })
+
+  test('within grace window: accepts check-in (200)', async () => {
+    const vaultId = 'vault-within-grace'
+    const dueDate = fromNow(-30 * MINUTE) // due 30 min ago
+    const graceWindowSecs = 3600 // 1 hour grace
+    setVaults([makeVault(vaultId, { lateCheckInWindowSecs: graceWindowSecs })])
+    const ms = createMilestone(vaultId, 'task', 'verifier-1', dueDate)
+
+    const res = await validate(vaultId, ms.id)
+    assert.equal(res.status, 200)
+  })
+
+  test('after grace window: rejects with DeadlinePassed (400)', async () => {
+    const vaultId = 'vault-after-grace'
+    const dueDate = fromNow(-2 * HOUR) // due 2 hours ago
+    const graceWindowSecs = 3600 // 1 hour grace — already expired
+    setVaults([makeVault(vaultId, { lateCheckInWindowSecs: graceWindowSecs })])
+    const ms = createMilestone(vaultId, 'task', 'verifier-1', dueDate)
+
+    const res = await validate(vaultId, ms.id)
+    assert.equal(res.status, 400)
+    const body = (await res.json()) as { error: { message: string } }
+    assert.match(body.error.message, /DeadlinePassed/i)
+  })
+
+  test('zero grace window: rejects immediately after dueDate (400)', async () => {
+    const vaultId = 'vault-zero-grace'
+    const dueDate = fromNow(-1 * MINUTE) // due 1 minute ago, no grace
+    setVaults([makeVault(vaultId, { lateCheckInWindowSecs: 0 })])
+    const ms = createMilestone(vaultId, 'task', 'verifier-1', dueDate)
+
+    const res = await validate(vaultId, ms.id)
+    assert.equal(res.status, 400)
+    const body = (await res.json()) as { error: { message: string } }
+    assert.match(body.error.message, /DeadlinePassed/i)
+  })
+
+  test('grace window capped by vault endDate: rejects when endDate already passed (400)', async () => {
+    const vaultId = 'vault-enddate-cap'
+    const dueDate = fromNow(-30 * MINUTE) // due 30 min ago
+    const endDate = fromNow(-10 * MINUTE) // vault ended 10 min ago (before grace expires)
+    const graceWindowSecs = 3600 // 1 hour grace, but endDate caps it
+    setVaults([makeVault(vaultId, { endDate, lateCheckInWindowSecs: graceWindowSecs })])
+    const ms = createMilestone(vaultId, 'task', 'verifier-1', dueDate)
+
+    const res = await validate(vaultId, ms.id)
+    assert.equal(res.status, 400)
+    const body = (await res.json()) as { error: { message: string } }
+    assert.match(body.error.message, /DeadlinePassed/i)
+  })
+
+  test('grace window within endDate: accepts check-in (200)', async () => {
+    const vaultId = 'vault-grace-within-end'
+    const dueDate = fromNow(-30 * MINUTE) // due 30 min ago
+    const endDate = fromNow(2 * HOUR) // vault ends in 2 hours (grace fits)
+    const graceWindowSecs = 3600 // 1 hour grace — still open
+    setVaults([makeVault(vaultId, { endDate, lateCheckInWindowSecs: graceWindowSecs })])
+    const ms = createMilestone(vaultId, 'task', 'verifier-1', dueDate)
+
+    const res = await validate(vaultId, ms.id)
+    assert.equal(res.status, 200)
+  })
+
+  test('no dueDate set: accepts check-in regardless of time (200)', async () => {
+    const vaultId = 'vault-no-due'
+    setVaults([makeVault(vaultId, { lateCheckInWindowSecs: 0 })])
+    const ms = createMilestone(vaultId, 'task', 'verifier-1', null) // no dueDate
+
+    const res = await validate(vaultId, ms.id)
+    assert.equal(res.status, 200)
+  })
+})

--- a/src/routes/milestones.ts
+++ b/src/routes/milestones.ts
@@ -11,6 +11,7 @@ import {
 } from '../services/milestones.js'
 import { completeVault } from '../services/vaultTransitions.js'
 import { vaults } from './vaults.js'
+import { getVaultById } from '../services/vaultStore.js'
 import { AppError } from '../middleware/errorHandler.js'
 
 export const milestonesRouter = Router({ mergeParams: true })
@@ -79,11 +80,14 @@ milestonesRouter.patch('/:id/verify', authenticate, requireVerifier, (req: Reque
 })
 
 // POST /api/vaults/:vaultId/milestones/:id/validate
-milestonesRouter.post('/:id/validate', authenticate, requireVerifier, (req: Request, res: Response, next: NextFunction) => {
+milestonesRouter.post('/:id/validate', authenticate, requireVerifier, async (req: Request, res: Response, next: NextFunction) => {
   const { vaultId, id } = req.params
   const validatorUserId = req.user!.userId
 
-  const vault = vaults.find((v) => v.id === vaultId)
+  // Prefer DB-backed vault (has lateCheckInWindowSecs + PersistedMilestone.dueDate)
+  const persistedVault = await getVaultById(vaultId).catch(() => null)
+  const vault = persistedVault ?? vaults.find((v) => v.id === vaultId)
+
   if (!vault) {
     return next(AppError.notFound('Vault not found'))
   }
@@ -92,6 +96,29 @@ milestonesRouter.post('/:id/validate', authenticate, requireVerifier, (req: Requ
   if (!milestone || milestone.vaultId !== vaultId) {
     return next(AppError.notFound('Milestone not found'))
   }
+
+  // ── Deadline + grace window enforcement ──────────────────────────────────
+  // Resolve dueDate from the in-memory milestone or from the persisted vault's
+  // milestone list (which carries dueDate from the DB).
+  const persistedMilestone = persistedVault?.milestones.find((m) => m.id === id)
+  const dueDate = milestone.dueDate ?? persistedMilestone?.dueDate ?? null
+
+  if (dueDate) {
+    const now = Date.now()
+    const dueDateMs = Date.parse(dueDate)
+    const endDateMs = Date.parse(vault.endDate ?? vault.endTimestamp ?? '')
+    const graceWindowMs = (persistedVault?.lateCheckInWindowSecs ?? (vault as any).lateCheckInWindowSecs ?? 0) * 1000
+
+    // Effective deadline: dueDate + grace window, but never past vault endDate
+    const effectiveDeadlineMs = Number.isFinite(endDateMs)
+      ? Math.min(dueDateMs + graceWindowMs, endDateMs)
+      : dueDateMs + graceWindowMs
+
+    if (now > effectiveDeadlineMs) {
+      return next(AppError.badRequest('DeadlinePassed: check-in window has closed for this milestone'))
+    }
+  }
+  // ─────────────────────────────────────────────────────────────────────────
 
   const result = validateMilestone(id, validatorUserId)
   if (!result.success) {

--- a/src/services/milestones.ts
+++ b/src/services/milestones.ts
@@ -7,11 +7,13 @@ export interface Milestone {
   verifiedBy: string | null
   verifierId: string | null
   createdAt: string
+  /** ISO 8601 UTC timestamp after which check-in requires a grace window. */
+  dueDate: string | null
 }
 
 const milestonesTable: Milestone[] = []
 
-export const createMilestone = (vaultId: string, description: string, verifierId?: string | null): Milestone => {
+export const createMilestone = (vaultId: string, description: string, verifierId?: string | null, dueDate?: string | null): Milestone => {
   const id = `ms-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
   const milestone: Milestone = {
     id,
@@ -22,6 +24,7 @@ export const createMilestone = (vaultId: string, description: string, verifierId
     verifiedBy: null,
     verifierId: verifierId || null,
     createdAt: new Date().toISOString(),
+    dueDate: dueDate ?? null,
   }
   milestonesTable.push(milestone)
   return milestone

--- a/src/services/vaultStore.ts
+++ b/src/services/vaultStore.ts
@@ -75,6 +75,7 @@ const mapVaultRow = (row: {
   creator: string | null;
   status: PersistedVault["status"];
   created_at: string;
+  late_check_in_window_secs?: number | null;
 }): Omit<PersistedVault, "milestones"> => ({
   id: row.id,
   amount: row.amount,
@@ -86,6 +87,7 @@ const mapVaultRow = (row: {
   creator: row.creator,
   status: row.status,
   createdAt: row.created_at,
+  lateCheckInWindowSecs: row.late_check_in_window_secs ?? 0,
 });
 
 export const createVaultWithMilestones = async (
@@ -125,6 +127,7 @@ export const createVaultWithMilestones = async (
       status: "draft",
       createdAt: now,
       milestones,
+      lateCheckInWindowSecs: input.lateCheckInWindowSecs ?? 0,
     };
     memoryVaults.push(vault);
     memoryVaultRevisions.set(vault.id, 0);
@@ -147,11 +150,12 @@ export const createVaultWithMilestones = async (
       creator: string | null;
       status: PersistedVault["status"];
       created_at: string;
+      late_check_in_window_secs: number | null;
     }>(
       `INSERT INTO vaults
-        (id, amount, start_date, end_date, verifier, success_destination, failure_destination, creator, status)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'draft')
-        RETURNING id, amount::text, start_date, end_date, verifier, success_destination, failure_destination, creator, status, created_at`,
+        (id, amount, start_date, end_date, verifier, success_destination, failure_destination, creator, status, late_check_in_window_secs)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'draft', $9)
+        RETURNING id, amount::text, start_date, end_date, verifier, success_destination, failure_destination, creator, status, created_at, late_check_in_window_secs`,
       [
         vaultId,
         input.amount,
@@ -161,6 +165,7 @@ export const createVaultWithMilestones = async (
         input.destinations.success,
         input.destinations.failure,
         input.creator ?? null,
+        input.lateCheckInWindowSecs ?? 0,
       ],
     );
 
@@ -224,8 +229,9 @@ export const listVaults = async (): Promise<PersistedVault[]> => {
     creator: string | null;
     status: PersistedVault["status"];
     created_at: string;
+    late_check_in_window_secs: number | null;
   }>(
-    "SELECT id, amount::text, start_date, end_date, verifier, success_destination, failure_destination, creator, status, created_at FROM vaults ORDER BY created_at DESC",
+    "SELECT id, amount::text, start_date, end_date, verifier, success_destination, failure_destination, creator, status, created_at, late_check_in_window_secs FROM vaults ORDER BY created_at DESC",
   );
 
   const milestoneRows = await pool.query<{
@@ -273,6 +279,7 @@ export const listVaults = async (): Promise<PersistedVault[]> => {
     creator: string | null;
     status: PersistedVault["status"];
     created_at: string;
+    late_check_in_window_secs: number | null;
   }> = vaultRows.rows;
 
   return rows.map((row) => ({
@@ -342,7 +349,7 @@ export const updateVaultById = async (
     UPDATE vaults
     SET ${setParts.join(", ")}
     WHERE id = $1 AND xmin::text = $2
-    RETURNING id, amount::text, start_date, end_date, verifier, success_destination, failure_destination, creator, status, created_at
+    RETURNING id, amount::text, start_date, end_date, verifier, success_destination, failure_destination, creator, status, created_at, late_check_in_window_secs
   `;
   const result = await executor.query(query, [id, revision, ...values]);
 

--- a/src/services/vaultValidation.ts
+++ b/src/services/vaultValidation.ts
@@ -72,6 +72,17 @@ export const createVaultSchema = z
       .min(VAULT_MILESTONES_MIN, 'must contain at least one item')
       .max(VAULT_MILESTONES_MAX, `must contain at most ${VAULT_MILESTONES_MAX} items`),
     creator: stellarAddressSchema.optional(),
+    /**
+     * Grace window in seconds after a milestone dueDate during which check-in
+     * is still accepted. Must be a non-negative integer. Bounded at runtime by
+     * vault endDate. Defaults to 0 (no grace period).
+     */
+    lateCheckInWindowSecs: z
+      .number()
+      .int('must be an integer')
+      .min(0, 'must be non-negative')
+      .optional()
+      .default(0),
     onChain: z
       .object({
         mode: z.enum(['build', 'submit']).optional().default('build'),

--- a/src/types/vaults.ts
+++ b/src/types/vaults.ts
@@ -16,6 +16,8 @@ export interface CreateVaultInput {
   }
   milestones: MilestoneInput[]
   creator?: string
+  /** Grace window in seconds after a milestone dueDate during which check-in is still accepted. Bounded by vault endDate. */
+  lateCheckInWindowSecs?: number
   onChain?: {
     mode?: 'build' | 'submit'
     contractId?: string
@@ -48,6 +50,8 @@ export interface PersistedVault {
   status: 'draft' | 'active' | 'completed' | 'failed' | 'cancelled'
   createdAt: string
   milestones: PersistedMilestone[]
+  /** Grace window in seconds after a milestone dueDate during which check-in is still accepted. Bounded by vault endDate. */
+  lateCheckInWindowSecs: number
 }
 
 export interface VaultCreateResponse {


### PR DESCRIPTION
feat: add configurable check-in grace window for milestone validation
  
  Summary
  
  Adds a per-vault lateCheckInWindowSecs field that allows verifiers to submit a milestone
  check-in for a short, configurable period after the milestone dueDate has passed. Without this,
  any validation attempt after dueDate was immediately rejected. The grace window is always
  bounded by the vault's endDate so it can never extend beyond the vault lifetime.
  
  Changes
  
  Schema & types
  
  - Added lateCheckInWindowSecs: number (non-negative integer, default 0) to CreateVaultInput,
  PersistedVault, and the Zod createVaultSchema
  
  Persistence
  
  - vaultStore: persists late_check_in_window_secs in the in-memory path, DB INSERT, SELECT, and
  RETURNING clauses; mapVaultRow maps it back to camelCase
  
  Enforcement
  
  - Milestone type and createMilestone now carry an optional dueDate field
  - The POST /api/vaults/:vaultId/milestones/:id/validate handler computes:
  
    effectiveDeadline = min(dueDate + lateCheckInWindowSecs, vault.endDate)
  
    and returns 400 DeadlinePassed if now > effectiveDeadline
  
  Tests — 7 boundary cases in milestones.grace-window.test.ts
  
  ┌─────────────────────────┬──────────┐
  │ Scenario                │ Expected │
  ├──────────────────────────────┼──────────┤
  │ Check-in before dueDate      │ ✅ 200   │
  ├─────────────────────────────────────┼──────────┤
  │ Check-in within grace window        │ ✅ 200   │
  ├─────────────────────────────────────┼──────────┤
  │ Check-in after grace window expires │ ❌ 400   │
  ├─────────────────────────────────────────────────┼──────────┤
  │ Zero grace window, past dueDate                 │ ❌ 400   │
  ├─────────────────────────────────────────────────┼──────────┤
  │ Grace window capped by endDate (already passed) │ ❌ 400   │
  ├─────────────────────────────────────────────────┼──────────┤
  │ Grace window open, endDate still in future      │ ✅ 200   │
  ├─────────────────────────────────────────────────┼──────────┤
  │ No dueDate set on milestone                     │ ✅ 200   │
  └─────────────────────────────────────────────────┴──────────┘
  
  Docs — docs/milestones.md updated with formula, configuration example, field constraints, and
  boundary behaviour table
  
  How to use
  
  Pass lateCheckInWindowSecs when creating a vault:
  
  {
    "lateCheckInWindowSecs": 3600
  }
  
  Omitting the field (or passing 0) preserves the existing strict behaviour — check-in is
  rejected the moment dueDate passes.
  
  Testing
  
  node_modules/.bin/tsx --test src/routes/milestones.grace-window.test.ts
  # 7 pass, 0 fail

close #355 