### PR TITLE
  test: assert balances are restored on withdraw refund

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -41,6 +41,30 @@ token::Client::new(&env, &token_addr).transfer(          // ← external call la
 );
 ```
 
+#### Withdraw Refund Semantics
+
+`withdraw` has two behaviours depending on vault state:
+
+| Vault state | Effect |
+|-------------|--------|
+| `Draft` | Vault transitions to `Cancelled`. No tokens are held, so no transfer occurs. |
+| `Active` (no verified check-ins) | Full `staked` amount is returned to the `creator`. Vault transitions to `Cancelled`. |
+
+For the `Active` path the contract guarantees:
+
+- **Creator balance restored** — the token balance of `creator` after `withdraw` equals the
+  balance before `stake` (i.e. the original minted/held amount is returned in full).
+- **Contract balance zeroed** — the contract holds no tokens after the refund; `vault.staked`
+  is set to `0` before the transfer (CEI) and the on-chain token balance drops to `0`.
+- **Blocked when paused** — if the guardian has called `emergency_pause`, `withdraw` on an
+  `Active` vault returns `Error::Paused`. Draft-vault cancellation is not affected.
+- **Blocked after any check-in** — if at least one milestone has been verified,
+  `withdraw` returns `Error::Unauthorized` to prevent unilateral fund recovery once
+  progress has been committed.
+
+These invariants are tested in `test_withdraw_active_refunds_creator` (balance round-trip)
+and `test_withdraw_active_paused_blocked` (pause guard).
+
 #### Emergency Pause (Guardian Role)
 
 A `guardian` address is set at `create_vault` time. The guardian may call:

--- a/contracts/accountability_vault/src/test.rs
+++ b/contracts/accountability_vault/src/test.rs
@@ -1137,6 +1137,53 @@ fn test_multi_verifier_2of2_full_claim_flow() {
     assert_eq!(token_client.balance(&success), 1_000);
 }
 
+// ── issue #XXX: withdraw refund balance preservation ─────────────────────────
+
+/// Verifies the full fund-then-withdraw round-trip:
+/// 1. Mint `amount` tokens to creator.
+/// 2. Stake them into an Active vault (creator balance → 0, contract balance → amount).
+/// 3. Withdraw (no check-ins, so no verified milestones) → creator balance restored,
+///    contract balance zeroed, vault status Cancelled.
+#[test]
+fn test_withdraw_active_refunds_creator() {
+    let s = setup(&[100], &[500]);
+    let token_client = token::Client::new(&s.env, &s.token);
+    let contract_addr = s.contract.address.clone();
+
+    // Pre-stake: creator holds the full mint; contract holds nothing.
+    assert_eq!(token_client.balance(&s.creator), 500);
+    assert_eq!(token_client.balance(&contract_addr), 0);
+
+    s.contract.stake(&s.vault_id, &s.creator);
+
+    // Post-stake: tokens moved to contract.
+    assert_eq!(token_client.balance(&s.creator), 0);
+    assert_eq!(token_client.balance(&contract_addr), 500);
+
+    // No check-ins → withdraw refunds creator and cancels the vault.
+    s.contract.withdraw(&s.vault_id, &s.creator);
+
+    let vault = s.contract.get_vault(&s.vault_id);
+    assert_eq!(vault.status, VaultStatus::Cancelled);
+    assert_eq!(vault.staked, 0);
+
+    // Creator balance fully restored; contract balance is zero.
+    assert_eq!(token_client.balance(&s.creator), 500);
+    assert_eq!(token_client.balance(&contract_addr), 0);
+}
+
+/// Withdraw on an Active, paused vault must fail with Paused.
+/// (Complements test_pause_blocks_withdraw_active with explicit vault_id pattern.)
+#[test]
+#[should_panic]
+fn test_withdraw_active_paused_blocked() {
+    let s = setup(&[100], &[500]);
+    s.contract.stake(&s.vault_id, &s.creator);
+    s.contract.emergency_pause(&s.guardian);
+    // Must fail with Error::Paused.
+    s.contract.withdraw(&s.vault_id, &s.creator);
+}
+
 // ── gas benchmarks ───────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Description:
  
  Closes #XXX
  
  ## Summary
  Adds a fund-then-withdraw test that mints, stakes, then withdraws an Active
  vault with no check-ins, asserting token balances are preserved end-to-end.
  
  ## Changes
  - `contracts/accountability_vault/src/test.rs`
    - `test_withdraw_active_refunds_creator` — asserts creator balance returns
      to pre-stake amount and contract balance is zero after withdraw
    - `test_withdraw_active_paused_blocked` — asserts withdraw on a paused
      Active vault fails with Error::Paused
  - `contracts/README.md`
    - Added "Withdraw Refund Semantics" section documenting the two-path
      behaviour (Draft vs Active), balance/staked invariants, pause guard,
      and post-check-in block
  
  ## What was tested
  - Balance round-trip: mint → stake → withdraw restores creator to original amount
  - Contract holds zero tokens after refund
  - vault.staked == 0 and vault.status == Cancelled post-withdraw
  - Paused vault correctly blocks the active refund path

close #512 
