### PR TITLE
feat: replace mock users in auth router with Prisma-backed role lookup

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -4,6 +4,8 @@
 
 The Disciplr backend enforces Role-Based Access Control (RBAC) across all protected endpoints. This document describes the role definitions, enforcement model, and trust hierarchy.
 
+User role and `lastLoginAt` state are persisted in the `users` table and read through Prisma-backed queries. The auth router does not maintain any in-process mock user cache, so role changes survive process restarts and future logins.
+
 ## Registration
 
 Endpoint: `POST /api/auth/register`
@@ -40,6 +42,8 @@ Endpoint: `POST /api/auth/register`
 - Passwords are hashed using `bcryptjs` with a cost factor of 12.
 - Email existence is not leaked during login (generic "Invalid credentials" error).
 - Password hashes are never returned in registration or login responses.
+- Role changes are persisted to the database and later read from the same `users` row.
+- Audit log metadata excludes email addresses and other request-body PII.
 
 ## Role Definitions
 
@@ -113,6 +117,13 @@ The enforcement model follows a **token-driven trust hierarchy**:
 3. **Role Assignment:** After verification, the token payload is extracted and `req.user.role` is set by the `authenticate` middleware.
 4. **Authorization Check:** The `authorize()` or `enforceRBAC()` middleware reads **exclusively** from `req.user.role`.
 5. **Deny by Default:** If `req.user.role` is not in the whitelist for a protected route, the request is rejected with `403 Forbidden`.
+
+### Persisted User State
+
+- The source of truth for user role and `lastLoginAt` is the `users` table.
+- `AuthService.login()` updates `lastLoginAt` as part of the login write path.
+- Legacy `POST /api/auth/login` requests that provide only `userId` read the persisted user row instead of fabricating in-memory role state.
+- Administrative role updates write through to the database, so subsequent requests and restarts observe the same role.
 
 ### Request Headers: Untrusted
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express'
+import { z } from 'zod'
 import { AuthService } from '../services/auth.service.js'
 import { registerSchema, loginSchema, refreshSchema } from '../lib/validation.js'
 import { createAuditLog } from '../lib/audit-logs.js'
@@ -6,38 +7,34 @@ import { authenticate } from '../middleware/auth.js'
 import { revokeSession, revokeAllUserSessions } from '../services/session.js'
 import { requireJson } from '../middleware/requireJson.js'
 import { AppError } from '../middleware/errorHandler.js'
+import { prisma } from '../lib/prisma.js'
+import { UserRole } from '../types/user.js'
 
 export const authRouter = Router();
 
-// ------------- Mock Users & Audit Logs Setup -------------
-type UserRole = "user" | "verifier" | "admin";
+const userIdOnlyLoginSchema = z.object({
+  userId: z.string().uuid('userId must be a valid UUID'),
+})
 
-type MockUser = {
-  id: string;
-  role: UserRole;
-  lastLoginAt: string | null;
-};
+const userRoleUpdateSchema = z.object({
+  role: z.nativeEnum(UserRole),
+})
 
-const users: MockUser[] = [];
-const supportedRoles: UserRole[] = ["user", "verifier", "admin"];
+const userIdParamSchema = z.object({
+  id: z.string().uuid('id must be a valid UUID'),
+})
 
-const getMockUserById = (userId: string): MockUser | undefined =>
-  users.find((user) => user.id === userId);
+const authUserSelect = {
+  id: true,
+  role: true,
+  lastLoginAt: true,
+} as const
 
-const upsertMockUser = (userId: string): MockUser => {
-  const existing = getMockUserById(userId);
-  if (existing) {
-    return existing;
-  }
-
-  const created: MockUser = {
-    id: userId,
-    role: "user",
-    lastLoginAt: null,
-  };
-  users.push(created);
-  return created;
-};
+const formatAuthUser = (user: { id: string; role: UserRole; lastLoginAt: Date | null }) => ({
+  id: user.id,
+  role: user.role,
+  lastLoginAt: user.lastLoginAt?.toISOString() ?? null,
+})
 
 // ------------- Endpoints -------------
 
