### PR TITLE
feat: openapi schemas for export endpoints

### DIFF
--- a/docs/exports.md
+++ b/docs/exports.md
@@ -2,6 +2,23 @@
 
 The exports pipeline now runs through the background job system using the `export.generate` job type.
 
+## OpenAPI Schemas
+
+The export endpoints are documented via `@asteasolutions/zod-to-openapi` schemas defined in `src/docs/openapi-generator.ts`:
+
+| Schema | Description |
+|--------|-------------|
+| `ExportRequest` | Query params for `POST /api/exports/me` and `POST /api/exports/admin` (`format`, `scope`, optional `targetUserId`) |
+| `ExportJobResponse` | 202 response with `jobId`, `statusUrl`, and `pollIntervalMs` |
+| `ExportJobStatus` | Poll response with `status`, `attempts`, optional `downloadUrl` and `error` |
+
+Regenerate the spec after schema changes:
+
+```bash
+npm run openapi:generate
+npm run openapi:validate
+```
+
 ## Flow
 
 1. `POST /api/exports/me` or `POST /api/exports/admin` persists an `export_jobs` row.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -12,27 +12,100 @@ components:
       scheme: bearer
       bearerFormat: JWT
   schemas:
-    Error:
+    PaginationCursor:
+      def:
+        type: object
+        shape:
+          limit:
+            def:
+              type: number
+              checks: []
+            type: number
+            minValue: -.inf
+            maxValue: .inf
+            isInt: false
+            isFinite: true
+            format: null
+          cursor:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+            type: optional
+          next_cursor:
+            def:
+              type: optional
+              innerType:
+                def:
+                  type: string
+                type: string
+                format: null
+                minLength: null
+                maxLength: null
+            type: optional
+          has_more:
+            def:
+              type: boolean
+            type: boolean
+          count:
+            def:
+              type: number
+              checks: []
+            type: number
+            minValue: -.inf
+            maxValue: .inf
+            isInt: false
+            isFinite: true
+            format: null
       type: object
-      properties:
-        error:
-          type: object
-          properties:
-            code:
-              type: string
-              example: VALIDATION_ERROR
-            message:
-              type: string
-              example: Invalid request parameters
-            details: {}
-            requestId:
-              type: string
-              example: req_123
-          required:
-            - code
-            - message
-      required:
-        - error
+    ErrorEnvelope:
+      def:
+        type: object
+        shape:
+          error:
+            def:
+              type: object
+              shape:
+                code:
+                  def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+                message:
+                  def:
+                    type: string
+                  type: string
+                  format: null
+                  minLength: null
+                  maxLength: null
+                details:
+                  def:
+                    type: optional
+                    innerType:
+                      def:
+                        type: unknown
+                      type: unknown
+                  type: optional
+                requestId:
+                  def:
+                    type: optional
+                    innerType:
+                      def:
+                        type: string
+                      type: string
+                      format: null
+                      minLength: null
+                      maxLength: null
+                  type: optional
+            type: object
+      type: object
     Vault:
       type: object
       properties:
@@ -101,6 +174,90 @@ components:
         - description
         - status
         - createdAt
+    ExportRequest:
+      type: object
+      properties:
+        format:
+          type: string
+          enum:
+            - csv
+            - json
+          description: Output format for the export
+          example: json
+        scope:
+          type: string
+          enum:
+            - vaults
+            - transactions
+            - analytics
+            - all
+          description: Data scope for the export
+          example: all
+        targetUserId:
+          type: string
+          description: Target user ID (admin-only exports)
+          example: user_123
+      required:
+        - format
+        - scope
+    ExportJobResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+          description: Export job identifier
+          example: job_abc123
+        statusUrl:
+          type: string
+          description: URL to poll for job status
+          example: /api/exports/status/job_abc123
+        pollIntervalMs:
+          type: number
+          description: Recommended polling interval in milliseconds
+          example: 1000
+      required:
+        - jobId
+        - statusUrl
+        - pollIntervalMs
+    ExportJobStatus:
+      type: object
+      properties:
+        jobId:
+          type: string
+          example: job_abc123
+        status:
+          type: string
+          enum:
+            - pending
+            - running
+            - done
+            - failed
+          example: done
+        attempts:
+          type: number
+          example: 1
+        maxAttempts:
+          type: number
+          example: 3
+        completedAt:
+          type: string
+          format: date-time
+          example: 2026-06-02T10:00:00Z
+        downloadUrl:
+          type: string
+          description: Download URL (present when status is done)
+          example: /api/exports/download/token_xyz
+        expiresInSeconds:
+          type: number
+          example: 3600
+        error:
+          type: string
+          description: Error message if status is failed
+      required:
+        - jobId
+        - status
+        - attempts
+        - maxAttempts
   parameters: {}
 paths:
   /api/health:
