### PR TITLE
refactor: request-scoped Prisma client via AsyncLocalStorage

### DIFF
--- a/docs/CONTROLLER_SERVICE_PATTERN.md
+++ b/docs/CONTROLLER_SERVICE_PATTERN.md
@@ -121,3 +121,74 @@ export class VaultNotFoundError extends Error {
 ```
 
 Routes catch and convert to HTTP responses.
+
+## Request-Scoped Prisma Client (AsyncLocalStorage)
+
+### Problem
+
+Services previously imported the Prisma singleton directly:
+
+```typescript
+import { prisma } from '../lib/prisma.js'
+```
+
+This makes it impossible to share a single `$transaction` client across multiple
+helpers called within the same request without threading the client through every
+argument list.
+
+### Solution
+
+`src/lib/prismaScope.ts` exposes an `AsyncLocalStorage<{ prisma }>` store and a
+`getPrisma()` helper.  Services call `getPrisma()` instead of using the
+singleton import directly.  The `withRequestPrisma` middleware populates the
+store at the start of every request.
+
+```
+Request → withRequestPrisma → ALS store = { prisma: singleton }
+                            → route handler
+                                → ServiceA.method()   ← getPrisma() == store.prisma
+                                → ServiceB.method()   ← getPrisma() == store.prisma
+```
+
+### Using $transaction across services
+
+Because all helpers in a request share the same ALS context you can wrap them in
+a transaction at the route layer without changing service signatures:
+
+```typescript
+// route handler
+const result = await getPrisma().$transaction(async (tx) => {
+  prismaStorage.run({ prisma: tx as any }, async () => {
+    await UserService.softDeleteUser(userId)   // getPrisma() → tx
+    await AuthService.logout(refreshToken)     // getPrisma() → tx
+  })
+})
+```
+
+### getPrisma() fallback
+
+If called outside an active ALS context (background jobs, scripts, tests that
+don't use the middleware) `getPrisma()` returns the global singleton.  No
+callers break.
+
+### Files
+
+| File | Role |
+|---|---|
+| `src/lib/prismaScope.ts` | ALS store + `getPrisma()` |
+| `src/middleware/withRequestPrisma.ts` | Express middleware that seeds the store |
+| `src/tests/prismaScope.test.ts` | Unit tests |
+
+### Service migration checklist
+
+Replace direct singleton imports with `getPrisma()`:
+
+```typescript
+// Before
+import { prisma } from '../lib/prisma.js'
+await prisma.refreshToken.updateMany(...)
+
+// After
+import { getPrisma } from '../lib/prismaScope.js'
+await getPrisma().refreshToken.updateMany(...)
+```

--- a/src/app-bootstrap.ts
+++ b/src/app-bootstrap.ts
@@ -22,6 +22,7 @@ import { adminVerifiersRouter } from './routes/adminVerifiers.js'
 import { verificationsRouter } from './routes/verifications.js'
 import { apiKeysRouter } from './routes/apiKeys.js'
 import { notificationsRouter } from './routes/notifications.js'
+import { withRequestPrisma } from './middleware/withRequestPrisma.js'
 import {
   securityMetricsMiddleware,
   securityRateLimitMiddleware,
@@ -33,6 +34,7 @@ export function bootstrapApp() {
 
   app.use(securityMetricsMiddleware)
   app.use(securityRateLimitMiddleware)
+  app.use(withRequestPrisma)
 
   app.use('/api/health', healthRateLimiter, createHealthRouter(jobSystem))
   app.use('/api/jobs', createJobsRouter(jobSystem))

--- a/src/lib/prismaScope.ts
+++ b/src/lib/prismaScope.ts
@@ -1,0 +1,19 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { PrismaClient } from '@prisma/client'
+import { prisma as singletonPrisma } from './prisma.js'
+
+export type PrismaScope = { prisma: PrismaClient }
+
+export const prismaStorage = new AsyncLocalStorage<PrismaScope>()
+
+/**
+ * Returns the request-scoped Prisma client if one has been bound by
+ * withRequestPrisma middleware, otherwise falls back to the global singleton.
+ *
+ * Use this everywhere instead of importing `prisma` directly so that callers
+ * inside an active $transaction context automatically receive the transaction
+ * client without any changes at the call site.
+ */
+export function getPrisma(): PrismaClient {
+  return prismaStorage.getStore()?.prisma ?? singletonPrisma
+}

--- a/src/middleware/withRequestPrisma.ts
+++ b/src/middleware/withRequestPrisma.ts
@@ -1,0 +1,14 @@
+import { RequestHandler } from 'express'
+import { prisma } from '../lib/prisma.js'
+import { prismaStorage } from '../lib/prismaScope.js'
+
+/**
+ * Binds the shared Prisma singleton to AsyncLocalStorage for the duration of
+ * a request.  Any service that calls getPrisma() within this request will
+ * receive the same client, making it trivial to wrap multiple service calls in
+ * a single prisma.$transaction() at the route layer without threading a client
+ * argument through every helper.
+ */
+export const withRequestPrisma: RequestHandler = (_req, _res, next) => {
+  prismaStorage.run({ prisma }, next)
+}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { prisma } from '../lib/prisma.js'
+import { getPrisma } from '../lib/prismaScope.js'
 import { hashPassword, comparePassword, generateAccessToken, generateRefreshToken, verifyRefreshToken, hashToken } from '../lib/auth-utils.js'
 import { RegisterInput, LoginInput } from '../lib/validation.js'
 import { UserRole } from '../types/user.js'
@@ -9,7 +9,7 @@ export class AuthService {
     static async register(input: RegisterInput) {
         try {
             const hashedPassword = await hashPassword(input.password)
-            const user = await prisma.user.create({
+            const user = await getPrisma().user.create({
                 data: {
                     email: input.email,
                     passwordHash: hashedPassword,
@@ -27,7 +27,7 @@ export class AuthService {
     }
 
     static async login(input: LoginInput) {
-        const user = await prisma.user.findUnique({ where: { email: input.email } })
+        const user = await getPrisma().user.findUnique({ where: { email: input.email } })
         if (!user) {
             throw new Error('Invalid credentials')
         }
@@ -37,7 +37,7 @@ export class AuthService {
             throw new Error('Invalid credentials')
         }
 
-        await prisma.user.update({
+        await getPrisma().user.update({
             where: { id: user.id },
             data: { lastLoginAt: new Date() },
         })
@@ -52,7 +52,7 @@ export class AuthService {
 
         // 2. Store hashed refresh token — the raw value is only returned to the client
         const tokenHash = hashToken(refreshTokenValue)
-        await prisma.refreshToken.create({
+        await getPrisma().refreshToken.create({
             data: {
                 token: tokenHash,
                 userId: user.id,
@@ -73,7 +73,7 @@ export class AuthService {
 
             // Look up by hash — we never store the raw token
             const tokenHash = hashToken(token)
-            const storedToken = await prisma.refreshToken.findUnique({
+            const storedToken = await getPrisma().refreshToken.findUnique({
                 where: { token: tokenHash },
                 include: { user: true },
             })
@@ -83,7 +83,7 @@ export class AuthService {
             }
 
             // Revoke old token BEFORE issuing new ones (no dual-valid window)
-            await prisma.refreshToken.update({
+            await getPrisma().refreshToken.update({
                 where: { id: storedToken.id },
                 data: { revokedAt: new Date() },
             })
@@ -98,7 +98,7 @@ export class AuthService {
 
             // 2. Store hashed new refresh token
             const newTokenHash = hashToken(newRefreshTokenValue)
-            await prisma.refreshToken.create({
+            await getPrisma().refreshToken.create({
                 data: {
                     token: newTokenHash,
                     userId: storedToken.user.id,
@@ -117,7 +117,7 @@ export class AuthService {
 
     static async logout(token: string) {
         const tokenHash = hashToken(token)
-        await prisma.refreshToken.updateMany({
+        await getPrisma().refreshToken.updateMany({
             where: { token: tokenHash },
             data: { revokedAt: new Date() },
         })
@@ -129,7 +129,7 @@ export class AuthService {
      */
     static async logoutAll(userId: string) {
         // 1. Revoke all refresh tokens for this user
-        await prisma.refreshToken.updateMany({
+        await getPrisma().refreshToken.updateMany({
             where: { userId, revokedAt: null },
             data: { revokedAt: new Date() },
         })

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,6 +1,6 @@
 import db from '../db/index.js'
 import { UserRole, UserStatus, User } from '../types/user.js'
-import { prisma } from '../lib/prisma.js'
+import { getPrisma } from '../lib/prismaScope.js'
 
 export interface UserFilters {
   role?: UserRole
@@ -165,7 +165,7 @@ export class UserService {
         updatedAt: deletedAt
       })
 
-    await prisma.refreshToken.updateMany({
+    await getPrisma().refreshToken.updateMany({
       where: { userId: id },
       data: { revokedAt: deletedAt }
     })
@@ -184,11 +184,11 @@ export class UserService {
       return null
     }
 
-    await prisma.refreshToken.deleteMany({
+    await getPrisma().refreshToken.deleteMany({
       where: { userId: id }
     })
 
-    await prisma.vault.deleteMany({
+    await getPrisma().vault.deleteMany({
       where: { creatorId: id }
     })
 

--- a/src/tests/prismaScope.test.ts
+++ b/src/tests/prismaScope.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
+
+// ── mock the singleton so we can distinguish it from a scoped client ──────────
+const mockSingleton = { tag: 'singleton' } as any
+jest.unstable_mockModule('../lib/prisma.js', () => ({ prisma: mockSingleton }))
+
+const { prismaStorage, getPrisma } = await import('../lib/prismaScope.js')
+const { withRequestPrisma } = await import('../middleware/withRequestPrisma.js')
+
+// ── reset ALS between tests ───────────────────────────────────────────────────
+beforeEach(() => {
+  // ALS context is request-bound and exits after each run() – no manual reset needed
+})
+
+describe('getPrisma()', () => {
+  it('returns the singleton when no scope is active', () => {
+    expect(getPrisma()).toBe(mockSingleton)
+  })
+
+  it('returns the scoped client when inside prismaStorage.run()', () => {
+    const scopedClient = { tag: 'scoped' } as any
+    prismaStorage.run({ prisma: scopedClient }, () => {
+      expect(getPrisma()).toBe(scopedClient)
+    })
+  })
+
+  it('falls back to singleton after the ALS run() callback exits', () => {
+    const scopedClient = { tag: 'scoped' } as any
+    prismaStorage.run({ prisma: scopedClient }, () => {
+      // inside scope — intentionally empty
+    })
+    // scope is gone
+    expect(getPrisma()).toBe(mockSingleton)
+  })
+
+  it('isolates scopes across concurrent async runs', async () => {
+    const clientA = { tag: 'A' } as any
+    const clientB = { tag: 'B' } as any
+    const results: string[] = []
+
+    await Promise.all([
+      new Promise<void>(resolve =>
+        prismaStorage.run({ prisma: clientA }, async () => {
+          await Promise.resolve() // yield
+          results.push((getPrisma() as any).tag)
+          resolve()
+        }),
+      ),
+      new Promise<void>(resolve =>
+        prismaStorage.run({ prisma: clientB }, async () => {
+          await Promise.resolve()
+          results.push((getPrisma() as any).tag)
+          resolve()
+        }),
+      ),
+    ])
+
+    // Each async context sees its own client – no cross-contamination
+    expect(results).toContain('A')
+    expect(results).toContain('B')
+    expect(results).toHaveLength(2)
+  })
+})
+
+describe('withRequestPrisma middleware', () => {
+  it('calls next() with no arguments (success path)', () => {
+    const req = {} as any
+    const res = {} as any
+    const next = jest.fn()
+
+    withRequestPrisma(req, res, next)
+    expect(next).toHaveBeenCalledTimes(1)
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it('makes the singleton accessible via getPrisma() inside next()', () => {
+    const req = {} as any
+    const res = {} as any
+
+    withRequestPrisma(req, res, () => {
+      expect(getPrisma()).toBe(mockSingleton)
+    })
+  })
+
+  it('scoped client is no longer accessible outside next()', () => {
+    const req = {} as any
+    const res = {} as any
+    withRequestPrisma(req, res, () => { /* request handled */ })
+    // After next() has returned we are outside the ALS context
+    expect(getPrisma()).toBe(mockSingleton)
+  })
+})


### PR DESCRIPTION
 refactor: request-scoped Prisma client via AsyncLocalStorage
  
  Summary
  
  Services previously imported the Prisma singleton directly, making it impossible to share a
  single $transaction client across multiple service calls within one request without threading a
  client argument through every helper.
  
  This PR introduces an AsyncLocalStorage-backed scope that binds a Prisma client to the current
  request context. Services call getPrisma() instead of the singleton — if a transaction client
  has been seeded into the ALS store, they get that; otherwise they fall back to the singleton
  transparently.
  
  Changes
  
  ┌────────────────────────┬──────────────┐
  │ File                   │ What changed                                                 │
  ├─────────────────────────────────────┼─────────────────────────────────────────────────────┤
  │ src/lib/prismaScope.ts              │ New — ALS store + getPrisma() helper with singleton │
  │                                     │ fallback                                            │
  ├─────────────────────────────────────┼─────────────────────────────────────────────────────┤
  │ src/middleware/withRequestPrisma.ts │ New — Express middleware that seeds the ALS store   │
  │                                     │ per request                                         │
  ├─────────────────────────────────────┼─────────────────────────────────────────────────────┤
  │ src/app-bootstrap.ts                │ Registers withRequestPrisma globally before route   │
  │                                     │ handlers                                            │
  ├─────────────────────────────────────┼─────────────────────────────────────────────────────┤
  │ src/services/auth.service.ts        │ Migrated 9 prisma.* call sites to getPrisma()       │
  ├─────────────────────────────────────┼─────────────────────────────────────────────────────┤
  │ src/services/user.service.ts        │ Migrated 3 prisma.* call sites to getPrisma()       │
  ├─────────────────────────────────────┼─────────────────────────────────────────────────────┤
  │ src/tests/prismaScope.test.ts       │ New — 7 unit tests (singleton fallback, scoped      │
  │                                     │ override, scope cleanup, concurrent isolation,      │
  │                                     │ middleware behaviour)                               │
  ├─────────────────────────────────────┼─────────────────────────────────────────────────────┤
  │ docs/CONTROLLER_SERVICE_PATTERN.md  │ Documents the pattern, $transaction usage, and      │
  │                                     │ migration checklist                                 │
  └─────────────────────────────────────┴─────────────────────────────────────────────────────┘
  
  Using $transaction across services
  
  const prisma = getPrisma()
  await prisma.$transaction(async (tx) => {
    prismaStorage.run({ prisma: tx as any }, async () => {
      await UserService.softDeleteUser(userId)  // getPrisma() → tx
      await AuthService.logout(refreshToken)    // getPrisma() → tx
    })
  })
  
  Testing
  
  - 7/7 new tests pass
  - No regressions in existing test suites
closes #458 