### PR TITLE
refactor: split cancel_vault from withdraw

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -141,6 +141,21 @@ cd contracts/accountability_vault
 cargo test
 ```
 
+### Migration: API change (cancel_vault vs withdraw)
+
+- The contract API now exposes `cancel_vault(vault_id, creator)` for explicitly
+  cancelling an unfunded `Draft` vault. This path emits the `vault_cancelled`
+  event and performs no token transfers.
+- The `withdraw(vault_id, creator)` function has been restricted to the funded
+  `Active` refund case (vaults that were staked but never had any verified
+  check-ins). It performs a CEI-safe refund to the `creator` and emits
+  `vault_withdrawn`.
+- Backend callers must choose the appropriate method based on the vault's
+  current `status`: use `cancel_vault` for `Draft`, and `withdraw` for
+  `Active` refunding. The `vault_cancelled` topic and payload remain
+  compatible with the existing backend event parser.
+
+
 #### Formatting
 
 The workspace ships a `contracts/rustfmt.toml` config. Format all contract sources with:

--- a/contracts/accountability_vault/src/lib.rs
+++ b/contracts/accountability_vault/src/lib.rs
@@ -675,30 +675,39 @@ impl AccountabilityVault {
         Ok(())
     }
 
-    /// Cancels an unfunded (`Draft`) vault, or refunds the creator if the vault
-    /// was funded but never activated against any milestone. Only the creator
-    /// may withdraw; vaults with any verified check-ins cannot be unwound.
-    ///
-    /// Checks-Effects-Interactions: vault state is updated and persisted BEFORE
-    /// the external token transfer for the active-vault refund path.
-    pub fn withdraw(env: Env, creator: Address) -> Result<(), Error> {
+    /// Cancels an unfunded (`Draft`) vault. Only the creator may cancel a
+    /// draft; this path does not transfer tokens and emits `vault_cancelled`.
+    pub fn cancel_vault(env: Env, vault_id: String, creator: Address) -> Result<(), Error> {
         creator.require_auth();
         let mut vault: Vault = Self::load(&env, &vault_id)?;
 
         if creator != vault.creator {
             return Err(Error::Unauthorized);
         }
-        if vault.status == VaultStatus::Draft {
-            vault.status = VaultStatus::Cancelled;
-            let key = DataKey::Vault(vault_id);
-            env.storage().persistent().set(&key, &vault);
-            Self::extend_ttl(&env, &key);
-
-            env.events()
-                .publish((String::from_str(&env, "vault_cancelled"), creator), 0i128);
-            return Ok(());
+        if vault.status != VaultStatus::Draft {
+            return Err(Error::NotDraft);
         }
 
+        vault.status = VaultStatus::Cancelled;
+        let key = DataKey::Vault(vault_id);
+        env.storage().persistent().set(&key, &vault);
+        Self::extend_ttl(&env, &key);
+
+        env.events()
+            .publish((String::from_str(&env, "vault_cancelled"), creator), 0i128);
+        Ok(())
+    }
+
+    /// Refunds the creator for an `Active` vault that was never checked-in.
+    /// This function is restricted to `Active` refund cases; callers that wish
+    /// to cancel a Draft should call `cancel_vault` instead.
+    pub fn withdraw(env: Env, vault_id: String, creator: Address) -> Result<(), Error> {
+        creator.require_auth();
+        let mut vault: Vault = Self::load(&env, &vault_id)?;
+
+        if creator != vault.creator {
+            return Err(Error::Unauthorized);
+        }
         if vault.status != VaultStatus::Active {
             return Err(Error::NotActive);
         }

--- a/contracts/accountability_vault/src/test.rs
+++ b/contracts/accountability_vault/src/test.rs
@@ -154,9 +154,23 @@ fn test_slash_on_miss() {
 #[test]
 fn test_withdraw_draft_cancels() {
     let s = setup(&[100], &[500]);
+    s.contract.cancel_vault(&s.vault_id, &s.creator);
+    let vault = s.contract.get_vault(&s.vault_id);
+    assert_eq!(vault.status, VaultStatus::Cancelled);
+}
+
+#[test]
+fn test_withdraw_active_refunds_creator() {
+    let s = setup(&[100], &[500]);
+    // Fund the vault and then call withdraw without any check-ins.
+    s.contract.stake(&s.vault_id, &s.creator);
+
     s.contract.withdraw(&s.vault_id, &s.creator);
     let vault = s.contract.get_vault(&s.vault_id);
     assert_eq!(vault.status, VaultStatus::Cancelled);
+
+    let token_client = token::Client::new(&s.env, &s.token);
+    assert_eq!(token_client.balance(&s.creator), 500);
 }
 
 #[test]
@@ -460,8 +474,9 @@ fn test_create_vault_invalid_threshold_exceeds_verifiers_fails() {
             verified: false,
         },
     ];
+    let vault_id = String::from_str(&env, "v1");
     contract.create_vault(
-        &creator, &verifier_set, &None, &token, &500, &success, &failure, &1_200,
+        &vault_id, &creator, &verifier_set, &None, &token, &500, &success, &failure, &1_200,
         &milestones, &guardian,
     );
 }
@@ -794,7 +809,7 @@ fn test_pause_blocks_withdraw_active() {
     s.contract.emergency_pause(&s.guardian);
 
     // Must fail with Paused.
-    s.contract.withdraw(&s.creator);
+    s.contract.withdraw(&s.vault_id, &s.creator);
 }
 
 #[test]
@@ -878,9 +893,9 @@ fn test_pause_does_not_block_draft_withdraw() {
     // Pause before staking (vault is still Draft).
     contract.emergency_pause(&guardian);
 
-    // Draft-path withdraw (cancel) must still succeed.
-    contract.withdraw(&creator);
-    let vault = contract.get_vault();
+    // Draft-path cancel must still succeed.
+    contract.cancel_vault(&vault_id, &creator);
+    let vault = contract.get_vault(&vault_id);
     assert_eq!(vault.status, VaultStatus::Cancelled);
 }
 


### PR DESCRIPTION
I split the dual-purpose withdraw into an explicit cancel_vault (cancels Draft vaults and emits vault_cancelled) and a restricted withdraw(vault_id, creator) (refunds only Active vaults with no verified check‑ins) in lib.rs; updated unit tests in test.rs and added a migration note to README.md. This clarifies caller intent, preserves CEI ordering for token transfers, keeps the vault_cancelled topic compatible with eventParser.ts, and is covered by tests validating both cancel and withdraw paths. 
Closed #477 