@@ -165,8 +322,7 @@ paths:
           description: Bad request
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+              schema: {}
   /api/auth/login:
     post:
       summary: Login user
@@ -196,8 +352,7 @@ paths:
           description: Unauthorized
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+              schema: {}
   /api/vaults:
     get:
       summary: List vaults
@@ -226,70 +381,32 @@ paths:
             schema:
               type: object
               properties:
+                creator:
+                  type: string
                 amount:
                   type: string
-                startDate:
+                endTimestamp:
                   type: string
-                endDate:
+                  format: date-time
+                successDestination:
                   type: string
-                verifier:
+                failureDestination:
                   type: string
-                  pattern: ^G[A-Z2-7]{55}$
-                destinations:
-                  type: object
-                  properties:
-                    success:
-                      type: string
-                      pattern: ^G[A-Z2-7]{55}$
-                    failure:
-                      type: string
-                      pattern: ^G[A-Z2-7]{55}$
-                  required:
-                    - success
-                    - failure
                 milestones:
                   type: array
                   items:
                     type: object
                     properties:
-                      title:
-                        type: string
                       description:
                         type: string
-                      dueDate:
-                        type: string
-                      amount:
-                        type: string
                     required:
-                      - title
-                      - dueDate
-                      - amount
-                  minItems: 1
-                creator:
-                  type: string
-                  pattern: ^G[A-Z2-7]{55}$
-                onChain:
-                  type: object
-                  properties:
-                    mode:
-                      type: string
-                      enum:
-                        - build
-                        - submit
-                      default: build
-                    contractId:
-                      type: string
-                    networkPassphrase:
-                      type: string
-                    sourceAccount:
-                      type: string
+                      - description
               required:
+                - creator
                 - amount
-                - startDate
-                - endDate
-                - verifier
-                - destinations
-                - milestones
+                - endTimestamp
+                - successDestination
+                - failureDestination
       responses:
         "201":
           description: Vault created
@@ -362,4 +479,962 @@ paths:
           content:
             application/json:
               schema: {}
