### PR TITLE
feat: heartbeat and staleness alerting for expirationScheduler

### DIFF
--- a/db/migrations/20260602130000_create_scheduler_heartbeats.cjs
+++ b/db/migrations/20260602130000_create_scheduler_heartbeats.cjs
@@ -1,0 +1,18 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('scheduler_heartbeats', (table) => {
+    table.string('name', 255).primary()
+    table.timestamp('last_run_at', { useTz: true }).notNullable()
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  await knex.schema.dropTableIfExists('scheduler_heartbeats')
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -47,6 +47,45 @@ Database connection closed
 | `JOB_WORKER_CONCURRENCY` | 2 | Number of concurrent job workers. |
 | `JOB_QUEUE_POLL_INTERVAL_MS` | 250 | How often the job queue checks for new work. |
 | `JOB_HISTORY_LIMIT` | 50 | Number of completed/failed jobs to keep in memory metrics. |
+| `SCHEDULER_DEGRADED_THRESHOLD_MS` | 180000 (3 mins) | Maximum time since last scheduler run before marking status degraded. |
+| `SCHEDULER_DOWN_THRESHOLD_MS` | 600000 (10 mins) | Maximum time since last scheduler run before marking status down/error. |
+
+## Expiration Scheduler Heartbeat
+
+To prevent silent failures of the in-process expiration scheduler (e.g. if the timer event loop crashes or hangs), a heartbeat is written to the PostgreSQL database on every run.
+
+### Heartbeat Mechanism
+On each execution of the expiration scheduler check (`runCheck`), the scheduler performs an upsert into the `scheduler_heartbeats` table:
+```sql
+INSERT INTO scheduler_heartbeats (name, last_run_at)
+VALUES ('expiration_scheduler', NOW())
+ON CONFLICT (name)
+DO UPDATE SET last_run_at = EXCLUDED.last_run_at;
+```
+
+### Missed-Run Alerting via Deep Health Check
+The `/api/health/deep` endpoint queries the `scheduler_heartbeats` table and surfaces the health status of the scheduler in the response details:
+
+- **`status`**:
+  - `up`: The scheduler heartbeat is fresh and has run within `SCHEDULER_DEGRADED_THRESHOLD_MS`.
+  - `stale`: The scheduler heartbeat is older than `SCHEDULER_DEGRADED_THRESHOLD_MS` but fresher than `SCHEDULER_DOWN_THRESHOLD_MS`. The deep health status is marked `degraded`.
+  - `down`: The scheduler heartbeat is older than `SCHEDULER_DOWN_THRESHOLD_MS` or no heartbeat exists. The overall deep health status is marked `error` and returns a `503 Service Unavailable` status code.
+
+### Deep Health Check Detail Example
+```json
+{
+  "status": "ok",
+  "timestamp": "2026-06-02T10:13:44.000Z",
+  "uptime": 123.45,
+  "details": {
+    "expirationScheduler": {
+      "status": "up",
+      "lastRunAt": "2026-06-02T10:13:00.000Z",
+      "timeSinceLastRunMs": 44000
+    }
+  }
+}
+```
 
 ## Soroban Testnet Account Funding (Friendbot Precheck)
 

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -16,5 +16,10 @@ export const createHealthRouter = (jobSystem: BackgroundJobSystem): Router => {
     return res.status(200).json(healthService.buildHealthStatus('disciplr-api', jobSystem))
   })
 
+  router.get('/deep', async (req, res) => {
+    const deepStatus = await healthService.buildDeepHealthStatus(jobSystem)
+    return res.status(deepStatus.status === 'error' ? 503 : 200).json(deepStatus)
+  })
+
   return router
 }

--- a/src/services/expirationScheduler.ts
+++ b/src/services/expirationScheduler.ts
@@ -81,6 +81,21 @@ export const startExpirationChecker = (intervalMs = 60_000, jobSystem?: Backgrou
       await enqueueSlashJobs(expired, resolvedJobSystem)
     } catch (error) {
       console.error('[ExpirationChecker] Check failed:', error)
+    } finally {
+      try {
+        const now = new Date()
+        await db('scheduler_heartbeats')
+          .insert({
+            name: 'expiration_scheduler',
+            last_run_at: now,
+          })
+          .onConflict('name')
+          .merge({
+            last_run_at: now,
+          })
+      } catch (error) {
+        console.error('[ExpirationChecker] Failed to record heartbeat:', error)
+      }
     }
   }
 

