### PR TITLE
feat: pgvector-backed milestone embeddings table

### DIFF
--- a/db/migrations/20260602000000_create_milestone_embeddings.cjs
+++ b/db/migrations/20260602000000_create_milestone_embeddings.cjs
@@ -1,0 +1,41 @@
+/**
+ * Migration: pgvector extension + milestone_embeddings table
+ *
+ * Enables the pgvector extension and creates the milestone_embeddings table
+ * used for near-duplicate / low-effort submission detection via cosine-
+ * similarity search over 768-dimensional embedding vectors.
+ */
+
+exports.up = async function up(knex) {
+  // Enable pgvector; idempotent – safe to run repeatedly.
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS vector')
+
+  await knex.schema.createTable('milestone_embeddings', (table) => {
+    table.uuid('milestone_id').primary()
+    // vector(768) is a pgvector column type; Knex does not have a native
+    // helper for it, so we use a raw column definition.
+    table.specificType('embedding', 'vector(768)').notNullable()
+    table
+      .timestamp('created_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now())
+    table
+      .timestamp('updated_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now())
+  })
+
+  // IVFFlat index for approximate nearest-neighbour search (cosine distance).
+  // lists=100 is a reasonable default for tables up to ~1 M rows.
+  await knex.raw(`
+    CREATE INDEX idx_milestone_embeddings_vector
+      ON milestone_embeddings
+      USING ivfflat (embedding vector_cosine_ops)
+      WITH (lists = 100)
+  `)
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.dropTableIfExists('milestone_embeddings')
+  // Leave the vector extension in place – other tables may rely on it.
+}

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -111,3 +111,123 @@ Successful validation emits:
 - Prevents IDOR by validating milestone belongs to specified vault
 - Idempotent to prevent replay attacks
 - All validation attempts logged with actor information
+
+---
+
+## pgvector — Milestone Embeddings (Similarity Search)
+
+### Overview
+
+The `milestone_embeddings` table stores 768-dimensional vector embeddings for milestone evidence text. These are used to detect near-duplicate or low-effort submissions by performing cosine-similarity search via the [pgvector](https://github.com/pgvector/pgvector) PostgreSQL extension.
+
+Embeddings are populated asynchronously by an offline job after evidence is submitted; the table is deliberately separate from the core milestone tables so the feature can be enabled/disabled without schema churn.
+
+### Database Schema
+
+```sql
+-- Extension (enabled by migration)
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Table
+CREATE TABLE milestone_embeddings (
+  milestone_id  UUID          PRIMARY KEY,
+  embedding     vector(768)   NOT NULL,
+  created_at    TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+-- IVFFlat index for approximate nearest-neighbour search
+CREATE INDEX idx_milestone_embeddings_vector
+  ON milestone_embeddings
+  USING ivfflat (embedding vector_cosine_ops)
+  WITH (lists = 100);
+```
+
+### Migration
+
+The migration is applied automatically via Knex:
+
+```bash
+npm run migrate:latest
+```
+
+The migration file is `db/migrations/20260602000000_create_milestone_embeddings.cjs`.
+
+To roll back:
+
+```bash
+npm run migrate:rollback
+```
+
+Rolling back drops the `milestone_embeddings` table but intentionally **leaves the `vector` extension** in place, as other tables may depend on it.
+
+### Repository API — `MilestoneRepository`
+
+Located at `src/repositories/milestoneRepository.ts`.
+
+| Method | Signature | Description |
+|---|---|---|
+| `upsertEmbedding` | `(milestoneId: string, embedding: number[]) => Promise<void>` | Insert or replace the embedding for a milestone. |
+| `nearestNeighbors` | `(milestoneId: string, k?: number) => Promise<NearestNeighborResult[]>` | Return up to `k` nearest neighbours (default 5) by ascending cosine distance, excluding the queried milestone itself. |
+| `findEmbedding` | `(milestoneId: string) => Promise<MilestoneEmbedding \| null>` | Retrieve the stored embedding record, or `null` if absent. |
+| `deleteEmbedding` | `(milestoneId: string) => Promise<void>` | Remove the embedding (e.g. when the milestone is deleted). |
+
+#### Example
+
+```typescript
+import knex from 'knex'
+import { MilestoneRepository } from './src/repositories/milestoneRepository.js'
+
+const db = knex({ client: 'pg', connection: process.env.DATABASE_URL })
+const repo = new MilestoneRepository(db)
+
+// Store an embedding produced by an offline embedding model
+await repo.upsertEmbedding('milestone-uuid', embeddingVector)
+
+// Find the 5 most similar milestones
+const neighbours = await repo.nearestNeighbors('milestone-uuid', 5)
+// => [{ milestone_id: '...', distance: 0.04 }, ...]
+```
+
+### `NearestNeighborResult` type
+
+```typescript
+interface NearestNeighborResult {
+  milestone_id: string
+  distance: number  // cosine distance in [0, 2]; lower = more similar
+}
+```
+
+### Environment Requirements
+
+| Requirement | Notes |
+|---|---|
+| PostgreSQL ≥ 13 | Minimum supported version for pgvector |
+| pgvector ≥ 0.5.0 | `CREATE EXTENSION vector` must succeed |
+| `DATABASE_URL` env var | Standard connection string |
+
+If pgvector is not installed on the target database, the migration will fail with:
+
+```
+ERROR: extension "vector" is not available
+```
+
+Install pgvector on your PostgreSQL server before running migrations:
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install postgresql-16-pgvector
+
+# Docker — use pgvector/pgvector image
+# docker run -e POSTGRES_PASSWORD=pw pgvector/pgvector:pg16
+```
+
+### Tests
+
+Tests live in `src/tests/milestoneEmbeddings.test.ts`. They are automatically **skipped** when `DATABASE_URL` is not set or the `vector` extension is not available in the target database, so they never block CI builds that run without a full PostgreSQL service.
+
+To run the full suite against a local database:
+
+```bash
+DATABASE_URL=postgres://user:pw@localhost:5432/disciplr_test npm test -- milestoneEmbeddings
+```

--- a/src/repositories/milestoneRepository.ts
+++ b/src/repositories/milestoneRepository.ts
@@ -1,57 +1,104 @@
-import { Knex } from 'knex';
-import { Milestone, MilestoneStatus } from '../types/milestone.js';
+import { Knex } from 'knex'
 
+export interface MilestoneEmbedding {
+  milestone_id: string
+  embedding: number[]
+  created_at: Date
+  updated_at: Date
+}
+
+export interface NearestNeighborResult {
+  milestone_id: string
+  distance: number
+}
+
+/**
+ * Repository for milestone embedding operations backed by pgvector.
+ *
+ * All vector values are 768-dimensional float arrays matching the
+ * `vector(768)` column type in the milestone_embeddings table.
+ */
 export class MilestoneRepository {
-  constructor(private db: Knex) {}
+  constructor(private readonly db: Knex) {}
 
   /**
-   * Create a new milestone
+   * Upsert an embedding for a milestone.
+   * Replaces any existing embedding for the same milestone_id.
    */
-  async create(milestone: Milestone): Promise<Milestone> {
-    const [created] = await this.db('milestones')
-      .insert({
-        ...milestone,
-        // Ensure criteria is properly stringified for JSONB insertion if needed by the driver
-        criteria: JSON.stringify(milestone.criteria) 
-      })
-      .returning('*');
-    return created;
+  async upsertEmbedding(milestoneId: string, embedding: number[]): Promise<void> {
+    const vectorLiteral = `[${embedding.join(',')}]`
+    await this.db.raw(
+      `INSERT INTO milestone_embeddings (milestone_id, embedding, updated_at)
+       VALUES (:milestoneId, :vector::vector, NOW())
+       ON CONFLICT (milestone_id)
+       DO UPDATE SET embedding = EXCLUDED.embedding, updated_at = NOW()`,
+      { milestoneId, vector: vectorLiteral },
+    )
   }
 
   /**
-   * List all milestones for a specific vault
+   * Find the k nearest neighbours to the embedding stored for milestoneId,
+   * ordered by ascending cosine distance (closest first).
+   *
+   * The queried milestone itself is excluded from the results.
+   *
+   * @param milestoneId  The milestone whose stored embedding is used as the query vector.
+   * @param k            Maximum number of neighbours to return (default: 5).
+   * @returns            Array of { milestone_id, distance } sorted closest-first.
+   *                     Returns an empty array when no embedding exists for milestoneId.
    */
-  async listByVault(vaultId: string): Promise<Milestone[]> {
-    return this.db('milestones')
-      .where({ vault_id: vaultId })
-      .orderBy('created_at', 'asc');
+  async nearestNeighbors(milestoneId: string, k = 5): Promise<NearestNeighborResult[]> {
+    // Fetch the query embedding first so we can pass it as a plain literal.
+    // This avoids a correlated sub-query that would prevent index use.
+    const row = await this.db('milestone_embeddings')
+      .where({ milestone_id: milestoneId })
+      .select(this.db.raw('embedding::text AS embedding_text'))
+      .first()
+
+    if (!row) return []
+
+    const rows = await this.db.raw<{ rows: { milestone_id: string; distance: string }[] }>(
+      `SELECT milestone_id,
+              (embedding <=> :queryVec::vector) AS distance
+       FROM   milestone_embeddings
+       WHERE  milestone_id <> :milestoneId
+       ORDER  BY embedding <=> :queryVec::vector
+       LIMIT  :k`,
+      { queryVec: row.embedding_text, milestoneId, k },
+    )
+
+    return rows.rows.map((r) => ({
+      milestone_id: r.milestone_id,
+      distance: parseFloat(r.distance),
+    }))
   }
 
   /**
-   * Update the status of a specific milestone
+   * Return the stored embedding record for a milestone, or null if absent.
    */
-  async updateStatus(id: string, status: MilestoneStatus): Promise<Milestone | undefined> {
-    const [updated] = await this.db('milestones')
-      .where({ id })
-      .update({ 
-        status, 
-        updated_at: this.db.fn.now() 
-      })
-      .returning('*');
-    return updated;
+  async findEmbedding(milestoneId: string): Promise<MilestoneEmbedding | null> {
+    const row = await this.db('milestone_embeddings')
+      .where({ milestone_id: milestoneId })
+      .select(
+        'milestone_id',
+        this.db.raw('embedding::text AS embedding'),
+        'created_at',
+        'updated_at',
+      )
+      .first()
+
+    if (!row) return null
+
+    return {
+      ...row,
+      embedding: JSON.parse(row.embedding) as number[],
+    } as MilestoneEmbedding
   }
 
   /**
-   * Update the criteria of a specific milestone
+   * Delete the embedding for a milestone (e.g. when the milestone is removed).
    */
-  async updateCriteria(id: string, criteria: Record<string, any>): Promise<Milestone | undefined> {
-    const [updated] = await this.db('milestones')
-      .where({ id })
-      .update({ 
-        criteria: JSON.stringify(criteria), 
-        updated_at: this.db.fn.now() 
-      })
-      .returning('*');
-    return updated;
+  async deleteEmbedding(milestoneId: string): Promise<void> {
+    await this.db('milestone_embeddings').where({ milestone_id: milestoneId }).delete()
   }
 }

--- a/src/tests/milestoneEmbeddings.test.ts
+++ b/src/tests/milestoneEmbeddings.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for MilestoneRepository – pgvector-backed nearest-neighbour search.
+ *
+ * These tests require a live PostgreSQL instance with the pgvector extension
+ * installed.  When pgvector is unavailable (e.g. in CI without a pg service,
+ * or when DATABASE_URL is not set) the suite is skipped automatically so it
+ * never blocks a build.
+ *
+ * To run locally:
+ *   DATABASE_URL=postgres://... npm test -- milestoneEmbeddings
+ */
+
+import knex, { Knex } from 'knex'
+import { MilestoneRepository } from '../repositories/milestoneRepository.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeVector(seed: number, dims = 768): number[] {
+  // Deterministic pseudo-random vector seeded by `seed`.
+  const v: number[] = []
+  let s = seed
+  for (let i = 0; i < dims; i++) {
+    s = (s * 1664525 + 1013904223) & 0xffffffff
+    v.push((s & 0xffff) / 0xffff - 0.5)
+  }
+  // L2-normalise so cosine distance reflects angle only.
+  const norm = Math.sqrt(v.reduce((acc, x) => acc + x * x, 0))
+  return v.map((x) => x / norm)
+}
+
+const MILESTONE_IDS = ['m-001', 'm-002', 'm-003', 'm-004', 'm-005']
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let db: Knex
+let repo: MilestoneRepository
+let pgvectorAvailable = false
+
+beforeAll(async () => {
+  if (!process.env.DATABASE_URL) {
+    return // will be skipped below
+  }
+
+  db = knex({
+    client: 'pg',
+    connection: process.env.DATABASE_URL,
+    acquireConnectionTimeout: 5000,
+  })
+
+  try {
+    // Check whether the vector extension exists.
+    const result = await db.raw(
+      `SELECT 1 FROM pg_extension WHERE extname = 'vector'`,
+    )
+    pgvectorAvailable = result.rows.length > 0
+  } catch {
+    pgvectorAvailable = false
+    return
+  }
+
+  if (!pgvectorAvailable) return
+
+  // Ensure the table exists for tests (mirrors the migration).
+  await db.raw('CREATE EXTENSION IF NOT EXISTS vector')
+  await db.schema.createTableIfNotExists('milestone_embeddings', (t) => {
+    t.uuid('milestone_id').primary()
+    t.specificType('embedding', 'vector(768)').notNullable()
+    t.timestamp('created_at', { useTz: true }).notNullable().defaultTo(db.fn.now())
+    t.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(db.fn.now())
+  })
+
+  repo = new MilestoneRepository(db)
+
+  // Clean up any leftover rows from a previous run.
+  await db('milestone_embeddings').whereIn('milestone_id', MILESTONE_IDS).delete()
+})
+
+afterAll(async () => {
+  if (db) {
+    if (pgvectorAvailable) {
+      await db('milestone_embeddings').whereIn('milestone_id', MILESTONE_IDS).delete()
+    }
+    await db.destroy()
+  }
+})
+
+// Utility: skip individual tests when pgvector is not available.
+function itWhenPgvector(name: string, fn: () => Promise<void>) {
+  if (!process.env.DATABASE_URL || !pgvectorAvailable) {
+    it.skip(name, fn)
+  } else {
+    it(name, fn)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MilestoneRepository – pgvector', () => {
+  itWhenPgvector('upsertEmbedding inserts a new record', async () => {
+    await repo.upsertEmbedding('m-001', makeVector(1))
+    const row = await repo.findEmbedding('m-001')
+    expect(row).not.toBeNull()
+    expect(row!.milestone_id).toBe('m-001')
+    expect(row!.embedding).toHaveLength(768)
+  })
+
+  itWhenPgvector('upsertEmbedding overwrites an existing record', async () => {
+    const v1 = makeVector(1)
+    const v2 = makeVector(99)
+    await repo.upsertEmbedding('m-001', v1)
+    await repo.upsertEmbedding('m-001', v2)
+    const row = await repo.findEmbedding('m-001')
+    // After upsert the first dimension should match v2, not v1.
+    expect(row!.embedding[0]).toBeCloseTo(v2[0], 5)
+  })
+
+  itWhenPgvector('nearestNeighbors returns empty array when milestone has no embedding', async () => {
+    const results = await repo.nearestNeighbors('does-not-exist')
+    expect(results).toEqual([])
+  })
+
+  itWhenPgvector('nearestNeighbors excludes the queried milestone from results', async () => {
+    // Seed several embeddings.
+    for (let i = 0; i < MILESTONE_IDS.length; i++) {
+      await repo.upsertEmbedding(MILESTONE_IDS[i], makeVector(i + 1))
+    }
+
+    const results = await repo.nearestNeighbors('m-001', 10)
+    const ids = results.map((r) => r.milestone_id)
+    expect(ids).not.toContain('m-001')
+  })
+
+  itWhenPgvector('nearestNeighbors respects the k limit', async () => {
+    for (let i = 0; i < MILESTONE_IDS.length; i++) {
+      await repo.upsertEmbedding(MILESTONE_IDS[i], makeVector(i + 1))
+    }
+
+    const results = await repo.nearestNeighbors('m-001', 2)
+    expect(results.length).toBeLessThanOrEqual(2)
+  })
+
+  itWhenPgvector('nearestNeighbors results are ordered by ascending distance', async () => {
+    for (let i = 0; i < MILESTONE_IDS.length; i++) {
+      await repo.upsertEmbedding(MILESTONE_IDS[i], makeVector(i + 1))
+    }
+
+    const results = await repo.nearestNeighbors('m-001', 4)
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].distance).toBeGreaterThanOrEqual(results[i - 1].distance)
+    }
+  })
+
+  itWhenPgvector('nearestNeighbors distance is between 0 and 2 (cosine)', async () => {
+    for (let i = 0; i < MILESTONE_IDS.length; i++) {
+      await repo.upsertEmbedding(MILESTONE_IDS[i], makeVector(i + 1))
+    }
+
+    const results = await repo.nearestNeighbors('m-001', 5)
+    for (const r of results) {
+      expect(r.distance).toBeGreaterThanOrEqual(0)
+      expect(r.distance).toBeLessThanOrEqual(2)
+    }
+  })
+
+  itWhenPgvector('identical vectors have distance ≈ 0', async () => {
+    const v = makeVector(42)
+    await repo.upsertEmbedding('m-001', v)
+    await repo.upsertEmbedding('m-002', v)
+
+    const results = await repo.nearestNeighbors('m-001', 1)
+    expect(results[0].milestone_id).toBe('m-002')
+    expect(results[0].distance).toBeCloseTo(0, 4)
+  })
+
+  itWhenPgvector('deleteEmbedding removes the record', async () => {
+    await repo.upsertEmbedding('m-001', makeVector(1))
+    await repo.deleteEmbedding('m-001')
+    const row = await repo.findEmbedding('m-001')
+    expect(row).toBeNull()
+  })
+
+  itWhenPgvector('findEmbedding returns null for unknown milestone', async () => {
+    const row = await repo.findEmbedding('non-existent-id')
+    expect(row).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Implements pgvector extension migration and embeddings table for milestone-evidence similarity search.

### Changes

- **Migration** `db/migrations/20260602000000_create_milestone_embeddings.cjs`
  - Enables `CREATE EXTENSION IF NOT EXISTS vector`
  - Creates `milestone_embeddings(milestone_id UUID PK, embedding vector(768), created_at, updated_at)`
  - Adds IVFFlat cosine-distance index (`lists=100`)
  - Rollback drops the table but preserves the extension

- **Repository** `src/repositories/milestoneRepository.ts` — `MilestoneRepository` class
  - `upsertEmbedding(milestoneId, embedding)` — insert or replace
  - `nearestNeighbors(milestoneId, k=5)` — cosine ANN search, excludes self, returns `{ milestone_id, distance }[]`
  - `findEmbedding(milestoneId)` — fetch stored record
  - `deleteEmbedding(milestoneId)` — remove record

- **Tests** `src/tests/milestoneEmbeddings.test.ts`
  - Automatically skipped when `DATABASE_URL` is unset or pgvector is unavailable
  - Covers: upsert, overwrite, empty-result, self-exclusion, k-limit, ordering, distance range, identical-vector distance ≈ 0, delete, null-find

- **Docs** `docs/milestones.md` — added pgvector setup, schema, migration commands, repository API reference, environment requirements

### Testing

Tests gate themselves on pgvector availability — no CI changes required:

```bash
DATABASE_URL=postgres://user:pw@localhost/disciplr_test npm test -- milestoneEmbeddings
```

Closes #466