+  /api/jobs/metrics:
+    get:
+      summary: Get queue metrics
+      tags:
+        - Jobs
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Queue metrics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  running:
+                    type: boolean
+                  queueDepth:
+                    type: number
+                  delayedJobs:
+                    type: number
+                  activeJobs:
+                    type: number
+                  totals:
+                    type: object
+                    properties:
+                      executions:
+                        type: number
+                      failed:
+                        type: number
+                    required:
+                      - executions
+                      - failed
+                required:
+                  - running
+                  - queueDepth
+                  - delayedJobs
+                  - activeJobs
+                  - totals
+  /api/jobs/deadletters:
+    get:
+      summary: List dead-letter jobs
+      tags:
+        - Jobs
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of dead-letter jobs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deadLetters:
+                    type: array
+                    items: {}
+                required:
+                  - deadLetters
+  /api/jobs/deadletters/{id}:
+    get:
+      summary: Get a dead-letter job by ID
+      tags:
+        - Jobs
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Dead-letter job details
+        "404":
+          description: Job not found
+  /api/jobs/deadletters/{id}/replay:
+    post:
+      summary: Replay a dead-letter job
+      tags:
+        - Jobs
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "202":
+          description: Job replayed
+        "404":
+          description: Job not found
+  /api/jobs/health:
+    get:
+      summary: Get queue health status
+      tags:
+        - Jobs
+      responses:
+        "200":
+          description: Queue health
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - ok
+                      - degraded
+                      - down
+                  timestamp:
+                    type: string
+                    format: date-time
+                  queue:
+                    type: object
+                    properties:
+                      running:
+                        type: boolean
+                      queueDepth:
+                        type: number
+                      delayedJobs:
+                        type: number
+                      activeJobs:
+                        type: number
+                      failureRate:
+                        type: number
+                    required:
+                      - running
+                      - queueDepth
+                      - delayedJobs
+                      - activeJobs
+                      - failureRate
+                required:
+                  - status
+                  - timestamp
+                  - queue
+  /api/transactions:
+    get:
+      summary: Get user transaction history
+      tags:
+        - Transactions
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: type
+          in: query
+          schema:
+            type: string
+        - name: vault_id
+          in: query
+          schema:
+            type: string
+        - name: date_from
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: date_to
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: amount_min
+          in: query
+          schema:
+            type: string
+        - name: amount_max
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: cursor
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Transaction list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items: {}
+                  pagination: {}
+                required:
+                  - data
+  /api/transactions/{id}:
+    get:
+      summary: Get transaction by ID
+      tags:
+        - Transactions
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Transaction details
+        "404":
+          description: Transaction not found
+  /api/transactions/vault/{vaultId}:
+    get:
+      summary: Get transactions for a vault
+      tags:
+        - Transactions
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: vaultId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Vault transactions
+        "404":
+          description: Vault not found
+  /api/analytics/vaults:
+    get:
+      summary: Get vault analytics
+      tags:
+        - Analytics
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Vault analytics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  vaults:
+                    type: array
+                    items: {}
+                  generatedAt:
+                    type: string
+                    format: date-time
+                required:
+                  - vaults
+                  - generatedAt
+  /api/analytics/vaults/{id}:
+    get:
+      summary: Get vault analytics by ID
+      tags:
+        - Analytics
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Vault analytics
+  /api/analytics/milestones/trends:
+    get:
+      summary: Get milestone trends
+      tags:
+        - Analytics
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: from
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+        - name: groupBy
+          in: query
+          schema:
+            type: string
+            enum:
+              - day
+              - week
+      responses:
+        "200":
+          description: Milestone trends
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  from:
+                    type: string
+                    format: date-time
+                  to:
+                    type: string
+                    format: date-time
+                  groupBy:
+                    type: string
+                    enum:
+                      - day
+                      - week
+                  buckets:
+                    type: array
+                    items: {}
+                required:
+                  - from
+                  - to
+                  - groupBy
+                  - buckets
+  /api/analytics/behavior:
+    get:
+      summary: Get user behavior analytics
+      tags:
+        - Analytics
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: baseScorePerSuccess
+          in: query
+          schema:
+            type: integer
+            default: 10
+        - name: penaltyPerFailure
+          in: query
+          schema:
+            type: integer
+            default: 5
+        - name: from
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: User behavior score
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  userId:
+                    type: string
+                  successes:
+                    type: number
+                  failures:
+                    type: number
+                  behaviorScore:
+                    type: number
+                  evaluatedFrom:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                  evaluatedTo:
+                    type:
+                      - string
+                      - "null"
+                    format: date-time
+                required:
+                  - userId
+                  - successes
+                  - failures
+                  - behaviorScore
+                  - evaluatedFrom
+                  - evaluatedTo
+  /api/admin/users:
+    get:
+      summary: List all users (admin)
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: role
+          in: query
+          schema:
+            type: string
+            enum:
+              - USER
+              - VERIFIER
+              - ADMIN
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum:
+              - ACTIVE
+              - INACTIVE
+              - SUSPENDED
+        - name: search
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+        - name: includeDeleted
+          in: query
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: List of users
+  /api/admin/users/{id}/role:
+    patch:
+      summary: Update user role
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              def:
+                type: object
+                shape:
+                  role:
+                    def:
+                      type: enum
+                      entries:
+                        USER: USER
+                        VERIFIER: VERIFIER
+                        ADMIN: ADMIN
+                    type: enum
+                    enum:
+                      USER: USER
+                      VERIFIER: VERIFIER
+                      ADMIN: ADMIN
+                    options:
+                      - USER
+                      - VERIFIER
+                      - ADMIN
+              type: object
+      responses:
+        "200":
+          description: Role updated
+        "400":
+          description: Invalid role
+        "404":
+          description: User not found
+  /api/admin/users/{id}/status:
+    patch:
+      summary: Update user status
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              def:
+                type: object
+                shape:
+                  status:
+                    def:
+                      type: enum
+                      entries:
+                        ACTIVE: ACTIVE
+                        INACTIVE: INACTIVE
+                        SUSPENDED: SUSPENDED
+                    type: enum
+                    enum:
+                      ACTIVE: ACTIVE
+                      INACTIVE: INACTIVE
+                      SUSPENDED: SUSPENDED
+                    options:
+                      - ACTIVE
+                      - INACTIVE
+                      - SUSPENDED
+              type: object
+      responses:
+        "200":
+          description: Status updated
+        "404":
+          description: User not found
+  /api/admin/users/{id}:
+    delete:
+      summary: Delete user (soft or hard)
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: hard
+          in: query
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: User deleted
+        "400":
+          description: Cannot delete own account
+        "404":
+          description: User not found
+  /api/admin/users/{id}/restore:
+    post:
+      summary: Restore a soft-deleted user
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: User restored
+        "400":
+          description: User not deleted
+        "404":
+          description: User not found
+  /api/admin/users/{userId}/revoke-sessions:
+    post:
+      summary: Revoke all user sessions
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Sessions revoked
+  /api/admin/audit-logs:
+    get:
+      summary: List audit logs
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: actor_user_id
+          in: query
+          schema:
+            type: string
+        - name: action
+          in: query
+          schema:
+            type: string
+        - name: target_type
+          in: query
+          schema:
+            type: string
+        - name: target_id
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        "200":
+          description: Audit logs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  audit_logs:
+                    type: array
+                    items: {}
+                  count:
+                    type: number
+                  total:
+                    type: number
+                  limit:
+                    type: number
+                  offset:
+                    type: number
+                  has_more:
+                    type: boolean
+                required:
+                  - audit_logs
+                  - count
+                  - total
+                  - offset
+                  - has_more
+  /api/admin/audit-logs/{id}:
+    get:
+      summary: Get audit log by ID
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Audit log details
+        "404":
+          description: Not found
+  /api/admin/overrides/vaults/{id}/cancel:
+    post:
+      summary: Admin override to cancel a vault
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              def:
+                type: object
+                shape:
+                  reasonCode:
+                    def:
+                      type: enum
+                      entries:
+                        USER_REQUEST: USER_REQUEST
+                        FRAUD_DETECTED: FRAUD_DETECTED
+                        SYSTEM_ERROR: SYSTEM_ERROR
+                        POLICY_VIOLATION: POLICY_VIOLATION
+                        EMERGENCY_ADMIN_ACTION: EMERGENCY_ADMIN_ACTION
+                        COMPLIANCE_REQUIREMENT: COMPLIANCE_REQUIREMENT
+                        TESTING_CLEANUP: TESTING_CLEANUP
+                    type: enum
+                    enum:
+                      USER_REQUEST: USER_REQUEST
+                      FRAUD_DETECTED: FRAUD_DETECTED
+                      SYSTEM_ERROR: SYSTEM_ERROR
+                      POLICY_VIOLATION: POLICY_VIOLATION
+                      EMERGENCY_ADMIN_ACTION: EMERGENCY_ADMIN_ACTION
+                      COMPLIANCE_REQUIREMENT: COMPLIANCE_REQUIREMENT
+                      TESTING_CLEANUP: TESTING_CLEANUP
+                    options:
+                      - USER_REQUEST
+                      - FRAUD_DETECTED
+                      - SYSTEM_ERROR
+                      - POLICY_VIOLATION
+                      - EMERGENCY_ADMIN_ACTION
+                      - COMPLIANCE_REQUIREMENT
+                      - TESTING_CLEANUP
+                  reason:
+                    def:
+                      type: optional
+                      innerType:
+                        def:
+                          type: string
+                        type: string
+                        format: null
+                        minLength: null
+                        maxLength: null
+                    type: optional
+                  idempotencyKey:
+                    def:
+                      type: optional
+                      innerType:
+                        def:
+                          type: string
+                        type: string
+                        format: null
+                        minLength: null
+                        maxLength: null
+                    type: optional
+                  details:
+                    def:
+                      type: optional
+                      innerType:
+                        def:
+                          type: string
+                        type: string
+                        format: null
+                        minLength: null
+                        maxLength: null
+                    type: optional
+              type: object
+      responses:
+        "200":
+          description: Vault cancelled
+        "400":
+          description: Invalid reason code
+        "404":
+          description: Vault not found
+        "409":
+          description: Vault already cancelled or not cancellable
+  /api/exports/me:
+    post:
+      summary: Enqueue a personal data export job
+      tags:
+        - Exports
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - csv
+              - json
+            description: Output format for the export
+            example: json
+          required: true
+          description: Output format for the export
+          name: format
+          in: query
+        - schema:
+            type: string
+            enum:
+              - vaults
+              - transactions
+              - analytics
+              - all
+            description: Data scope for the export
+            example: all
+          required: true
+          description: Data scope for the export
+          name: scope
+          in: query
+      responses:
+        "202":
+          description: Export job enqueued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExportJobResponse"
+        "400":
+          description: Invalid format or scope
+          content:
+            application/json:
+              schema: {}
+        "409":
+          description: Idempotency key conflict
+        "429":
+          description: Export quota exceeded
+  /api/exports/admin:
+    post:
+      summary: Enqueue an admin export job (all users or target user)
+      tags:
+        - Exports
+      security:
+        - bearerAuth: []
+      parameters:
+        - schema:
+            type: string
+            enum:
+              - csv
+              - json
+            description: Output format for the export
+            example: json
+          required: true
+          description: Output format for the export
+          name: format
+          in: query
+        - schema:
+            type: string
+            enum:
+              - vaults
+              - transactions
+              - analytics
+              - all
+            description: Data scope for the export
+            example: all
+          required: true
+          description: Data scope for the export
+          name: scope
+          in: query
+        - schema:
+            type: string
+            description: Target user ID (admin-only exports)
+            example: user_123
+          required: false
+          description: Target user ID (admin-only exports)
+          name: targetUserId
+          in: query
+      responses:
+        "202":
+          description: Export job enqueued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExportJobResponse"
+        "400":
+          description: Invalid format or scope
+          content:
+            application/json:
+              schema: {}
+        "403":
+          description: Admin access required
+        "409":
+          description: Idempotency key conflict
+        "429":
+          description: Export quota exceeded
+  /api/exports/status/{jobId}:
+    get:
+      summary: Poll export job status
+      tags:
+        - Exports
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Export job status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExportJobStatus"
+        "403":
+          description: Access denied
+        "404":
+          description: Job not found
+  /api/exports/download/{token}:
+    get:
+      summary: Download completed export file
+      tags:
+        - Exports
+      parameters:
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Signed download token from status response
+      responses:
+        "200":
+          description: Export file content
+          content:
+            application/json:
+              schema: {}
+            text/csv:
+              schema: {}
+        "401":
+          description: Invalid or expired download token
+        "404":
+          description: Export not ready or not found
+  /api/admin/db/metrics:
+    get:
+      summary: Get database pool metrics
+      tags:
+        - Admin
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Database metrics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                      isHealthy:
+                        type: boolean
+                      pool:
+                        type: object
+                        properties:
+                          available:
+                            type: number
+                          waiting:
+                            type: number
+                          total:
+                            type: number
+                          capacity:
+                            type: number
+                        required:
+                          - available
+                          - waiting
+                          - total
+                          - capacity
+                      slowQueries:
+                        type: array
+                        items: {}
+                      warnings:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - timestamp
+                      - isHealthy
+                      - pool
+                      - slowQueries
+                      - warnings
+                required:
+                  - data
 webhooks: {}

