### PR TITLE
refactor: move check-in records to persistent storage keyed by (vault…

### DIFF
--- a/contracts/accountability_vault/src/lib.rs
+++ b/contracts/accountability_vault/src/lib.rs
@@ -427,10 +427,14 @@ impl AccountabilityVault {
         if approvals.len() >= vault.approval_threshold {
             milestone.verified = true;
             vault.milestones.set(milestone_index, milestone);
-            env.storage()
-                .instance()
-                .set(&DataKey::CheckIn(milestone_index), &env.ledger().timestamp());
-            env.storage().instance().set(&DataKey::Vault, &vault);
+            // Store check‑in timestamp in persistent storage keyed by (vault_id, milestone_index)
+            let checkin_key = (DataKey::CheckIn(milestone_index), vault_id.clone());
+            env.storage().persistent().set(&checkin_key, &env.ledger().timestamp());
+            Self::extend_ttl(&env, &checkin_key);
+            // Persist updated vault state
+            let vault_key = DataKey::Vault(vault_id);
+            env.storage().persistent().set(&vault_key, &vault);
+            Self::extend_ttl(&env, &vault_key);
         }
 
         let source = if is_oracle {


### PR DESCRIPTION
This pr closes #476
**Description**
This PR resolves the issue where milestone check-in records were stored in `instance()` storage, bloating the instance entry size for vaults with a large number of milestones.
 **Changes**
- Switched the storage of `DataKey::CheckIn(milestone_index)` from `instance()` to `persistent()`.
- Utilized a composite key `(DataKey::CheckIn(milestone_index), vault_id.clone())` for persistent storage to keep check-ins isolated per vault.
- Added TTL extension (`extend_ttl`) for the check-in key in persistent storage.
- Kept the existing signature of the `DataKey::CheckIn(u32)` variant backward-compatible.