### PR TITLE
test(accountability_vault): add cancel-then-stake terminal-state regression coverage closes (#519)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -64,6 +64,17 @@ addresses from the verifier set (or the optional oracle) have approved it.
 - The threshold must be ≥ 1 and ≤ `verifiers.len()`; otherwise `create_vault` returns
   `Error::InvalidThreshold`.
 
+#### Token Admin Balance Conservation
+
+The token admin account is only used in tests to mint initial balances to the creator and
+must not be debited or credited by vault lifecycle operations. Invariant tests assert that
+the token admin balance is unchanged across:
+
+- success path: `stake -> check_in -> claim`
+- slash path: `stake -> slash_on_miss`
+
+This guards against unintended mint/burn side effects during settlement flows.
+
 #### Evidence Hash Binding
 
 `check_in` accepts an `evidence_hash: BytesN<32>` parameter — a 32-byte digest (e.g.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -75,6 +75,17 @@ the token admin balance is unchanged across:
 
 This guards against unintended mint/burn side effects during settlement flows.
 
+#### Terminal-State Rule: Cancelled Vaults Cannot Be Re-Staked
+
+Once a vault transitions to `Cancelled`, staking must remain permanently blocked. Regression
+tests lock this down for both cancellation entry points:
+
+- `cancel_vault` path (Draft cancellation)
+- `withdraw` path (Active refund cancellation)
+
+In both scenarios, a subsequent `stake` call must fail with `Error::NotDraft`. This preserves
+the lifecycle state machine and prevents reopening a terminal vault state.
+
 #### Evidence Hash Binding
 
 `check_in` accepts an `evidence_hash: BytesN<32>` parameter — a 32-byte digest (e.g.

--- a/contracts/accountability_vault/src/test.rs
+++ b/contracts/accountability_vault/src/test.rs
@@ -26,6 +26,7 @@ struct Setup {
     env: Env,
     contract: AccountabilityVaultClient<'static>,
     token: Address,
+    token_admin: Address,
     #[allow(dead_code)]
     token_admin_client: token::StellarAssetClient<'static>,
     creator: Address,
@@ -97,6 +98,7 @@ fn setup_with_oracle(
         env,
         contract,
         token,
+        token_admin,
         token_admin_client,
         creator,
         verifier,
@@ -105,6 +107,18 @@ fn setup_with_oracle(
         failure,
         vault_id,
     }
+}
+
+fn assert_token_admin_balance_unchanged(
+    token_client: &token::Client<'_>,
+    token_admin: &Address,
+    expected_balance: i128,
+) {
+    assert_eq!(
+        token_client.balance(token_admin),
+        expected_balance,
+        "token admin balance must remain unchanged by vault lifecycle operations",
+    );
 }
 
 // ── existing lifecycle tests ─────────────────────────────────────────────────
@@ -164,6 +178,45 @@ fn test_slash_on_miss() {
 
     let token_client = token::Client::new(&s.env, &s.token);
     assert_eq!(token_client.balance(&s.failure), 500);
+}
+
+#[test]
+fn test_token_admin_balance_invariant_success_lifecycle() {
+    let s = setup(&[100, 200], &[300, 700]);
+    let token_client = token::Client::new(&s.env, &s.token);
+    let admin_balance_before = token_client.balance(&s.token_admin);
+
+    // Stake should only move creator -> vault.
+    s.contract.stake(&s.vault_id, &s.creator);
+    assert_token_admin_balance_unchanged(&token_client, &s.token_admin, admin_balance_before);
+
+    // Check-ins should not move any tokens.
+    s.contract
+        .check_in(&s.vault_id, &s.verifier, &0, &evidence_hash(&s.env, 7));
+    assert_token_admin_balance_unchanged(&token_client, &s.token_admin, admin_balance_before);
+    s.contract
+        .check_in(&s.vault_id, &s.verifier, &1, &evidence_hash(&s.env, 9));
+    assert_token_admin_balance_unchanged(&token_client, &s.token_admin, admin_balance_before);
+
+    // Claim should move vault -> success destination only.
+    s.contract.claim(&s.vault_id, &s.creator);
+    assert_token_admin_balance_unchanged(&token_client, &s.token_admin, admin_balance_before);
+}
+
+#[test]
+fn test_token_admin_balance_invariant_slash_lifecycle() {
+    let s = setup(&[100], &[500]);
+    let token_client = token::Client::new(&s.env, &s.token);
+    let admin_balance_before = token_client.balance(&s.token_admin);
+
+    // Stake should only move creator -> vault.
+    s.contract.stake(&s.vault_id, &s.creator);
+    assert_token_admin_balance_unchanged(&token_client, &s.token_admin, admin_balance_before);
+
+    // Slash should move vault -> failure destination only.
+    s.env.ledger().set_timestamp(2_000);
+    s.contract.slash_on_miss(&s.vault_id);
+    assert_token_admin_balance_unchanged(&token_client, &s.token_admin, admin_balance_before);
 }
 
 #[test]

--- a/contracts/accountability_vault/src/test.rs
+++ b/contracts/accountability_vault/src/test.rs
@@ -121,6 +121,15 @@ fn assert_token_admin_balance_unchanged(
     );
 }
 
+fn assert_stake_rejected_with_not_draft(s: &Setup) {
+    let result = s.contract.try_stake(&s.vault_id, &s.creator);
+    assert!(
+        matches!(result, Err(Ok(Error::NotDraft))),
+        "stake after cancellation must be rejected with Error::NotDraft, got: {:?}",
+        result,
+    );
+}
+
 // ── existing lifecycle tests ─────────────────────────────────────────────────
 
 #[test]
@@ -228,6 +237,17 @@ fn test_withdraw_draft_cancels() {
 }
 
 #[test]
+fn test_cancel_vault_then_stake_rejected_with_not_draft() {
+    let s = setup(&[100], &[500]);
+    s.contract.cancel_vault(&s.vault_id, &s.creator);
+    let vault = s.contract.get_vault(&s.vault_id);
+    assert_eq!(vault.status, VaultStatus::Cancelled);
+
+    // Terminal-state regression guard: Cancelled vault must never accept stake.
+    assert_stake_rejected_with_not_draft(&s);
+}
+
+#[test]
 fn test_withdraw_active_refunds_creator() {
     let s = setup(&[100], &[500]);
     // Fund the vault and then call withdraw without any check-ins.
@@ -239,6 +259,19 @@ fn test_withdraw_active_refunds_creator() {
 
     let token_client = token::Client::new(&s.env, &s.token);
     assert_eq!(token_client.balance(&s.creator), 500);
+}
+
+#[test]
+fn test_withdraw_cancelled_then_stake_rejected_with_not_draft() {
+    let s = setup(&[100], &[500]);
+    s.contract.stake(&s.vault_id, &s.creator);
+    s.contract.withdraw(&s.vault_id, &s.creator);
+
+    let vault = s.contract.get_vault(&s.vault_id);
+    assert_eq!(vault.status, VaultStatus::Cancelled);
+
+    // Terminal-state regression guard: once cancelled via withdraw, staking is blocked.
+    assert_stake_rejected_with_not_draft(&s);
 }
 
 #[test]

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -5,7 +5,7 @@ The application uses an abstraction for notification delivery, allowing for mult
 ## Architecture
 
 1.  **Job Enqueueing**: Notifications are enqueued as `notification.send` jobs.
-2.  **Job Execution**: The job handler uses `NotificationService` to select and execute the configured provider.
+2.  **Job Execution**: The job handler uses an injected `NotificationService` instance to select and execute the configured provider.
 3.  **Retries**: Jobs are automatically retried with exponential backoff on failure.
 
 ## Provider Interface
@@ -21,10 +21,17 @@ export interface NotificationProvider {
 
 ## Configuration
 
-The active provider is selected via the `NOTIFICATION_PROVIDER` environment variable.
+The active provider is selected at boot via the validated `NOTIFICATION_PROVIDER` environment variable and injected through `src/index.ts` -> `src/app-bootstrap.ts` -> `BackgroundJobSystem`.
 Available providers:
 - `email`: Sends via Email (Stub implementation).
 - `console`: Logs to console (Default for local development).
+
+### Fail-fast behavior
+
+- `NotificationService` is initialized with a provider registry and a default provider name.
+- If the configured provider name is unknown, startup fails with an explicit error.
+- If a runtime override requests an unknown provider, the send operation throws immediately.
+- Silent fallback to `console` for unknown provider names is intentionally removed to avoid masking misconfiguration.
 
 ## Observability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@prisma/client": "^6.19.2",
         "@stellar/stellar-sdk": "^14.5.0",
+        "argon2": "^0.44.0",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^11.10.0",
         "cors": "^2.8.6",
@@ -622,6 +623,12 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
       "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2041,6 +2048,15 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4345,6 +4361,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argon2": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "dev": true,
@@ -5213,9 +5245,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6911,7 +6959,6 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -8356,6 +8403,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -8394,6 +8450,17 @@
       "version": "1.6.7",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -8800,7 +8867,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9897,7 +9963,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9908,7 +9973,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11460,7 +11524,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@prisma/client": "^6.19.2",
     "@stellar/stellar-sdk": "^14.5.0",
+    "argon2": "^0.44.0",
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^11.10.0",
     "cors": "^2.8.6",
@@ -39,8 +40,7 @@
     "jsonwebtoken": "^9.0.3",
     "pg": "^8.20.0",
     "prom-client": "^15.0.0",
-    "zod": "^4.3.6",
-    "argon2": "^0.29.4"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@asteasolutions/zod-to-openapi": "^8.5.0",
@@ -53,7 +53,6 @@
     "@types/express": "^4.17.21",
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
-    
     "@types/node": "^22.9.0",
     "@types/pg": "^8.16.0",
     "@types/supertest": "^6.0.3",

--- a/src/app-bootstrap.ts
+++ b/src/app-bootstrap.ts
@@ -27,9 +27,18 @@ import {
   securityMetricsMiddleware,
   securityRateLimitMiddleware,
 } from './security/abuse-monitor.js'
+import { createNotificationService, type NotificationService } from './services/notifications/factory.js'
 
-export function bootstrapApp() {
-  const jobSystem = new BackgroundJobSystem()
+type BootstrapOptions = {
+  notificationService?: NotificationService
+  notificationProviderName?: string
+}
+
+export function bootstrapApp(options: BootstrapOptions = {}) {
+  const notificationService =
+    options.notificationService ??
+    createNotificationService(options.notificationProviderName ?? process.env.NOTIFICATION_PROVIDER ?? 'console')
+  const jobSystem = new BackgroundJobSystem(notificationService)
   configureExportJobRepository(createKnexExportJobRepository(db))
 
   app.use(securityMetricsMiddleware)

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -114,6 +114,7 @@ export const envSchema = z
     JOB_QUEUE_POLL_INTERVAL_MS: positiveInt(250),
     JOB_HISTORY_LIMIT: positiveInt(50),
     ENABLE_JOB_SCHEDULER: z.string().optional(),
+    NOTIFICATION_PROVIDER: z.enum(["email", "console"]).default("console"),
 
     // ── ETL ───────────────────────────────────────────────────────
     ETL_INTERVAL_MINUTES: positiveInt(5),

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,13 +24,17 @@ import {
 import { initializeDatabase, closeDatabase } from './db/database.js'
 import { etlWorker } from './services/etlWorker.js'
 import { createShutdownHandler } from './server/shutdown.js'
+import { getEnv } from './config/index.js'
+import { createNotificationService } from './services/notifications/factory.js'
 
 const PORT = process.env.PORT ?? 3000
 
 // Initialize SQLite database for analytics
 initializeDatabase()
 
-const { jobSystem } = bootstrapApp()
+const env = getEnv()
+const notificationService = createNotificationService(env.NOTIFICATION_PROVIDER)
+const { jobSystem } = bootstrapApp({ notificationService })
 
 jobSystem.start()
 

--- a/src/jobs/handlers.ts
+++ b/src/jobs/handlers.ts
@@ -17,13 +17,12 @@ const logJob = (type: JobType, message: string): void => {
   console.log(`[jobs:${type}] ${message}`)
 }
 
-export const defaultJobHandlers: JobHandlerRegistry = {
+export const createDefaultJobHandlers = (
+  notificationService: NotificationService,
+): JobHandlerRegistry => ({
   'notification.send': async (payload, context) => {
-    await NotificationService.send(payload.recipient, payload.subject, payload.body)
-    logJob(
-      'notification.send',
-      `executed job_id=${context.jobId} attempt=${context.attempt}`,
-    )
+    await notificationService.send(payload.recipient, payload.subject, payload.body)
+    logJob('notification.send', `executed job_id=${context.jobId} attempt=${context.attempt}`)
   },
   'deadline.check': async (payload, context) => {
     await sleep(30)
@@ -66,4 +65,4 @@ export const defaultJobHandlers: JobHandlerRegistry = {
       `exportJobId=${payload.exportJobId} attempt=${context.attempt}`,
     )
   },
-}
+})

--- a/src/jobs/system.ts
+++ b/src/jobs/system.ts
@@ -1,7 +1,11 @@
-import { defaultJobHandlers } from './handlers.js'
+import { createDefaultJobHandlers } from './handlers.js'
 import { InMemoryJobQueue, type QueueMetrics, type QueuedJobReceipt } from './queue.js'
 import { type EnqueueOptions, type JobPayloadByType, type JobType } from './types.js'
 import { recoverPendingExportJobs } from '../services/exportQueue.js'
+import {
+  createNotificationService,
+  type NotificationService,
+} from '../services/notifications/factory.js'
 
 const parsePositiveInteger = (value: string | undefined, fallback: number): number => {
   if (!value) {
@@ -22,18 +26,21 @@ export class BackgroundJobSystem {
   private started = false
   private shuttingDown = false
 
-  constructor() {
+  constructor(notificationService?: NotificationService) {
     this.queue = new InMemoryJobQueue({
       concurrency: parsePositiveInteger(process.env.JOB_WORKER_CONCURRENCY, 2),
       pollIntervalMs: parsePositiveInteger(process.env.JOB_QUEUE_POLL_INTERVAL_MS, 250),
       historyLimit: parsePositiveInteger(process.env.JOB_HISTORY_LIMIT, 50),
     })
+    const resolvedNotificationService =
+      notificationService ?? createNotificationService(process.env.NOTIFICATION_PROVIDER ?? 'console')
+    const handlers = createDefaultJobHandlers(resolvedNotificationService)
 
-    this.queue.registerHandler('notification.send', defaultJobHandlers['notification.send'])
-    this.queue.registerHandler('deadline.check', defaultJobHandlers['deadline.check'])
-    this.queue.registerHandler('oracle.call', defaultJobHandlers['oracle.call'])
-    this.queue.registerHandler('analytics.recompute', defaultJobHandlers['analytics.recompute'])
-    this.queue.registerHandler('export.generate', defaultJobHandlers['export.generate'])
+    this.queue.registerHandler('notification.send', handlers['notification.send'])
+    this.queue.registerHandler('deadline.check', handlers['deadline.check'])
+    this.queue.registerHandler('oracle.call', handlers['oracle.call'])
+    this.queue.registerHandler('analytics.recompute', handlers['analytics.recompute'])
+    this.queue.registerHandler('export.generate', handlers['export.generate'])
   }
 
   start(): void {

--- a/src/services/expirationScheduler.ts
+++ b/src/services/expirationScheduler.ts
@@ -1,6 +1,7 @@
 import db from '../db/index.js'
 import { BackgroundJobSystem } from '../jobs/system.js'
 import { getIdempotentResponse, saveIdempotentResponse } from './idempotency.js'
+import { createNotificationService } from './notifications/factory.js'
 
 const BATCH_SIZE = 50
 
@@ -12,7 +13,9 @@ let _defaultJobSystem: BackgroundJobSystem | null = null
 
 const getDefaultJobSystem = (): BackgroundJobSystem => {
   if (!_defaultJobSystem) {
-    _defaultJobSystem = new BackgroundJobSystem()
+    _defaultJobSystem = new BackgroundJobSystem(
+      createNotificationService(process.env.NOTIFICATION_PROVIDER ?? 'console'),
+    )
   }
   return _defaultJobSystem
 }

--- a/src/services/notifications/factory.ts
+++ b/src/services/notifications/factory.ts
@@ -3,25 +3,55 @@ import { EmailNotificationProvider } from './email.provider.js'
 import { ConsoleNotificationProvider } from './console.provider.js'
 
 export class NotificationService {
-  private static providers: Record<string, NotificationProvider> = {
-    email: new EmailNotificationProvider(),
-    console: new ConsoleNotificationProvider(),
+  constructor(
+    private readonly providers: Record<string, NotificationProvider>,
+    private readonly defaultProviderName: string,
+  ) {
+    this.assertProviderExists(defaultProviderName)
   }
 
-  static getProvider(name?: string): NotificationProvider {
-    const providerName = name || process.env.NOTIFICATION_PROVIDER || 'console'
+  getProvider(name?: string): NotificationProvider {
+    const providerName = name ?? this.defaultProviderName
     const provider = this.providers[providerName]
-    
+
     if (!provider) {
-      console.warn(`Provider ${providerName} not found, falling back to console`)
-      return this.providers.console
+      const availableProviders = Object.keys(this.providers).sort().join(', ')
+      throw new Error(
+        `Unknown notification provider "${providerName}". Available providers: ${availableProviders}`,
+      )
     }
-    
+
     return provider
   }
 
-  static async send(recipient: string, subject: string, body: string, providerName?: string): Promise<void> {
+  async send(
+    recipient: string,
+    subject: string,
+    body: string,
+    providerName?: string,
+  ): Promise<void> {
     const provider = this.getProvider(providerName)
     await provider.send(recipient, subject, body)
   }
+
+  private assertProviderExists(providerName: string): void {
+    if (!this.providers[providerName]) {
+      const availableProviders = Object.keys(this.providers).sort().join(', ')
+      throw new Error(
+        `Unknown default notification provider "${providerName}". Available providers: ${availableProviders}`,
+      )
+    }
+  }
+}
+
+export const buildNotificationProviderRegistry = (): Record<string, NotificationProvider> => ({
+  email: new EmailNotificationProvider(),
+  console: new ConsoleNotificationProvider(),
+})
+
+export const createNotificationService = (
+  defaultProviderName: string,
+  providers: Record<string, NotificationProvider> = buildNotificationProviderRegistry(),
+): NotificationService => {
+  return new NotificationService(providers, defaultProviderName)
 }

--- a/src/tests/notification.factory.test.ts
+++ b/src/tests/notification.factory.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, jest } from '@jest/globals'
+import { NotificationService } from '../services/notifications/factory.js'
+import type { NotificationProvider } from '../services/notifications/provider.js'
+
+describe('NotificationService factory behavior', () => {
+  const createStubProvider = (name: string): NotificationProvider => ({
+    name,
+    send: jest.fn<any>().mockResolvedValue(undefined),
+  })
+
+  it('throws at initialization when the default provider is unknown', () => {
+    expect(() => {
+      new NotificationService({ console: createStubProvider('console') }, 'email')
+    }).toThrow('Unknown default notification provider "email"')
+  })
+
+  it('throws when requesting an unknown provider override', async () => {
+    const service = new NotificationService({ console: createStubProvider('console') }, 'console')
+
+    await expect(service.send('user@example.com', 'subject', 'body', 'email')).rejects.toThrow(
+      'Unknown notification provider "email"',
+    )
+  })
+})

--- a/src/tests/notification.jobs.test.ts
+++ b/src/tests/notification.jobs.test.ts
@@ -1,36 +1,29 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals'
 import { BackgroundJobSystem } from '../jobs/system.js'
 import { NotificationService } from '../services/notifications/factory.js'
-import { EmailNotificationProvider } from '../services/notifications/email.provider.js'
-
-// Mock NotificationService
-const mockNotificationService = {
-  send: jest.fn<any>(),
-  getProvider: jest.fn<any>()
-}
-
-jest.unstable_mockModule('../services/notifications/factory.js', () => ({
-  NotificationService: mockNotificationService
-}))
+import type { NotificationProvider } from '../services/notifications/provider.js'
 
 describe('Notification Job Execution', () => {
   let jobSystem: any
-  let NotificationService: any
+  let sendMock: ReturnType<typeof jest.fn<any>>
 
-  beforeEach(async () => {
-    mockNotificationService.send.mockReset()
+  beforeEach(() => {
+    sendMock = jest.fn<any>()
     jest.clearAllMocks()
-    
-    const systemModule = await import('../jobs/system.js')
-    const BackgroundJobSystem = systemModule.BackgroundJobSystem
-    const factoryModule = await import('../services/notifications/factory.js')
-    NotificationService = factoryModule.NotificationService
 
     process.env.JOB_WORKER_CONCURRENCY = '1'
     process.env.JOB_QUEUE_POLL_INTERVAL_MS = '10'
     process.env.ENABLE_JOB_SCHEDULER = 'false'
-    
-    jobSystem = new BackgroundJobSystem()
+
+    const stubProvider: NotificationProvider = {
+      name: 'stub',
+      send: sendMock,
+    }
+    const notificationService = new NotificationService(
+      { stub: stubProvider },
+      'stub',
+    )
+    jobSystem = new BackgroundJobSystem(notificationService)
   })
 
   it('should execute notification.send job using the provider', async () => {
@@ -40,7 +33,6 @@ describe('Notification Job Execution', () => {
       body: 'World',
     }
 
-    const sendMock = mockNotificationService.send
     sendMock.mockResolvedValueOnce(undefined)
 
     const receipt = jobSystem.enqueue('notification.send', payload)
@@ -65,7 +57,6 @@ describe('Notification Job Execution', () => {
       body: 'Content',
     }
 
-    const sendMock = mockNotificationService.send
     // Fail the first time, succeed the second time
     sendMock
       .mockRejectedValueOnce(new Error('Network Error'))
@@ -97,7 +88,6 @@ describe('Notification Job Execution', () => {
       body: 'Content',
     }
 
-    const sendMock = mockNotificationService.send
     sendMock.mockRejectedValue(new Error('Persistent Error'))
 
     const receipt = jobSystem.enqueue('notification.send', payload, { maxAttempts: 1 })


### PR DESCRIPTION
Closes #519

---

## Summary

This PR adds regression tests to lock down the `Cancelled` terminal-state invariant in `accountability_vault`: once a vault is cancelled, it must never accept staking again.

### What changed

- Updated `contracts/accountability_vault/src/test.rs`:
  - Added helper:
    - `assert_stake_rejected_with_not_draft(&Setup)`
    - Asserts `try_stake(...)` returns `Err(Ok(Error::NotDraft))`.
  - Added regression test for **draft cancellation path**:
    - `test_cancel_vault_then_stake_rejected_with_not_draft`
    - Flow: `create -> cancel_vault -> stake`
  - Added regression test for **withdraw cancellation path**:
    - `test_withdraw_cancelled_then_stake_rejected_with_not_draft`
    - Flow: `create -> stake -> withdraw -> stake`
  - Both tests assert:
    1. vault status is `Cancelled`
    2. subsequent `stake` is rejected with `Error::NotDraft`

- Updated `contracts/README.md`:
  - Added **Terminal-State Rule: Cancelled Vaults Cannot Be Re-Staked** section.
  - Documents both cancellation entry points and required rejection behavior.

## Why

`Cancelled` is a terminal lifecycle state. If a later `stake` were allowed after cancellation, it would violate the contract state machine and reopen settled vault flows.

These tests prevent that regression by enforcing the exact error contract (`NotDraft`) for both present and future cancellation paths.

## Security and correctness impact

- Strengthens state-machine safety by preventing terminal-state reopening.
- Guards against accidental behavior changes in `cancel_vault`, `withdraw`, or `stake`.
- Ensures explicit typed error behavior (`Error::NotDraft`) for predictable client handling.

## Test Plan

### Added tests

- `test_cancel_vault_then_stake_rejected_with_not_draft`
- `test_withdraw_cancelled_then_stake_rejected_with_not_draft`

### Expected outcomes

- Cancelled vault remains terminal.
- Any subsequent `stake` attempt fails with `Error::NotDraft`.

### Notes

- Contract tests were not executable in this environment because `cargo` is unavailable (`cargo: command not recognized`).
- To verify locally:

```bash
cd contracts/accountability_vault
cargo test