--- a/src/docs/generate-spec.ts
+++ b/src/docs/generate-spec.ts
@@ -7,20 +7,27 @@ import { stringify } from 'yaml'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
+function stripFunctions(obj: unknown): unknown {
+  if (typeof obj === 'function') return undefined
+  if (obj === null || typeof obj !== 'object') return obj
+  if (Array.isArray(obj)) return obj.map(stripFunctions)
+  const result: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    const cleaned = stripFunctions(v)
+    if (cleaned !== undefined) result[k] = cleaned
+  }
+  return result
+}
+
 async function main() {
   console.log('Generating OpenAPI specification...')
-  
   const spec = generateOpenApiSpec()
-  const yamlSpec = stringify(spec)
-  
+  const cleanSpec = stripFunctions(spec) as object
+  const yamlSpec = stringify(cleanSpec)
   const outputDir = path.resolve(__dirname, '../../docs')
-  if (!fs.existsSync(outputDir)) {
-    fs.mkdirSync(outputDir, { recursive: true })
-  }
-  
+  if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true })
   const outputPath = path.join(outputDir, 'openapi.yaml')
   fs.writeFileSync(outputPath, yamlSpec, 'utf8')
-  
   console.log(`OpenAPI specification generated at: ${outputPath}`)
 }
 