--- a/src/services/healthService.ts
+++ b/src/services/healthService.ts
@@ -44,11 +44,12 @@ export const healthService = {
   },
 
   async buildDeepHealthStatus(jobSystem: BackgroundJobSystem) {
-    const [dbResult, migrationResult, jobResult, horizonResult] = await Promise.allSettled([
+    const [dbResult, migrationResult, jobResult, horizonResult, schedulerResult] = await Promise.allSettled([
       this.checkDatabase(),
       this.checkMigrations(),
       Promise.resolve(this.checkJobSystem(jobSystem)),
       this.checkHorizonListener(),
+      this.checkExpirationScheduler(),
     ]);
 
     const database =
@@ -71,9 +72,14 @@ export const healthService = {
         ? horizonResult.value
         : { status: 'down', error: String(horizonResult.reason?.message ?? 'Unknown error') };
 
+    const expirationScheduler =
+      schedulerResult.status === 'fulfilled'
+        ? schedulerResult.value
+        : { status: 'down', error: String(schedulerResult.reason?.message ?? 'Unknown error') };
+
     const sorobanBoot = this.checkSorobanBoot();
 
-    const components = [database, migrations, jobs, horizonListener];
+    const components = [database, migrations, jobs, horizonListener, expirationScheduler];
     const isDown = components.some((c: any) => c.status === 'down');
     const isDegraded = components.some((c: any) => c.status === 'stale');
 
@@ -86,6 +92,7 @@ export const healthService = {
         migrations,
         jobs,
         horizonListener,
+        expirationScheduler,
         sorobanBoot,
       },
     };
@@ -205,6 +212,60 @@ export const healthService = {
       };
     } catch (error: any) {
       return { status: 'down', error: error.message };
+    }
+  },
+
+  async checkExpirationScheduler(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<{
+    status: string
+    lastRunAt?: string
+    timeSinceLastRunMs?: number
+    error?: string
+  }> {
+    const DEGRADED_THRESHOLD_MS = Number(process.env.SCHEDULER_DEGRADED_THRESHOLD_MS ?? 3 * 60 * 1000)
+    const DOWN_THRESHOLD_MS = Number(process.env.SCHEDULER_DOWN_THRESHOLD_MS ?? 10 * 60 * 1000)
+
+    try {
+      const state = await withTimeout(
+        db('scheduler_heartbeats')
+          .where({ name: 'expiration_scheduler' })
+          .select('last_run_at')
+          .first() as Promise<{ last_run_at: string | Date } | undefined>,
+        timeoutMs,
+        'Expiration scheduler check'
+      )
+
+      if (!state || !state.last_run_at) {
+        return { status: 'down', error: 'No heartbeat recorded in scheduler_heartbeats' }
+      }
+
+      const lastRunAt = new Date(state.last_run_at)
+      const timeSinceLastRunMs = Date.now() - lastRunAt.getTime()
+
+      if (timeSinceLastRunMs > DOWN_THRESHOLD_MS) {
+        return {
+          status: 'down',
+          lastRunAt: lastRunAt.toISOString(),
+          timeSinceLastRunMs,
+          error: 'Scheduler appears to be down (no run for over 10 minutes)',
+        }
+      }
+
+      if (timeSinceLastRunMs > DEGRADED_THRESHOLD_MS) {
+        return {
+          status: 'stale',
+          lastRunAt: lastRunAt.toISOString(),
+          timeSinceLastRunMs,
+          error: 'Heartbeat is stale',
+        }
+      }
+
+      return {
+        status: 'up',
+        lastRunAt: lastRunAt.toISOString(),
+        timeSinceLastRunMs,
+      }
+    } catch (error: any) {
+      return { status: 'down', error: error.message }
     }
   },
 

--- a/src/tests/expirationScheduler.heartbeat.test.ts
+++ b/src/tests/expirationScheduler.heartbeat.test.ts
@@ -1,0 +1,135 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockKnexIndexChain: any = {
+  where: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  onConflict: jest.fn().mockReturnThis(),
+  merge: jest.fn().mockResolvedValue(true),
+  select: jest.fn().mockReturnThis(),
+  first: jest.fn(),
+  then: jest.fn((resolve: any) => resolve([])),
+}
+const mockKnexIndex = jest.fn(() => mockKnexIndexChain)
+
+const mockKnexKnexChain: any = {
+  where: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  onConflict: jest.fn().mockReturnThis(),
+  merge: jest.fn().mockResolvedValue(true),
+  select: jest.fn().mockReturnThis(),
+  first: jest.fn(),
+  then: jest.fn((resolve: any) => resolve([])),
+}
+const mockKnexKnex = jest.fn(() => mockKnexKnexChain)
+
+jest.unstable_mockModule('../db/index.js', () => ({
+  default: mockKnexIndex,
+  db: mockKnexIndex,
+}))
+
+jest.unstable_mockModule('../db/knex.js', () => ({
+  db: mockKnexKnex,
+}))
+
+jest.unstable_mockModule('../lib/prisma.js', () => ({
+  prisma: { $queryRaw: jest.fn<any>().mockResolvedValue([{ '?column?': 1 }]) },
+}))
+
+// Mock jobs system
+const mockJobSystem = {
+  getMetrics: jest.fn().mockReturnValue({
+    running: true,
+    queueDepth: 0,
+    activeJobs: 0,
+    totals: { enqueued: 0, completed: 0, failed: 0 },
+  }),
+}
+
+// ─── Import subject ──────────────────────────────────────────────────────────
+
+const { startExpirationChecker, stopExpirationChecker } = await import('./../services/expirationScheduler.js')
+const { healthService } = await import('./../services/healthService.js')
+
+// Helper to flush promises
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 10))
+
+describe('expirationScheduler and healthService heartbeat integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    delete process.env.SCHEDULER_DEGRADED_THRESHOLD_MS
+    delete process.env.SCHEDULER_DOWN_THRESHOLD_MS
+  })
+
+  afterEach(() => {
+    stopExpirationChecker()
+    jest.useRealTimers()
+  })
+
+  it('writes a heartbeat on startup/run', async () => {
+    mockKnexIndexChain.then.mockImplementation((resolve: any) => resolve([]))
+    startExpirationChecker(60000, mockJobSystem as any)
+    
+    // Allow runCheck to run through its async chain
+    jest.advanceTimersByTime(1)
+    await flushPromises()
+
+    expect(mockKnexIndex).toHaveBeenCalledWith('scheduler_heartbeats')
+    expect(mockKnexIndexChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'expiration_scheduler',
+        last_run_at: expect.any(Date),
+      })
+    )
+  })
+
+  it('checkExpirationScheduler returns down when no heartbeat is present', async () => {
+    mockKnexKnexChain.first.mockResolvedValue(undefined)
+    const result = await healthService.checkExpirationScheduler()
+    expect(result.status).toBe('down')
+    expect(result.error).toMatch(/No heartbeat recorded/i)
+  })
+
+  it('checkExpirationScheduler returns up when heartbeat is fresh', async () => {
+    mockKnexKnexChain.first.mockResolvedValue({
+      last_run_at: new Date(),
+    })
+    const result = await healthService.checkExpirationScheduler()
+    expect(result.status).toBe('up')
+    expect(result.timeSinceLastRunMs).toBeLessThan(1000)
+  })
+
+  it('checkExpirationScheduler returns stale when heartbeat is stale but not down', async () => {
+    // 4 minutes ago is between 3 mins degraded and 10 mins down
+    mockKnexKnexChain.first.mockResolvedValue({
+      last_run_at: new Date(Date.now() - 4 * 60 * 1000),
+    })
+    const result = await healthService.checkExpirationScheduler()
+    expect(result.status).toBe('stale')
+    expect(result.error).toMatch(/Heartbeat is stale/i)
+  })
+
+  it('checkExpirationScheduler returns down when heartbeat is extremely stale', async () => {
+    // 11 minutes ago is > 10 mins down threshold
+    mockKnexKnexChain.first.mockResolvedValue({
+      last_run_at: new Date(Date.now() - 11 * 60 * 1000),
+    })
+    const result = await healthService.checkExpirationScheduler()
+    expect(result.status).toBe('down')
+    expect(result.error).toMatch(/Scheduler appears to be down/i)
+  })
+
+  it('buildDeepHealthStatus includes expirationScheduler status', async () => {
+    mockKnexKnexChain.first.mockResolvedValue({
+      last_run_at: new Date(),
+    })
+    const result = await healthService.buildDeepHealthStatus(mockJobSystem as any)
+    expect(result.status).toBe('ok')
+    expect(result.details.expirationScheduler).toBeDefined()
+    expect(result.details.expirationScheduler.status).toBe('up')
+  })
+})