@@ -58,17 +55,30 @@ authRouter.post('/register', requireJson, async (req, res, next) => {
 authRouter.post('/login', requireJson, async (req, res, next) => {
     // Support mock login if only userId is provided (from audit-logs feature branch)
     if (req.body.userId && !req.body.email && !req.body.password) {
-        const { userId } = req.body as { userId: string }
+        const result = userIdOnlyLoginSchema.safeParse(req.body)
+        if (!result.success) {
+            return next(AppError.validation('Validation failed', result.error.format()))
+        }
 
-        const now = new Date().toISOString();
-        const user = upsertMockUser(userId);
-        user.lastLoginAt = now;
+        const user = await prisma.user.findUnique({
+          where: { id: result.data.userId },
+          select: authUserSelect,
+        })
+        if (!user) {
+          return next(AppError.notFound('User not found'))
+        }
+
+        const updatedUser = await prisma.user.update({
+          where: { id: user.id },
+          data: { lastLoginAt: new Date() },
+          select: authUserSelect,
+        })
 
         const auditLog = await createAuditLog({
-          actor_user_id: user.id,
+          actor_user_id: updatedUser.id,
           action: "auth.login",
           target_type: "user",
-          target_id: user.id,
+          target_id: updatedUser.id,
           metadata: {
             userAgent: req.header("user-agent") ?? "unknown",
             ip: req.ip,
@@ -76,8 +86,8 @@ authRouter.post('/login', requireJson, async (req, res, next) => {
         });
 
         res.status(200).json({
-          user,
-          token: `mock-token-${user.id}`,
+          user: formatAuthUser(updatedUser),
+          token: `mock-token-${updatedUser.id}`,
           auditLogId: auditLog.id,
         });
         return;
@@ -145,40 +155,48 @@ authRouter.post('/logout-all', authenticate, async (req: Request, res: Response,
   res.json({ message: "Successfully logged out from all devices" });
 });
 
-authRouter.post('/users/:id/role', async (req, res, next) => {
-  const actorRole = req.header('x-user-role')
-  const actorId = req.header('x-user-id')
-
-  if (actorRole !== 'admin') {
+authRouter.post('/users/:id/role', requireJson, authenticate, async (req, res, next) => {
+  if (req.user?.role !== UserRole.ADMIN) {
     return next(AppError.forbidden('Only admin users can change roles'))
   }
 
-  if (!actorId) {
-    return next(AppError.badRequest('Missing x-user-id header'))
+  const paramsResult = userIdParamSchema.safeParse(req.params)
+  if (!paramsResult.success) {
+    return next(AppError.validation('Validation failed', paramsResult.error.format()))
   }
 
-  const { role } = req.body as { role?: string };
-  if (!role || !supportedRoles.includes(role as UserRole)) {
-    return next(AppError.validation('Invalid role. Supported roles: user, verifier, admin'))
+  const bodyResult = userRoleUpdateSchema.safeParse(req.body)
+  if (!bodyResult.success) {
+    return next(AppError.validation('Validation failed', bodyResult.error.format()))
   }
 
-  const user = upsertMockUser(req.params.id);
-  const previousRole = user.role;
-  user.role = role as UserRole;
+  const user = await prisma.user.findUnique({
+    where: { id: paramsResult.data.id },
+    select: authUserSelect,
+  })
+  if (!user) {
+    return next(AppError.notFound('User not found'))
+  }
+
+  const updatedUser = await prisma.user.update({
+    where: { id: user.id },
+    data: { role: bodyResult.data.role },
+    select: authUserSelect,
+  })
 
   const auditLog = await createAuditLog({
-    actor_user_id: actorId,
+    actor_user_id: req.user.userId,
     action: "auth.role_changed",
     target_type: "user",
     target_id: user.id,
     metadata: {
-      previousRole,
-      newRole: user.role,
+      previousRole: user.role,
+      newRole: updatedUser.role,
     },
   });
 
   res.status(200).json({
-    user,
+    user: formatAuthUser(updatedUser),
     auditLogId: auditLog.id,
   });
 });

--- a/src/routes/auth.users.test.ts
+++ b/src/routes/auth.users.test.ts
@@ -1,0 +1,183 @@
+import { jest } from '@jest/globals'
+import express from 'express'
+import request from 'supertest'
+import { UserRole } from '../types/user.js'
+
+type PersistedUser = {
+  id: string
+  email: string
+  role: UserRole
+  lastLoginAt: Date | null
+}
+
+const users = new Map<string, PersistedUser>()
+const createAuditLog = jest.fn(async () => ({ id: 'audit-1' }))
+
+const cloneSelectedUser = (
+  user: PersistedUser | null | undefined,
+  select?: Record<string, boolean>,
+): Record<string, unknown> | null => {
+  if (!user) return null
+  if (!select) return { ...user }
+
+  return Object.fromEntries(
+    Object.entries(select)
+      .filter(([, include]) => include)
+      .map(([key]) => [key, user[key as keyof PersistedUser]]),
+  )
+}
+
+const prisma = {
+  user: {
+    findUnique: jest.fn(async ({ where, select }: { where: { id?: string; email?: string }; select?: Record<string, boolean> }) => {
+      const user = where.id
+        ? users.get(where.id)
+        : Array.from(users.values()).find((entry) => entry.email === where.email)
+      return cloneSelectedUser(user, select)
+    }),
+    update: jest.fn(async ({ where, data, select }: { where: { id: string }; data: Partial<PersistedUser>; select?: Record<string, boolean> }) => {
+      const existing = users.get(where.id)
+      if (!existing) {
+        throw new Error('User not found')
+      }
+
+      const updated: PersistedUser = {
+        ...existing,
+        ...data,
+      }
+      users.set(where.id, updated)
+      return cloneSelectedUser(updated, select)
+    }),
+  },
+}
+
+jest.unstable_mockModule('../lib/prisma.js', () => ({ prisma }))
+jest.unstable_mockModule('../lib/audit-logs.js', () => ({ createAuditLog }))
+jest.unstable_mockModule('../middleware/auth.js', () => ({
+  authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = {
+      userId: req.header('x-test-user-id') ?? 'admin-user-id',
+      role: (req.header('x-test-role') as UserRole | null) ?? UserRole.ADMIN,
+    } as any
+    next()
+  },
+}))
+jest.unstable_mockModule('../services/auth.service.js', () => ({
+  AuthService: {
+    register: jest.fn(),
+    login: jest.fn(),
+    refresh: jest.fn(),
+    logout: jest.fn(),
+  },
+}))
+jest.unstable_mockModule('../services/session.js', () => ({
+  revokeSession: jest.fn(),
+  revokeAllUserSessions: jest.fn(),
+}))
+
+const { authRouter } = await import('./auth.js')
+const { errorHandler } = await import('../middleware/errorHandler.js')
+
+describe('auth router persisted user role paths', () => {
+  const buildApp = () => {
+    const app = express()
+    app.use(express.json())
+    app.use('/api/auth', authRouter)
+    app.use(errorHandler)
+    return app
+  }
+
+  beforeEach(() => {
+    users.clear()
+    users.set('11111111-1111-1111-1111-111111111111', {
+      id: '11111111-1111-1111-1111-111111111111',
+      email: 'verifier@example.com',
+      role: UserRole.VERIFIER,
+      lastLoginAt: new Date('2026-01-01T00:00:00.000Z'),
+    })
+    users.set('22222222-2222-2222-2222-222222222222', {
+      id: '22222222-2222-2222-2222-222222222222',
+      email: 'member@example.com',
+      role: UserRole.USER,
+      lastLoginAt: null,
+    })
+    createAuditLog.mockClear()
+    prisma.user.findUnique.mockClear()
+    prisma.user.update.mockClear()
+  })
+
+  it('reads the persisted role for userId-only login and updates lastLoginAt', async () => {
+    const app = buildApp()
+
+    const response = await request(app)
+      .post('/api/auth/login')
+      .send({ userId: '11111111-1111-1111-1111-111111111111' })
+
+    expect(response.status).toBe(200)
+    expect(response.body).toMatchObject({
+      user: {
+        id: '11111111-1111-1111-1111-111111111111',
+        role: UserRole.VERIFIER,
+      },
+      token: 'mock-token-11111111-1111-1111-1111-111111111111',
+      auditLogId: 'audit-1',
+    })
+
+    expect(typeof response.body.user.lastLoginAt).toBe('string')
+    expect(new Date(response.body.user.lastLoginAt).getTime()).toBeGreaterThan(new Date('2026-01-01T00:00:00.000Z').getTime())
+    expect(users.get('11111111-1111-1111-1111-111111111111')?.role).toBe(UserRole.VERIFIER)
+    expect(createAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      actor_user_id: '11111111-1111-1111-1111-111111111111',
+      action: 'auth.login',
+      metadata: expect.objectContaining({
+        userAgent: 'unknown',
+      }),
+    }))
+    expect(createAuditLog.mock.calls[0]?.[0]?.metadata).not.toHaveProperty('email')
+  })
+
+  it('updates persisted roles via prisma instead of process memory', async () => {
+    const app = buildApp()
+
+    const response = await request(app)
+      .post('/api/auth/users/22222222-2222-2222-2222-222222222222/role')
+      .set('x-test-user-id', '99999999-9999-9999-9999-999999999999')
+      .set('x-test-role', UserRole.ADMIN)
+      .send({ role: UserRole.ADMIN })
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({
+      user: {
+        id: '22222222-2222-2222-2222-222222222222',
+        role: UserRole.ADMIN,
+        lastLoginAt: null,
+      },
+      auditLogId: 'audit-1',
+    })
+    expect(users.get('22222222-2222-2222-2222-222222222222')?.role).toBe(UserRole.ADMIN)
+    expect(createAuditLog).toHaveBeenCalledWith({
+      actor_user_id: '99999999-9999-9999-9999-999999999999',
+      action: 'auth.role_changed',
+      target_type: 'user',
+      target_id: '22222222-2222-2222-2222-222222222222',
+      metadata: {
+        previousRole: UserRole.USER,
+        newRole: UserRole.ADMIN,
+      },
+    })
+  })
+
+  it('rejects invalid role payloads before mutating the persisted user row', async () => {
+    const app = buildApp()
+
+    const response = await request(app)
+      .post('/api/auth/users/22222222-2222-2222-2222-222222222222/role')
+      .set('x-test-role', UserRole.ADMIN)
+      .send({ role: 'SUPERUSER' })
+
+    expect(response.status).toBe(400)
+    expect(response.body.error.code).toBe('VALIDATION_ERROR')
+    expect(users.get('22222222-2222-2222-2222-222222222222')?.role).toBe(UserRole.USER)
+    expect(createAuditLog).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -27,7 +27,8 @@ export class AuthService {
     }
 
     static async login(input: LoginInput) {
-        const user = await getPrisma().user.findUnique({ where: { email: input.email } })
+        const prisma = getPrisma()
+        const user = await prisma.user.findUnique({ where: { email: input.email } })
         if (!user) {
             throw new Error('Invalid credentials')
         }
@@ -37,31 +38,38 @@ export class AuthService {
             throw new Error('Invalid credentials')
         }
 
-        await getPrisma().user.update({
-            where: { id: user.id },
-            data: { lastLoginAt: new Date() },
-        })
-
         const jti = randomUUID()
+        const sessionId = randomUUID()
+        const lastLoginAt = new Date()
         const accessToken = generateAccessToken({ userId: user.id, role: user.role, jti })
         const refreshTokenValue = generateRefreshToken({ userId: user.id })
-
-        // 1. Record session for access token (middleware/auth.ts compatibility)
         const accessExpiresAt = new Date(Date.now() + 15 * 60 * 1000) // 15 minutes
-        await recordSession(user.id, jti, accessExpiresAt)
-
-        // 2. Store hashed refresh token — the raw value is only returned to the client
         const tokenHash = hashToken(refreshTokenValue)
-        await getPrisma().refreshToken.create({
-            data: {
-                token: tokenHash,
-                userId: user.id,
-                expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
-            },
+
+        const loggedInUser = await prisma.$transaction(async (tx) => {
+            const updatedUser = await tx.user.update({
+                where: { id: user.id },
+                data: { lastLoginAt },
+            })
+
+            await tx.$executeRaw`
+                INSERT INTO "sessions" ("id", "user_id", "jti", "expires_at")
+                VALUES (${sessionId}, ${user.id}, ${jti}, ${accessExpiresAt})
+            `
+
+            await tx.refreshToken.create({
+                data: {
+                    token: tokenHash,
+                    userId: user.id,
+                    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
+                },
+            })
+
+            return updatedUser
         })
 
         return {
-            user: { id: user.id, email: user.email, role: user.role },
+            user: { id: loggedInUser.id, email: loggedInUser.email, role: loggedInUser.role },
             accessToken,
             refreshToken: refreshTokenValue,
         }

--- a/src/tests/auth.persistence.test.ts
+++ b/src/tests/auth.persistence.test.ts
@@ -1,0 +1,131 @@
+import { jest } from '@jest/globals'
+import express from 'express'
+import request from 'supertest'
+import { UserRole } from '../types/user.js'
+
+type PersistedUser = {
+  id: string
+  email: string
+  role: UserRole
+  lastLoginAt: Date | null
+}
+
+const users = new Map<string, PersistedUser>()
+const createAuditLog = jest.fn(async () => ({ id: 'audit-persist' }))
+
+const cloneSelectedUser = (
+  user: PersistedUser | null | undefined,
+  select?: Record<string, boolean>,
+): Record<string, unknown> | null => {
+  if (!user) return null
+  if (!select) return { ...user }
+
+  return Object.fromEntries(
+    Object.entries(select)
+      .filter(([, include]) => include)
+      .map(([key]) => [key, user[key as keyof PersistedUser]]),
+  )
+}
+
+const prisma = {
+  user: {
+    findUnique: jest.fn(async ({ where, select }: { where: { id?: string; email?: string }; select?: Record<string, boolean> }) => {
+      const user = where.id
+        ? users.get(where.id)
+        : Array.from(users.values()).find((entry) => entry.email === where.email)
+      return cloneSelectedUser(user, select)
+    }),
+    update: jest.fn(async ({ where, data, select }: { where: { id: string }; data: Partial<PersistedUser>; select?: Record<string, boolean> }) => {
+      const existing = users.get(where.id)
+      if (!existing) {
+        throw new Error('User not found')
+      }
+
+      const updated: PersistedUser = {
+        ...existing,
+        ...data,
+      }
+      users.set(where.id, updated)
+      return cloneSelectedUser(updated, select)
+    }),
+  },
+}
+
+const installMocks = () => {
+  jest.unstable_mockModule('../lib/prisma.js', () => ({ prisma }))
+  jest.unstable_mockModule('../lib/audit-logs.js', () => ({ createAuditLog }))
+  jest.unstable_mockModule('../middleware/auth.js', () => ({
+    authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+      req.user = {
+        userId: req.header('x-test-user-id') ?? 'admin-user-id',
+        role: (req.header('x-test-role') as UserRole | null) ?? UserRole.ADMIN,
+      } as any
+      next()
+    },
+  }))
+  jest.unstable_mockModule('../services/auth.service.js', () => ({
+    AuthService: {
+      register: jest.fn(),
+      login: jest.fn(),
+      refresh: jest.fn(),
+      logout: jest.fn(),
+    },
+  }))
+  jest.unstable_mockModule('../services/session.js', () => ({
+    revokeSession: jest.fn(),
+    revokeAllUserSessions: jest.fn(),
+  }))
+}
+
+const loadApp = async () => {
+  jest.resetModules()
+  installMocks()
+
+  const { authRouter } = await import('../routes/auth.js')
+  const { errorHandler } = await import('../middleware/errorHandler.js')
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api/auth', authRouter)
+  app.use(errorHandler)
+  return app
+}
+
+describe('auth role persistence across router reloads', () => {
+  beforeEach(() => {
+    users.clear()
+    users.set('33333333-3333-3333-3333-333333333333', {
+      id: '33333333-3333-3333-3333-333333333333',
+      email: 'restart@example.com',
+      role: UserRole.USER,
+      lastLoginAt: null,
+    })
+    createAuditLog.mockClear()
+    prisma.user.findUnique.mockClear()
+    prisma.user.update.mockClear()
+  })
+
+  it('persists a role change across simulated process restarts', async () => {
+    const appBeforeRestart = await loadApp()
+
+    const roleUpdate = await request(appBeforeRestart)
+      .post('/api/auth/users/33333333-3333-3333-3333-333333333333/role')
+      .set('x-test-user-id', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+      .set('x-test-role', UserRole.ADMIN)
+      .send({ role: UserRole.ADMIN })
+
+    expect(roleUpdate.status).toBe(200)
+    expect(users.get('33333333-3333-3333-3333-333333333333')?.role).toBe(UserRole.ADMIN)
+
+    const appAfterRestart = await loadApp()
+    const loginAfterRestart = await request(appAfterRestart)
+      .post('/api/auth/login')
+      .send({ userId: '33333333-3333-3333-3333-333333333333' })
+
+    expect(loginAfterRestart.status).toBe(200)
+    expect(loginAfterRestart.body.user).toMatchObject({
+      id: '33333333-3333-3333-3333-333333333333',
+      role: UserRole.ADMIN,
+    })
+  })
+})


### PR DESCRIPTION
Closes: #426 

## Summary

- remove the in-memory mock users array from `src/routes/auth.ts`
- read and update auth user role and `lastLoginAt` through Prisma-backed `users` rows
- make auth role changes use authenticated admin identity instead of spoofable role headers
- update `AuthService.login()` so `lastLoginAt`, session creation, and refresh-token creation are committed in one Prisma transaction
- add route coverage for persisted role reads and a restart-style test proving role changes survive router reloads
- update auth docs to describe persisted role state and remove in-process state assumptions

## Testing

Not run in this workspace.

Reason:
- `node_modules` is not installed here
- per instruction, no package installation was performed

## Notes

- branch: `feat/auth-remove-mock-users`
- commit: `84638f5`