### PR TITLE
refactor: extract reusable OpenAPI schemas for ErrorEnvelope and Pagi…

### DIFF
--- a/src/docs/openapi-generator.ts
+++ b/src/docs/openapi-generator.ts
@@ -20,17 +20,22 @@ registry.registerComponent('securitySchemes', 'bearerAuth', {
 })
 
 // --- Shared Schemas ---
-const ErrorSchema = registry.register(
-  'Error',
-  z.object({
-    error: z.object({
-      code: z.string().openapi({ example: 'VALIDATION_ERROR' }),
-      message: z.string().openapi({ example: 'Invalid request parameters' }),
-      details: z.unknown().optional(),
-      requestId: z.string().optional().openapi({ example: 'req_123' }),
-    }),
-  })
-)
+const PaginationCursor = registry.registerComponent('schemas', 'PaginationCursor', z.object({
+  limit: z.number(),
+  cursor: z.string().optional(),
+  next_cursor: z.string().optional(),
+  has_more: z.boolean(),
+  count: z.number(),
+}))
+
+const ErrorEnvelope = registry.registerComponent('schemas', 'ErrorEnvelope', z.object({
+  error: z.object({
+    code: z.string().openapi({ example: 'VALIDATION_ERROR' }),
+    message: z.string().openapi({ example: 'Invalid request parameters' }),
+    details: z.unknown().optional(),
+    requestId: z.string().optional().openapi({ example: 'req_123' }),
+  }),
+}))
 
 const VaultSchema = registry.register(
   'Vault',
@@ -102,7 +107,7 @@ registry.registerPath({
       description: 'User registered successfully',
       content: { 'application/json': { schema: z.any() } },
     },
-    400: { description: 'Bad request', content: { 'application/json': { schema: ErrorSchema } } },
+    400: { description: 'Bad request', content: { 'application/json': { schema: registry.getComponentRef('ErrorEnvelope') } } },
   },
 })
 
@@ -123,7 +128,7 @@ registry.registerPath({
       description: 'Login successful',
       content: { 'application/json': { schema: z.any() } },
     },
-    401: { description: 'Unauthorized', content: { 'application/json': { schema: ErrorSchema } } },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: registry.getComponentRef('ErrorEnvelope') } } },
   },
 })
 
@@ -378,13 +383,7 @@ registry.registerPath({
         'application/json': {
           schema: z.object({
             data: z.array(z.any()),
-            pagination: z.object({
-              limit: z.number(),
-              cursor: z.string().optional(),
-              next_cursor: z.string().optional(),
-              has_more: z.boolean(),
-              count: z.number(),
-            }),
+            pagination: registry.getComponentRef('PaginationCursor'),
           }),
         },
       },

--- a/src/tests/openapi.refs.test.ts
+++ b/src/tests/openapi.refs.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'fs';
+import { parse } from 'yaml';
+
+describe('OpenAPI component refs', () => {
+  const spec = parse(readFileSync('docs/openapi.yaml', 'utf8')) as any;
+
+  test('components schemas include ErrorEnvelope and PaginationCursor', () => {
+    expect(spec.components.schemas).toHaveProperty('ErrorEnvelope');
+    expect(spec.components.schemas).toHaveProperty('PaginationCursor');
+  });
+
+  test('some path references ErrorEnvelope', () => {
+    const paths = spec.paths;
+    const refs = [] as string[];
+    for (const pathKey of Object.keys(paths)) {
+      const methods = paths[pathKey];
+      for (const methodKey of Object.keys(methods)) {
+        const responses = methods[methodKey].responses || {};
+        for (const respKey of Object.keys(responses)) {
+          const content = responses[respKey].content;
+          if (content) {
+            for (const mt of Object.keys(content)) {
+              const schema = content[mt].schema;
+              if (schema && schema['$ref'] && schema['$ref'].includes('ErrorEnvelope')) {
+                refs.push(`${pathKey} ${methodKey} ${respKey}`);
+              }
+            }
+          }
+        }
+      }
+    }
+    expect(refs.length).toBeGreaterThan(0);
+  });
+
+  test('transactions pagination uses PaginationCursor', () => {
+    const txnPath = spec.paths['/api/transactions'];
+    expect(txnPath).toBeDefined();
+    const getMethod = txnPath.get;
+    const schema = getMethod.responses[200].content['application/json'].schema;
+    const paginationSchema = schema.properties.pagination;
+    expect(paginationSchema['$ref']).toContain('PaginationCursor');
+  });
+});


### PR DESCRIPTION
this pr closes #450 Extracted reusable OpenAPI component schemas:

ErrorEnvelope – matches the AppError shape used throughout the API.
PaginationCursor – standard pagination fields (limit, cursor, next_cursor, has_more, count).
All inline ErrorSchema definitions were replaced with $ref: '#/components/schemas/ErrorEnvelope' and the pagination object in the /api/transactions endpoint now references PaginationCursor.