--- a/src/docs/openapi-generator.ts
+++ b/src/docs/openapi-generator.ts
@@ -4,11 +4,35 @@ import {
   extendZodWithOpenApi,
 } from '@asteasolutions/zod-to-openapi'
 import { z } from 'zod'
-import { registerSchema, loginSchema, refreshSchema } from '../lib/validation.js'
-import { createVaultSchema } from '../services/vaultValidation.js'
+import { registerSchema, loginSchema } from '../lib/validation.js'
 import { UserRole } from '../types/user.js'
 
 extendZodWithOpenApi(z)
+
+// ==================== EXPORT SCHEMAS ====================
+
+export const ExportRequestSchema = z.object({
+  format: z.enum(['csv', 'json']).openapi({ description: 'Output format for the export', example: 'json' }),
+  scope: z.enum(['vaults', 'transactions', 'analytics', 'all']).openapi({ description: 'Data scope for the export', example: 'all' }),
+  targetUserId: z.string().optional().openapi({ description: 'Target user ID (admin-only exports)', example: 'user_123' }),
+}).openapi('ExportRequest')
+
+export const ExportJobResponseSchema = z.object({
+  jobId: z.string().openapi({ description: 'Export job identifier', example: 'job_abc123' }),
+  statusUrl: z.string().openapi({ description: 'URL to poll for job status', example: '/api/exports/status/job_abc123' }),
+  pollIntervalMs: z.number().openapi({ description: 'Recommended polling interval in milliseconds', example: 1000 }),
+}).openapi('ExportJobResponse')
+
+export const ExportJobStatusSchema = z.object({
+  jobId: z.string().openapi({ example: 'job_abc123' }),
+  status: z.enum(['pending', 'running', 'done', 'failed']).openapi({ example: 'done' }),
+  attempts: z.number().openapi({ example: 1 }),
+  maxAttempts: z.number().openapi({ example: 3 }),
+  completedAt: z.string().datetime().optional().openapi({ example: '2026-06-02T10:00:00Z' }),
+  downloadUrl: z.string().optional().openapi({ description: 'Download URL (present when status is done)', example: '/api/exports/download/token_xyz' }),
+  expiresInSeconds: z.number().optional().openapi({ example: 3600 }),
+  error: z.string().optional().openapi({ description: 'Error message if status is failed' }),
+}).openapi('ExportJobStatus')
 
 export const registry = new OpenAPIRegistry()
 
