### PR TITLE
feat: friendbot funding precheck on testnet boot

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -47,3 +47,42 @@ Database connection closed
 | `JOB_WORKER_CONCURRENCY` | 2 | Number of concurrent job workers. |
 | `JOB_QUEUE_POLL_INTERVAL_MS` | 250 | How often the job queue checks for new work. |
 | `JOB_HISTORY_LIMIT` | 50 | Number of completed/failed jobs to keep in memory metrics. |
+
+## Soroban Testnet Account Funding (Friendbot Precheck)
+
+On Stellar testnet, the `SOROBAN_SOURCE_ACCOUNT` must hold XLM before submitting any transactions. Without an initial balance the first vault creation fails with *account not found*.
+
+### How it works
+
+At startup (after the HTTP server binds), the backend runs a one-time precheck:
+
+1. Reads `SOROBAN_SOURCE_ACCOUNT` and `SOROBAN_RPC_URL` from the environment.
+2. Queries the Horizon endpoint derived from `SOROBAN_RPC_URL` for the account.
+3. **If the account exists** — nothing happens.
+4. **If the account does not exist** — calls [Stellar Friendbot](https://friendbot.stellar.org) to fund it with testnet XLM.
+
+The precheck only runs when **all** of the following are true:
+
+- Soroban submit mode is fully configured (all five `SOROBAN_*` variables are set).
+- `SOROBAN_NETWORK_PASSPHRASE` equals `Test SDF Network ; September 2015`.
+
+On mainnet (or any other passphrase) the precheck is a no-op — Friendbot is never called.
+
+### Result in `/api/health/deep`
+
+The cached result is exposed as `details.sorobanBoot` in the deep health response. It does **not** affect the overall `status` field (informational only).
+
+| `status` | Meaning |
+|---|---|
+| `pending` | Precheck has not completed yet (startup in progress). |
+| `not_applicable` | Soroban not configured or not testnet. |
+| `ok` | Precheck passed. `funded: true` if Friendbot was called. |
+| `error` | Precheck failed (non-fatal); see `error` field for details. |
+
+### Environment variables
+
+| Variable | Required for precheck | Description |
+|---|---|---|
+| `SOROBAN_SOURCE_ACCOUNT` | Yes | Public key (`G…`) of the transaction submitter. |
+| `SOROBAN_NETWORK_PASSPHRASE` | Yes | Must be testnet passphrase to enable Friendbot call. |
+| `SOROBAN_RPC_URL` | Yes | Used to derive the Horizon base URL for the account lookup. |

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { initEnv } from './config/index.js'
 // This ensures the process exits immediately on misconfiguration.
 initEnv()
 
+import { ensureSorobanBootPrecheck } from './services/sorobanBoot.js'
+
 import { app } from './app.js'
 import { bootstrapApp } from './app-bootstrap.js'
 import { startExpirationChecker } from './services/expirationScheduler.js'
@@ -40,6 +42,7 @@ const server = app.listen(PORT, () => {
   if (process.env.ENABLE_ETL_WORKER !== 'false') {
     etlWorker.start(ETL_INTERVAL_MINUTES)
   }
+  void ensureSorobanBootPrecheck()
 })
 
 const shutdownHandler = createShutdownHandler({

--- a/src/services/healthService.ts
+++ b/src/services/healthService.ts
@@ -1,6 +1,7 @@
 import { prisma } from '../lib/prisma.js';
 import { db } from '../db/knex.js';
 import type { BackgroundJobSystem } from '../jobs/system.js';
+import { getSorobanBootResult } from './sorobanBoot.js';
 
 const DEFAULT_TIMEOUT_MS = 3000;
 
@@ -70,6 +71,8 @@ export const healthService = {
         ? horizonResult.value
         : { status: 'down', error: String(horizonResult.reason?.message ?? 'Unknown error') };
 
+    const sorobanBoot = this.checkSorobanBoot();
+
     const components = [database, migrations, jobs, horizonListener];
     const isDown = components.some((c: any) => c.status === 'down');
     const isDegraded = components.some((c: any) => c.status === 'stale');
@@ -83,8 +86,21 @@ export const healthService = {
         migrations,
         jobs,
         horizonListener,
+        sorobanBoot,
       },
     };
+  },
+
+  /**
+   * Reports the cached result of the testnet friendbot precheck.
+   * Status is 'pending' before the async precheck completes.
+   */
+  checkSorobanBoot(): { status: string; funded?: boolean; error?: string } {
+    const result = getSorobanBootResult();
+    if (!result) return { status: 'pending' };
+    if (!result.ran) return { status: 'not_applicable' };
+    if (result.error) return { status: 'error', error: result.error };
+    return { status: 'ok', funded: result.funded ?? false };
   },
 
   async checkDatabase(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<{ status: string; error?: string }> {

--- a/src/services/sorobanBoot.ts
+++ b/src/services/sorobanBoot.ts
@@ -1,0 +1,132 @@
+/**
+ * sorobanBoot.ts
+ *
+ * Startup precheck for the Soroban source account on Stellar testnet.
+ * When the configured network is the public testnet and the source account
+ * has no XLM balance, this module calls Stellar Friendbot to fund it so the
+ * first vault-creation transaction does not fail with "account not found".
+ *
+ * Friendbot is only available on testnet; this module is a no-op on mainnet
+ * or when Soroban submit mode is not configured.
+ */
+
+import { getSorobanConfig, type SorobanConfig } from './soroban.js'
+
+export const TESTNET_PASSPHRASE = 'Test SDF Network ; September 2015'
+export const FRIENDBOT_URL = 'https://friendbot.stellar.org'
+
+export type FriendBotFetch = (url: string) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>
+type ConfigFn = () => SorobanConfig | null
+
+export interface SorobanBootResult {
+  /** Whether the precheck ran (false when Soroban is not configured or wrong network). */
+  ran: boolean
+  /** Whether the source account was already funded. */
+  alreadyFunded?: boolean
+  /** Whether friendbot was successfully called. */
+  funded?: boolean
+  /** Non-fatal error message if the precheck failed. */
+  error?: string
+}
+
+const log = (level: 'info' | 'warn' | 'error', event: string, data: Record<string, unknown> = {}): void => {
+  const entry = { level, service: 'disciplr-backend', component: 'soroban-boot', event, ts: new Date().toISOString(), ...data }
+  level === 'error' ? console.error(JSON.stringify(entry)) : console.log(JSON.stringify(entry))
+}
+
+/**
+ * Checks the source account balance via the Horizon REST API.
+ * Returns true when the account exists (HTTP 200), false when not found (HTTP 404).
+ */
+export async function isAccountFunded(
+  sourceAccount: string,
+  rpcUrl: string,
+  fetchFn: FriendBotFetch = globalThis.fetch as FriendBotFetch,
+): Promise<boolean> {
+  const parsed = new URL(rpcUrl)
+  const horizonBase = `${parsed.protocol}//${parsed.host}`
+  const res = await fetchFn(`${horizonBase}/accounts/${sourceAccount}`)
+  if (res.status === 404) return false
+  if (!res.ok) throw new Error(`Horizon account lookup failed: HTTP ${res.status}`)
+  return true
+}
+
+/**
+ * Calls Friendbot to fund the given Stellar testnet account.
+ */
+export async function callFriendbot(
+  sourceAccount: string,
+  fetchFn: FriendBotFetch = globalThis.fetch as FriendBotFetch,
+): Promise<void> {
+  const url = `${FRIENDBOT_URL}?addr=${encodeURIComponent(sourceAccount)}`
+  const res = await fetchFn(url)
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Friendbot request failed: HTTP ${res.status} — ${body}`)
+  }
+}
+
+/**
+ * Runs the testnet funding precheck. Safe to call at startup; never throws.
+ *
+ * - No-op when Soroban is not configured (submit mode disabled).
+ * - No-op on non-testnet networks (guards against accidental mainnet calls).
+ * - Calls Friendbot only when the source account is unfunded.
+ *
+ * @param fetchFn  Injectable fetch implementation (defaults to globalThis.fetch).
+ * @param configFn Injectable config loader (defaults to getSorobanConfig).
+ */
+export async function runSorobanBootPrecheck(
+  fetchFn: FriendBotFetch = globalThis.fetch as FriendBotFetch,
+  configFn: ConfigFn = getSorobanConfig,
+): Promise<SorobanBootResult> {
+  const config = configFn()
+  if (!config) return { ran: false }
+
+  if (config.networkPassphrase !== TESTNET_PASSPHRASE) {
+    log('info', 'soroban.boot.skipped', { reason: 'not-testnet' })
+    return { ran: false }
+  }
+
+  try {
+    const funded = await isAccountFunded(config.sourceAccount, config.rpcUrl, fetchFn)
+    if (funded) {
+      log('info', 'soroban.boot.already_funded', { account: config.sourceAccount })
+      return { ran: true, alreadyFunded: true, funded: false }
+    }
+
+    log('info', 'soroban.boot.funding', { account: config.sourceAccount })
+    await callFriendbot(config.sourceAccount, fetchFn)
+    log('info', 'soroban.boot.funded', { account: config.sourceAccount })
+    return { ran: true, alreadyFunded: false, funded: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log('warn', 'soroban.boot.error', { error: message })
+    return { ran: true, alreadyFunded: false, funded: false, error: message }
+  }
+}
+
+// ─── Module-level result cached for health checks ─────────────────────────
+
+let _bootResult: SorobanBootResult | null = null
+
+/**
+ * Runs the precheck once and caches the result.
+ * Subsequent calls return the cached result without re-running.
+ */
+export async function ensureSorobanBootPrecheck(
+  fetchFn?: FriendBotFetch,
+  configFn?: ConfigFn,
+): Promise<SorobanBootResult> {
+  if (_bootResult !== null) return _bootResult
+  _bootResult = await runSorobanBootPrecheck(fetchFn, configFn)
+  return _bootResult
+}
+
+/** Returns the cached boot result (null if not yet run). */
+export const getSorobanBootResult = (): SorobanBootResult | null => _bootResult
+
+/** Resets the cached result — for testing only. */
+export const resetSorobanBootResult = (): void => {
+  _bootResult = null
+}

--- a/src/tests/sorobanBoot.test.ts
+++ b/src/tests/sorobanBoot.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals'
+
+import {
+  isAccountFunded,
+  callFriendbot,
+  runSorobanBootPrecheck,
+  ensureSorobanBootPrecheck,
+  getSorobanBootResult,
+  resetSorobanBootResult,
+  TESTNET_PASSPHRASE,
+  FRIENDBOT_URL,
+} from '../services/sorobanBoot.js'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const SOURCE = 'G' + 'A'.repeat(55)
+const RPC_URL = 'https://soroban-testnet.stellar.org'
+
+const testnetConfig = () => ({
+  networkPassphrase: TESTNET_PASSPHRASE,
+  sourceAccount: SOURCE,
+  rpcUrl: RPC_URL,
+})
+
+const okFetch = (body = '{}') =>
+  jest.fn<any>().mockResolvedValue({ ok: true, status: 200, text: async () => body })
+
+const notFoundFetch = () =>
+  jest.fn<any>().mockResolvedValue({ ok: false, status: 404, text: async () => 'not found' })
+
+const errorFetch = (status = 500, body = 'server error') =>
+  jest.fn<any>().mockResolvedValue({ ok: false, status, text: async () => body })
+
+// ─── isAccountFunded ──────────────────────────────────────────────────────────
+
+describe('isAccountFunded', () => {
+  it('returns true when Horizon returns 200', async () => {
+    const fetch = okFetch()
+    expect(await isAccountFunded(SOURCE, RPC_URL, fetch)).toBe(true)
+    expect((fetch.mock.calls[0] as any[])[0]).toContain(`/accounts/${SOURCE}`)
+  })
+
+  it('strips the RPC path and uses only the host for Horizon base URL', async () => {
+    const fetch = okFetch()
+    await isAccountFunded(SOURCE, 'https://soroban-testnet.stellar.org/rpc/path', fetch)
+    const url: string = (fetch.mock.calls[0] as any[])[0]
+    expect(url).toMatch(/^https:\/\/soroban-testnet\.stellar\.org\/accounts\//)
+  })
+
+  it('returns false when Horizon returns 404', async () => {
+    expect(await isAccountFunded(SOURCE, RPC_URL, notFoundFetch())).toBe(false)
+  })
+
+  it('throws on unexpected HTTP error', async () => {
+    await expect(isAccountFunded(SOURCE, RPC_URL, errorFetch(503))).rejects.toThrow('HTTP 503')
+  })
+})
+
+// ─── callFriendbot ────────────────────────────────────────────────────────────
+
+describe('callFriendbot', () => {
+  it('calls the correct friendbot URL with encoded account', async () => {
+    const fetch = okFetch()
+    await callFriendbot(SOURCE, fetch)
+    const url: string = (fetch.mock.calls[0] as any[])[0]
+    expect(url).toContain(FRIENDBOT_URL)
+    expect(url).toContain(encodeURIComponent(SOURCE))
+  })
+
+  it('throws on non-ok response and includes body in message', async () => {
+    await expect(callFriendbot(SOURCE, errorFetch(400, 'bad account'))).rejects.toThrow('bad account')
+  })
+})
+
+// ─── runSorobanBootPrecheck ───────────────────────────────────────────────────
+
+describe('runSorobanBootPrecheck', () => {
+  it('returns {ran:false} when Soroban is not configured', async () => {
+    expect(await runSorobanBootPrecheck(undefined, () => null)).toEqual({ ran: false })
+  })
+
+  it('returns {ran:false} on non-testnet network', async () => {
+    const cfg = { ...testnetConfig(), networkPassphrase: 'Public Global Stellar Network ; September 2015' }
+    expect(await runSorobanBootPrecheck(undefined, () => cfg as any)).toEqual({ ran: false })
+  })
+
+  it('returns alreadyFunded:true and does NOT call friendbot when account exists', async () => {
+    const fetch = okFetch()
+    const result = await runSorobanBootPrecheck(fetch, () => testnetConfig() as any)
+    expect(result).toEqual({ ran: true, alreadyFunded: true, funded: false })
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls friendbot and returns funded:true when account is unfunded', async () => {
+    const fetch = jest.fn<any>()
+      .mockResolvedValueOnce({ ok: false, status: 404, text: async () => 'not found' })
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => '{}' })
+    const result = await runSorobanBootPrecheck(fetch, () => testnetConfig() as any)
+    expect(result).toEqual({ ran: true, alreadyFunded: false, funded: true })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns error result without throwing when horizon lookup fails', async () => {
+    const fetch = jest.fn<any>().mockRejectedValue(new Error('network timeout'))
+    const result = await runSorobanBootPrecheck(fetch, () => testnetConfig() as any)
+    expect(result.ran).toBe(true)
+    expect(result.funded).toBe(false)
+    expect(result.error).toMatch(/network timeout/)
+  })
+
+  it('returns error result without throwing when friendbot call fails', async () => {
+    const fetch = jest.fn<any>()
+      .mockResolvedValueOnce({ ok: false, status: 404, text: async () => 'not found' })
+      .mockResolvedValueOnce({ ok: false, status: 429, text: async () => 'rate limited' })
+    const result = await runSorobanBootPrecheck(fetch, () => testnetConfig() as any)
+    expect(result.ran).toBe(true)
+    expect(result.funded).toBe(false)
+    expect(result.error).toMatch(/rate limited/)
+  })
+})
+
+// ─── ensureSorobanBootPrecheck (caching) ─────────────────────────────────────
+
+describe('ensureSorobanBootPrecheck', () => {
+  beforeEach(() => resetSorobanBootResult())
+  afterEach(() => resetSorobanBootResult())
+
+  it('runs the precheck on first call', async () => {
+    expect(await ensureSorobanBootPrecheck(undefined, () => null)).toEqual({ ran: false })
+  })
+
+  it('returns cached result without re-running on subsequent calls', async () => {
+    const fetch = okFetch()
+    const first = await ensureSorobanBootPrecheck(fetch, () => testnetConfig() as any)
+    expect(first.alreadyFunded).toBe(true)
+    const second = await ensureSorobanBootPrecheck(fetch, () => testnetConfig() as any)
+    expect(second).toBe(first)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─── getSorobanBootResult ─────────────────────────────────────────────────────
+
+describe('getSorobanBootResult', () => {
+  beforeEach(() => resetSorobanBootResult())
+  afterEach(() => resetSorobanBootResult())
+
+  it('returns null before any precheck has run', () => {
+    expect(getSorobanBootResult()).toBeNull()
+  })
+
+  it('returns the cached result after a precheck', async () => {
+    await ensureSorobanBootPrecheck(undefined, () => null)
+    expect(getSorobanBootResult()).toEqual({ ran: false })
+  })
+})


### PR DESCRIPTION
Friendbot funding precheck on testnet boot
  
  On testnet, SOROBAN_SOURCE_ACCOUNT must hold XLM before any vault creation
  transaction can be submitted. Without it, the first call fails with account
  not found. This PR adds a non-blocking startup precheck that automatically
  funds the account via Stellar Friendbot when needed.
  
  Changes
  
  - src/services/sorobanBoot.ts — new module with isAccountFunded (Horizon
  account lookup), callFriendbot (Friendbot HTTP call), and
  runSorobanBootPrecheck (orchestrator, never throws). Result is cached via
  ensureSorobanBootPrecheck for health check consumption.
  - src/index.ts — calls void ensureSorobanBootPrecheck() inside the app.listen
   callback (fire-and-forget, does not delay startup).
  - src/services/healthService.ts — exposes details.sorobanBoot in GET
  /api/health?deep=1. Informational only; does not affect the overall status
   rollup.
  - src/tests/sorobanBoot.test.ts — 16 tests covering all branches: not
  configured, non-testnet, already funded, unfunded (friendbot called), Horizon
  error, Friendbot error, caching behaviour.
  - docs/operations.md — documents the precheck, the sorobanBoot health status
  values, and relevant env vars.
  
  Safety
  
  Friendbot is only called when SOROBAN_NETWORK_PASSPHRASE exactly matches Test
  SDF Network ; September 2015. Any other passphrase (including mainnet) skips
  the precheck entirely.
  
  Testing
  
  All 16 new tests pass. Zero regressions introduced against the pre-existing
  suite.
closes #473