### PR TITLE
test: add timestamp boundary

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -218,3 +218,12 @@ Location: `accountability_vault/src/lib.rs` — `AccountabilityVault::reclaim_af
 ### License
 
 See main repository license file.
+
+## Accountability Vault - Key Behaviors
+
+### Timestamp Boundary Rules
+- `slash_on_miss`: 
+  - `env.ledger().timestamp() <= vault.end_timestamp` → Returns `DeadlineNotReached` (exact equality is **rejected**)
+  - `env.ledger().timestamp() > vault.end_timestamp` → Slash is executed
+- `check_in`:
+  - Exact equality (`timestamp == milestone.due_date`) is **allowed** and succeeds.

--- a/contracts/accountability_vault/src/test.rs
+++ b/contracts/accountability_vault/src/test.rs
@@ -1308,3 +1308,61 @@ fn test_gas_benchmarks_slash_on_miss_10_milestones() {
     assert!(slash_cpu < 900_000);
     assert!(slash_mem < 250_000);
 }
+
+#[test]
+fn test_slash_on_miss_timestamp_boundaries() {
+    let env = TestEnv::default();
+    let contract = AccountabilityVaultContract::new(&env);
+
+    let vault = Vault {
+        end_timestamp: 1000,
+        ..Default::default()
+    };
+
+    // Setup vault
+    contract.create_vault(&vault);
+
+    // === Exact Equality Test: Should NOT slash (DeadlineNotReached) ===
+    env.ledger().set_timestamp(1000); // end_timestamp
+    let result = contract.slash_on_miss(0);
+    assert_eq!(result, Err(ContractError::DeadlineNotReached));
+
+    // === After Deadline: Should slash ===
+    env.ledger().set_timestamp(1001); // end_timestamp + 1
+    let result = contract.slash_on_miss(0);
+    assert!(result.is_ok());
+
+    // === Before Deadline: Should NOT slash ===
+    env.ledger().set_timestamp(999); // end_timestamp - 1
+    let result = contract.slash_on_miss(0);
+    assert_eq!(result, Err(ContractError::DeadlineNotReached));
+}
+
+#[test]
+fn test_check_in_milestone_due_date_boundaries() {
+    let env = TestEnv::default();
+    let contract = AccountabilityVaultContract::new(&env);
+
+    let milestone = Milestone {
+        due_date: 2000,
+        ..Default::default()
+    };
+
+    // Setup
+    contract.add_milestone(&milestone);
+
+    // Exact equality - should succeed
+    env.ledger().set_timestamp(2000);
+    let result = contract.check_in(0);
+    assert!(result.is_ok());
+
+    // Before due date - should fail
+    env.ledger().set_timestamp(1999);
+    let result = contract.check_in(0);
+    assert_eq!(result, Err(ContractError::TooEarly));
+
+    // After due date - should still succeed (assuming allowed)
+    env.ledger().set_timestamp(2001);
+    let result = contract.check_in(0);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Description
Added boundary tests for timestamp exact-equality in `slash_on_miss` and `check_in` functions.

## Changes
- Added `test_slash_on_miss_timestamp_boundaries()` 
- Added `test_check_in_milestone_due_date_boundaries()`
- Updated `contracts/README.md` with timestamp boundary rules

## Key Behaviors Tested
- `end_timestamp` exact equality → `DeadlineNotReached` (as per `slash_on_miss`)
- `end_timestamp + 1` → Slash allowed
- `end_timestamp - 1` → Rejected
- `milestone.due_date` exact equality → Allowed in `check_in`

Closes #501