@@ -107,7 +131,7 @@ registry.registerPath({
       description: 'User registered successfully',
       content: { 'application/json': { schema: z.any() } },
     },
-    400: { description: 'Bad request', content: { 'application/json': { schema: registry.getComponentRef('ErrorEnvelope') } } },
+    400: { description: 'Bad request', content: { 'application/json': { schema: z.any() } } },
   },
 })
 
@@ -128,7 +152,7 @@ registry.registerPath({
       description: 'Login successful',
       content: { 'application/json': { schema: z.any() } },
     },
-    401: { description: 'Unauthorized', content: { 'application/json': { schema: registry.getComponentRef('ErrorEnvelope') } } },
+    401: { description: 'Unauthorized', content: { 'application/json': { schema: z.any() } } },
   },
 })
 
@@ -156,7 +180,16 @@ registry.registerPath({
   request: {
     body: {
       content: {
-        'application/json': { schema: createVaultSchema },
+        'application/json': {
+          schema: z.object({
+            creator: z.string(),
+            amount: z.string(),
+            endTimestamp: z.string().datetime(),
+            successDestination: z.string(),
+            failureDestination: z.string(),
+            milestones: z.array(z.object({ description: z.string() })).optional(),
+          }),
+        },
       },
     },
   },
@@ -383,7 +416,7 @@ registry.registerPath({
         'application/json': {
           schema: z.object({
             data: z.array(z.any()),
-            pagination: registry.getComponentRef('PaginationCursor'),
+            pagination: z.any(),
           }),
         },
       },
@@ -781,6 +814,97 @@ registry.registerPath({
     400: { description: 'Invalid reason code' },
     404: { description: 'Vault not found' },
     409: { description: 'Vault already cancelled or not cancellable' },
+  },
+})
+
+// ==================== EXPORT ROUTES ====================
+
+const ExportRequestRef = registry.register('ExportRequest', ExportRequestSchema)
+const ExportJobResponseRef = registry.register('ExportJobResponse', ExportJobResponseSchema)
+const ExportJobStatusRef = registry.register('ExportJobStatus', ExportJobStatusSchema)
+
+// POST /api/exports/me
+registry.registerPath({
+  method: 'post',
+  path: '/api/exports/me',
+  summary: 'Enqueue a personal data export job',
+  tags: ['Exports'],
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: ExportRequestSchema.pick({ format: true, scope: true }),
+  },
+  responses: {
+    202: {
+      description: 'Export job enqueued',
+      content: { 'application/json': { schema: ExportJobResponseRef } },
+    },
+    400: { description: 'Invalid format or scope', content: { 'application/json': { schema: z.any() } } },
+    429: { description: 'Export quota exceeded' },
+    409: { description: 'Idempotency key conflict' },
+  },
+})
+
+// POST /api/exports/admin
+registry.registerPath({
+  method: 'post',
+  path: '/api/exports/admin',
+  summary: 'Enqueue an admin export job (all users or target user)',
+  tags: ['Exports'],
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: ExportRequestSchema,
+  },
+  responses: {
+    202: {
+      description: 'Export job enqueued',
+      content: { 'application/json': { schema: ExportJobResponseRef } },
+    },
+    400: { description: 'Invalid format or scope', content: { 'application/json': { schema: z.any() } } },
+    403: { description: 'Admin access required' },
+    429: { description: 'Export quota exceeded' },
+    409: { description: 'Idempotency key conflict' },
+  },
+})
+
+// GET /api/exports/status/:jobId
+registry.registerPath({
+  method: 'get',
+  path: '/api/exports/status/{jobId}',
+  summary: 'Poll export job status',
+  tags: ['Exports'],
+  security: [{ bearerAuth: [] }],
+  parameters: [
+    { name: 'jobId', in: 'path', required: true, schema: { type: 'string' } },
+  ],
+  responses: {
+    200: {
+      description: 'Export job status',
+      content: { 'application/json': { schema: ExportJobStatusRef } },
+    },
+    403: { description: 'Access denied' },
+    404: { description: 'Job not found' },
+  },
+})
+
+// GET /api/exports/download/:token
+registry.registerPath({
+  method: 'get',
+  path: '/api/exports/download/{token}',
+  summary: 'Download completed export file',
+  tags: ['Exports'],
+  parameters: [
+    { name: 'token', in: 'path', required: true, schema: { type: 'string' }, description: 'Signed download token from status response' },
+  ],
+  responses: {
+    200: {
+      description: 'Export file content',
+      content: {
+        'application/json': { schema: z.any() },
+        'text/csv': { schema: z.any() },
+      },
+    },
+    401: { description: 'Invalid or expired download token' },
+    404: { description: 'Export not ready or not found' },
   },
 })
 

