### PR TITLE
docs: add jobs/transactions/analytics/admin to OpenAPI spec

### DIFF
--- a/src/docs/openapi-generator.ts
+++ b/src/docs/openapi-generator.ts
@@ -233,6 +233,591 @@ registry.registerPath({
   },
 })
 
+// ==================== JOBS ROUTES ====================
+
+// GET /api/jobs/metrics
+registry.registerPath({
+  method: 'get',
+  path: '/api/jobs/metrics',
+  summary: 'Get queue metrics',
+  tags: ['Jobs'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: 'Queue metrics',
+      content: {
+        'application/json': {
+          schema: z.object({
+            running: z.boolean(),
+            queueDepth: z.number(),
+            delayedJobs: z.number(),
+            activeJobs: z.number(),
+            totals: z.object({
+              executions: z.number(),
+              failed: z.number(),
+            }),
+          }),
+        },
+      },
+    },
+  },
+})
+
+// GET /api/jobs/deadletters
+registry.registerPath({
+  method: 'get',
+  path: '/api/jobs/deadletters',
+  summary: 'List dead-letter jobs',
+  tags: ['Jobs'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: 'List of dead-letter jobs',
+      content: {
+        'application/json': {
+          schema: z.object({
+            deadLetters: z.array(z.any()),
+          }),
+        },
+      },
+    },
+  },
+})
+
+// GET /api/jobs/deadletters/:id
+registry.registerPath({
+  method: 'get',
+  path: '/api/jobs/deadletters/{id}',
+  summary: 'Get a dead-letter job by ID',
+  tags: ['Jobs'],
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  responses: {
+    200: { description: 'Dead-letter job details' },
+    404: { description: 'Job not found' },
+  },
+})
+
+// POST /api/jobs/deadletters/:id/replay
+registry.registerPath({
+  method: 'post',
+  path: '/api/jobs/deadletters/{id}/replay',
+  summary: 'Replay a dead-letter job',
+  tags: ['Jobs'],
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  responses: {
+    202: { description: 'Job replayed' },
+    404: { description: 'Job not found' },
+  },
+})
+
+// GET /api/jobs/health
+registry.registerPath({
+  method: 'get',
+  path: '/api/jobs/health',
+  summary: 'Get queue health status',
+  tags: ['Jobs'],
+  responses: {
+    200: {
+      description: 'Queue health',
+      content: {
+        'application/json': {
+          schema: z.object({
+            status: z.enum(['ok', 'degraded', 'down']),
+            timestamp: z.string().datetime(),
+            queue: z.object({
+              running: z.boolean(),
+              queueDepth: z.number(),
+              delayedJobs: z.number(),
+              activeJobs: z.number(),
+              failureRate: z.number(),
+            }),
+          }),
+        },
+      },
+    },
+  },
+})
+
+// ==================== TRANSACTIONS ROUTES ====================
+
+// GET /api/transactions
+registry.registerPath({
+  method: 'get',
+  path: '/api/transactions',
+  summary: 'Get user transaction history',
+  tags: ['Transactions'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    { name: 'type', in: 'query', schema: { type: 'string' } },
+    { name: 'vault_id', in: 'query', schema: { type: 'string' } },
+    { name: 'date_from', in: 'query', schema: { type: 'string', format: 'date' } },
+    { name: 'date_to', in: 'query', schema: { type: 'string', format: 'date' } },
+    { name: 'amount_min', in: 'query', schema: { type: 'string' } },
+    { name: 'amount_max', in: 'query', schema: { type: 'string' } },
+    { name: 'limit', in: 'query', schema: { type: 'integer', default: 20 } },
+    { name: 'cursor', in: 'query', schema: { type: 'string' } },
+  ],
+  responses: {
+    200: {
+      description: 'Transaction list',
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.array(z.any()),
+            pagination: z.object({
+              limit: z.number(),
+              cursor: z.string().optional(),
+              next_cursor: z.string().optional(),
+              has_more: z.boolean(),
+              count: z.number(),
+            }),
+          }),
+        },
+      },
+    },
+  },
+})
+
+// GET /api/transactions/:id
+registry.registerPath({
+  method: 'get',
+  path: '/api/transactions/{id}',
+  summary: 'Get transaction by ID',
+  tags: ['Transactions'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  responses: {
+    200: { description: 'Transaction details' },
+    404: { description: 'Transaction not found' },
+  },
+})
+
+// GET /api/transactions/vault/:vaultId
+registry.registerPath({
+  method: 'get',
+  path: '/api/transactions/vault/{vaultId}',
+  summary: 'Get transactions for a vault',
+  tags: ['Transactions'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    {
+      name: 'vaultId',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  responses: {
+    200: { description: 'Vault transactions' },
+    404: { description: 'Vault not found' },
+  },
+})
+
+// ==================== ANALYTICS ROUTES (Missing) ====================
+
+// GET /api/analytics/vaults
+registry.registerPath({
+  method: 'get',
+  path: '/api/analytics/vaults',
+  summary: 'Get vault analytics',
+  tags: ['Analytics'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: 'Vault analytics',
+      content: {
+        'application/json': {
+          schema: z.object({
+            vaults: z.array(z.any()),
+            generatedAt: z.string().datetime(),
+          }),
+        },
+      },
+    },
+  },
+})
+
+// GET /api/analytics/vaults/:id
+registry.registerPath({
+  method: 'get',
+  path: '/api/analytics/vaults/{id}',
+  summary: 'Get vault analytics by ID',
+  tags: ['Analytics'],
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  responses: {
+    200: { description: 'Vault analytics' },
+  },
+})
+
+// GET /api/analytics/milestones/trends
+registry.registerPath({
+  method: 'get',
+  path: '/api/analytics/milestones/trends',
+  summary: 'Get milestone trends',
+  tags: ['Analytics'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    { name: 'from', in: 'query', required: true, schema: { type: 'string', format: 'date-time' } },
+    { name: 'to', in: 'query', required: true, schema: { type: 'string', format: 'date-time' } },
+    { name: 'groupBy', in: 'query', schema: { type: 'string', enum: ['day', 'week'] } },
+  ],
+  responses: {
+    200: {
+      description: 'Milestone trends',
+      content: {
+        'application/json': {
+          schema: z.object({
+            from: z.string().datetime(),
+            to: z.string().datetime(),
+            groupBy: z.enum(['day', 'week']),
+            buckets: z.array(z.any()),
+          }),
+        },
+      },
+    },
+  },
+})
+
+// GET /api/analytics/behavior
+registry.registerPath({
+  method: 'get',
+  path: '/api/analytics/behavior',
+  summary: 'Get user behavior analytics',
+  tags: ['Analytics'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    { name: 'userId', in: 'query', required: true, schema: { type: 'string' } },
+    { name: 'baseScorePerSuccess', in: 'query', schema: { type: 'integer', default: 10 } },
+    { name: 'penaltyPerFailure', in: 'query', schema: { type: 'integer', default: 5 } },
+    { name: 'from', in: 'query', schema: { type: 'string', format: 'date-time' } },
+    { name: 'to', in: 'query', schema: { type: 'string', format: 'date-time' } },
+  ],
+  responses: {
+    200: {
+      description: 'User behavior score',
+      content: {
+        'application/json': {
+          schema: z.object({
+            userId: z.string(),
+            successes: z.number(),
+            failures: z.number(),
+            behaviorScore: z.number(),
+            evaluatedFrom: z.string().datetime().nullable(),
+            evaluatedTo: z.string().datetime().nullable(),
+          }),
+        },
+      },
+    },
+  },
+})
+
+// ==================== ADMIN ROUTES ====================
+
+// GET /api/admin/users
+registry.registerPath({
+  method: 'get',
+  path: '/api/admin/users',
+  summary: 'List all users (admin)',
+  tags: ['Admin'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    { name: 'role', in: 'query', schema: { type: 'string', enum: ['USER', 'VERIFIER', 'ADMIN'] } },
+    { name: 'status', in: 'query', schema: { type: 'string', enum: ['ACTIVE', 'INACTIVE', 'SUSPENDED'] } },
+    { name: 'search', in: 'query', schema: { type: 'string' } },
+    { name: 'limit', in: 'query', schema: { type: 'integer', default: 20 } },
+    { name: 'offset', in: 'query', schema: { type: 'integer', default: 0 } },
+    { name: 'includeDeleted', in: 'query', schema: { type: 'boolean', default: false } },
+  ],
+  responses: {
+    200: { description: 'List of users' },
+  },
+})
+
+// PATCH /api/admin/users/:id/role
+registry.registerPath({
+  method: 'patch',
+  path: '/api/admin/users/{id}/role',
+  summary: 'Update user role',
+  tags: ['Admin'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  requestBody: {
+    content: {
+      'application/json': {
+        schema: z.object({
+          role: z.enum(['USER', 'VERIFIER', 'ADMIN']),
+        }),
+      },
+    },
+  },
+  responses: {
+    200: { description: 'Role updated' },
+    400: { description: 'Invalid role' },
+    404: { description: 'User not found' },
+  },
+})
+
+// PATCH /api/admin/users/:id/status
+registry.registerPath({
+  method: 'patch',
+  path: '/api/admin/users/{id}/status',
+  summary: 'Update user status',
+  tags: ['Admin'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  requestBody: {
+    content: {
+      'application/json': {
+        schema: z.object({
+          status: z.enum(['ACTIVE', 'INACTIVE', 'SUSPENDED']),
+        }),
+      },
+    },
+  },
+  responses: {
+    200: { description: 'Status updated' },
+    404: { description: 'User not found' },
+  },
+})
+
+// DELETE /api/admin/users/:id
+registry.registerPath({
+  method: 'delete',
+  path: '/api/admin/users/{id}',
+  summary: 'Delete user (soft or hard)',
+  tags: ['Admin'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+    { name: 'hard', in: 'query', schema: { type: 'boolean', default: false } },
+  ],
+  responses: {
+    200: { description: 'User deleted' },
+    400: { description: 'Cannot delete own account' },
+    404: { description: 'User not found' },
+  },
+})
+
+// POST /api/admin/users/:id/restore
+registry.registerPath({
+  method: 'post',
+  path: '/api/admin/users/{id}/restore',
+  summary: 'Restore a soft-deleted user',
+  tags: ['Admin'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  responses: {
+    200: { description: 'User restored' },
+    400: { description: 'User not deleted' },
+    404: { description: 'User not found' },
+  },
+})
+
+// POST /api/admin/users/:userId/revoke-sessions
+registry.registerPath({
+  method: 'post',
+  path: '/api/admin/users/{userId}/revoke-sessions',
+  summary: 'Revoke all user sessions',
+  tags: ['Admin'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    {
+      name: 'userId',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  responses: {
+    200: { description: 'Sessions revoked' },
+  },
+})
+
+// GET /api/admin/audit-logs
+registry.registerPath({
+  method: 'get',
+  path: '/api/admin/audit-logs',
+  summary: 'List audit logs',
+  tags: ['Admin'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    { name: 'actor_user_id', in: 'query', schema: { type: 'string' } },
+    { name: 'action', in: 'query', schema: { type: 'string' } },
+    { name: 'target_type', in: 'query', schema: { type: 'string' } },
+    { name: 'target_id', in: 'query', schema: { type: 'string' } },
+    { name: 'limit', in: 'query', schema: { type: 'integer', default: 50 } },
+    { name: 'offset', in: 'query', schema: { type: 'integer', default: 0 } },
+  ],
+  responses: {
+    200: {
+      description: 'Audit logs',
+      content: {
+        'application/json': {
+          schema: z.object({
+            audit_logs: z.array(z.any()),
+            count: z.number(),
+            total: z.number(),
+            limit: z.number().optional(),
+            offset: z.number(),
+            has_more: z.boolean(),
+          }),
+        },
+      },
+    },
+  },
+})
+
+// GET /api/admin/audit-logs/:id
+registry.registerPath({
+  method: 'get',
+  path: '/api/admin/audit-logs/{id}',
+  summary: 'Get audit log by ID',
+  tags: ['Admin'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  responses: {
+    200: { description: 'Audit log details' },
+    404: { description: 'Not found' },
+  },
+})
+
+// POST /api/admin/overrides/vaults/:id/cancel
+registry.registerPath({
+  method: 'post',
+  path: '/api/admin/overrides/vaults/{id}/cancel',
+  summary: 'Admin override to cancel a vault',
+  tags: ['Admin'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  requestBody: {
+    content: {
+      'application/json': {
+        schema: z.object({
+          reasonCode: z.enum([
+            'USER_REQUEST',
+            'FRAUD_DETECTED',
+            'SYSTEM_ERROR',
+            'POLICY_VIOLATION',
+            'EMERGENCY_ADMIN_ACTION',
+            'COMPLIANCE_REQUIREMENT',
+            'TESTING_CLEANUP',
+          ]),
+          reason: z.string().optional(),
+          idempotencyKey: z.string().optional(),
+          details: z.string().optional(),
+        }),
+      },
+    },
+  },
+  responses: {
+    200: { description: 'Vault cancelled' },
+    400: { description: 'Invalid reason code' },
+    404: { description: 'Vault not found' },
+    409: { description: 'Vault already cancelled or not cancellable' },
+  },
+})
+
+// GET /api/admin/db/metrics
+registry.registerPath({
+  method: 'get',
+  path: '/api/admin/db/metrics',
+  summary: 'Get database pool metrics',
+  tags: ['Admin'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: 'Database metrics',
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.object({
+              timestamp: z.string().datetime(),
+              isHealthy: z.boolean(),
+              pool: z.object({
+                available: z.number(),
+                waiting: z.number(),
+                total: z.number(),
+                capacity: z.number(),
+              }),
+              slowQueries: z.array(z.any()),
+              warnings: z.array(z.string()),
+            }),
+          }),
+        },
+      },
+    },
+  },
+})
+
+
 export function generateOpenApiSpec() {
   const generator = new OpenApiGeneratorV31(registry.definitions)
 

--- a/src/tests/openapi.generation.test.ts
+++ b/src/tests/openapi.generation.test.ts
@@ -1,0 +1,65 @@
+import { generateOpenApiSpec } from '../docs/openapi-generator.js'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+describe('OpenAPI Generation', () => {
+  it('generates a valid OpenAPI spec without errors', () => {
+    expect(() => {
+      const spec = generateOpenApiSpec()
+      expect(spec).toBeDefined()
+      expect(spec.openapi).toBe('3.1.0')
+      expect(spec.info.title).toBe('Disciplr API')
+    }).not.toThrow()
+  })
+
+  it('includes Jobs routes', () => {
+    const spec = generateOpenApiSpec()
+    const paths = spec.paths || {}
+    
+    expect(paths['/api/jobs/enqueue']).toBeDefined()
+    expect(paths['/api/jobs/metrics']).toBeDefined()
+    expect(paths['/api/jobs/deadletters']).toBeDefined()
+    expect(paths['/api/jobs/health']).toBeDefined()
+  })
+
+  it('includes Transactions routes', () => {
+    const spec = generateOpenApiSpec()
+    const paths = spec.paths || {}
+    
+    expect(paths['/api/transactions']).toBeDefined()
+    expect(paths['/api/transactions/{id}']).toBeDefined()
+    expect(paths['/api/transactions/vault/{vaultId}']).toBeDefined()
+  })
+
+  it('includes Analytics routes', () => {
+    const spec = generateOpenApiSpec()
+    const paths = spec.paths || {}
+    
+    expect(paths['/api/analytics/summary']).toBeDefined()
+    expect(paths['/api/analytics/vaults']).toBeDefined()
+    expect(paths['/api/analytics/milestones/trends']).toBeDefined()
+    expect(paths['/api/analytics/behavior']).toBeDefined()
+  })
+
+  it('includes Admin routes', () => {
+    const spec = generateOpenApiSpec()
+    const paths = spec.paths || {}
+    
+    expect(paths['/api/admin/users']).toBeDefined()
+    expect(paths['/api/admin/audit-logs']).toBeDefined()
+    expect(paths['/api/admin/db/metrics']).toBeDefined()
+    expect(paths['/api/admin/overrides/vaults/{id}/cancel']).toBeDefined()
+  })
+
+  it('can write to openapi.yaml without errors', () => {
+    const spec = generateOpenApiSpec()
+    const yamlContent = require('yaml').stringify(spec)
+    
+    expect(yamlContent).toBeDefined()
+    expect(yamlContent.length).toBeGreaterThan(100)
+  })
+})


### PR DESCRIPTION
## Summary
Adds missing OpenAPI documentation for Jobs, Transactions, Analytics, and Admin routes.

## Changes
- Added OpenAPI paths for Jobs routes (`/metrics`, `/deadletters`, `/health`)
- Added OpenAPI paths for Transactions routes (`GET /`, `/:id`, `/vault/:vaultId`)
- Added OpenAPI paths for Analytics routes (`/vaults`, `/vaults/:id`, `/milestones/trends`, `/behavior`)
- Added OpenAPI paths for Admin routes (user management, audit logs, overrides, db metrics)
- Created generation smoke test `openapi.generation.test.ts`

## Testing
```bash
npm run openapi:validate
```
Closes #342