### PR DESCRIPTION
closes #457

I have implemented all the requested changes for the scheduler heartbeat and watchdog deep health query.

Summary of Work Done
Database Migration: Created a Knex migration file under db/migrations/ to create the scheduler_heartbeats table (with columns name and last_run_at).
Heartbeat Upsert: Updated src/services/expirationScheduler.ts to write/upsert the 'expiration_scheduler' heartbeat on every run of runCheck inside a finally block to capture the heartbeat even when processing errors occur.
Health Service Extension: Added a checkExpirationScheduler query in src/services/healthService.ts to fetch and validate the heartbeat against two configurable thresholds:
SCHEDULER_DEGRADED_THRESHOLD_MS (default: 3 minutes)
SCHEDULER_DOWN_THRESHOLD_MS (default: 10 minutes) Integrated it into the deep health check component checklist so that staleness or lack of a heartbeat correctly degrades or marks the overall status as down/error.
API Endpoint Route: Added the /api/health/deep route mapping explicitly in src/routes/health.ts.
Automated Unit Tests: Implemented comprehensive unit tests under src/tests/expirationScheduler.heartbeat.test.ts verifying all components, including startup heartbeats, threshold checks, and deep health check output.
Operations Documentation: Documented the new watchdog features, environment variables, and expected health payloads in docs/operations.md.