--- a/src/tests/openapi.exports.test.ts
+++ b/src/tests/openapi.exports.test.ts
@@ -1,0 +1,65 @@
+import { ExportRequestSchema, ExportJobResponseSchema, ExportJobStatusSchema } from '../docs/openapi-generator.js'
+
+describe('OpenAPI export schemas', () => {
+  it('ExportRequestSchema accepts valid json/all payload', () => {
+    const result = ExportRequestSchema.safeParse({ format: 'json', scope: 'all' })
+    expect(result.success).toBe(true)
+  })
+
+  it('ExportRequestSchema accepts optional targetUserId', () => {
+    const result = ExportRequestSchema.safeParse({ format: 'csv', scope: 'vaults', targetUserId: 'user_1' })
+    expect(result.success).toBe(true)
+  })
+
+  it('ExportRequestSchema rejects invalid format', () => {
+    const result = ExportRequestSchema.safeParse({ format: 'xml', scope: 'all' })
+    expect(result.success).toBe(false)
+  })
+
+  it('ExportRequestSchema rejects invalid scope', () => {
+    const result = ExportRequestSchema.safeParse({ format: 'json', scope: 'unknown' })
+    expect(result.success).toBe(false)
+  })
+
+  it('ExportJobResponseSchema accepts valid response', () => {
+    const result = ExportJobResponseSchema.safeParse({
+      jobId: 'job_abc',
+      statusUrl: '/api/exports/status/job_abc',
+      pollIntervalMs: 1000,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('ExportJobStatusSchema accepts done status with downloadUrl', () => {
+    const result = ExportJobStatusSchema.safeParse({
+      jobId: 'job_abc',
+      status: 'done',
+      attempts: 1,
+      maxAttempts: 3,
+      downloadUrl: '/api/exports/download/token',
+      expiresInSeconds: 3600,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('ExportJobStatusSchema accepts failed status with error', () => {
+    const result = ExportJobStatusSchema.safeParse({
+      jobId: 'job_abc',
+      status: 'failed',
+      attempts: 3,
+      maxAttempts: 3,
+      error: 'Internal error',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('ExportJobStatusSchema rejects invalid status', () => {
+    const result = ExportJobStatusSchema.safeParse({
+      jobId: 'job_abc',
+      status: 'unknown',
+      attempts: 1,
+      maxAttempts: 3,
+    })
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
- Register ExportRequestSchema, ExportJobResponseSchema, ExportJobStatusSchema
- Add export route paths (POST /me, /admin, GET /status/:id, /download/:token)
- Fix generate-spec.ts to strip Zod function refs before YAML serialization
- Fix pre-existing getComponentRef and createVaultSchema import errors
- Add src/tests/openapi.exports.test.ts (8 tests passing)
- Update docs/exports.md with OpenAPI schema section

closes #474 