### PR TITLE
test: deterministic vault address derivation

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -67,3 +67,41 @@ If you need to update this budget as the contract grows:
 (`src/services/horizonListener.ts`) and `src/services/eventParser.ts`
 ingest the events emitted by these functions to keep the off-chain vault state
 in sync.
+
+## Deterministic vault address derivation
+
+Each vault is deployed as its own contract instance. The address is derived
+deterministically from the deployer address and a 32-byte salt, so
+`src/services/soroban.ts` can correlate the on-chain address to the off-chain
+`PersistedVault.id` **before** the deploy transaction is confirmed.
+
+### Derivation formula
+
+```
+contract_address = sha256("contract" || deployer_bytes || salt_bytes)
+```
+
+This is Soroban's built-in CREATE2-style address scheme. It can be computed
+client-side using `env.deployer().with_address(deployer, salt).deployed_address()`
+in Rust tests, or via the Stellar SDK `Contract.fromAddress` / deployer helpers
+in TypeScript.
+
+### Salt convention (backend)
+
+```
+salt = sha256(vault_id)   // 32-byte hash of the off-chain UUID string
+```
+
+See `src/services/soroban.ts` → `saltFromVaultId`.
+
+### Properties
+
+| Property | Guarantee |
+|---|---|
+| Same `(deployer, salt)` | Always yields the same address |
+| Different `salt` | Different address (distinct vault UUIDs → distinct contracts) |
+| Different `deployer` | Different address (multi-tenant safe) |
+
+The test suite in `contracts/accountability_vault/src/test.rs`
+(`test_deterministic_address_*`) exercises all three properties and verifies
+that `deployed_address()` matches the address of the actually deployed contract.

--- a/contracts/accountability_vault/src/test.rs
+++ b/contracts/accountability_vault/src/test.rs
@@ -141,8 +141,115 @@ fn test_create_and_stake() {
     assert_eq!(token_client.balance(&s.creator), 0);
 }
 
+// ── #493: deterministic vault address derivation ──────────────────────────────
+//
+// The backend (src/services/soroban.ts) deploys one AccountabilityVault
+// contract per vault and must correlate the on-chain address to the off-chain
+// PersistedVault.id before the transaction is confirmed.
+//
+// Soroban derives contract addresses deterministically from (deployer, salt):
+//
+//   address = sha256("contract" || deployer_bytes || salt_bytes)
+//
+// This means the address can be predicted *before* deployment using:
+//   env.deployer().with_address(deployer, salt).deployed_address()
+//
+// Salt convention used by the backend:
+//   BytesN<32> = sha256(vault_id_string) — a 32-byte hash of the off-chain UUID
+//   (see src/services/soroban.ts: saltFromVaultId)
+//
+// These tests exercise and document the pattern so the backend deploy flow can
+// be validated and the address correlation logic can be unit-tested off-chain.
+
 #[test]
-fn test_abi_spec_snapshot() {
+fn test_deterministic_address_matches_deployed_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deployer = Address::generate(&env);
+    // Salt derived from vault UUID — in production: sha256(vault_id).
+    let salt = BytesN::from_array(&env, &[0xdeu8; 32]);
+
+    // Step 1: predict the address BEFORE deployment.
+    let predicted = env
+        .deployer()
+        .with_address(deployer.clone(), salt.clone())
+        .deployed_address();
+
+    // Step 2: install the wasm and deploy at the deterministic address.
+    let wasm_hash = env.deployer().upload_contract_wasm(AccountabilityVault::WASM);
+    let deployed = env
+        .deployer()
+        .with_address(deployer, salt)
+        .deploy_v2::<()>(wasm_hash, ());
+
+    // The predicted and deployed addresses must match.
+    assert_eq!(predicted, deployed);
+}
+
+#[test]
+fn test_different_salts_yield_different_addresses() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deployer = Address::generate(&env);
+    let salt_a = BytesN::from_array(&env, &[0xAAu8; 32]);
+    let salt_b = BytesN::from_array(&env, &[0xBBu8; 32]);
+
+    let addr_a = env
+        .deployer()
+        .with_address(deployer.clone(), salt_a)
+        .deployed_address();
+    let addr_b = env
+        .deployer()
+        .with_address(deployer, salt_b)
+        .deployed_address();
+
+    assert_ne!(addr_a, addr_b, "distinct salts must produce distinct addresses");
+}
+
+#[test]
+fn test_different_deployers_same_salt_yield_different_addresses() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let deployer_a = Address::generate(&env);
+    let deployer_b = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[0x42u8; 32]);
+
+    let addr_a = env
+        .deployer()
+        .with_address(deployer_a, salt.clone())
+        .deployed_address();
+    let addr_b = env
+        .deployer()
+        .with_address(deployer_b, salt)
+        .deployed_address();
+
+    assert_ne!(
+        addr_a, addr_b,
+        "same salt but different deployers must produce different addresses"
+    );
+}
+
+#[test]
+fn test_same_deployer_same_salt_is_idempotent() {
+    // Calling deployed_address() twice with identical inputs returns the same value.
+    let env = Env::default();
+    let deployer = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[0x01u8; 32]);
+
+    let addr_1 = env
+        .deployer()
+        .with_address(deployer.clone(), salt.clone())
+        .deployed_address();
+    let addr_2 = env
+        .deployer()
+        .with_address(deployer, salt)
+        .deployed_address();
+
+    assert_eq!(addr_1, addr_2, "deployed_address must be deterministic");
+}
     // Build a stable JSON representation of the contract ABI.
     let spec = json!({
         "name": "AccountabilityVault",


### PR DESCRIPTION
- Add 4 deployer tests in test.rs exercising Soroban's CREATE2-style address derivation via env.deployer().with_address(deployer, salt):
  - test_deterministic_address_matches_deployed_address: predicts address with deployed_address() then deploys; asserts they are equal
  - test_different_salts_yield_different_addresses: same deployer, two salts
  - test_different_deployers_same_salt_yield_different_addresses: two deployers
  - test_same_deployer_same_salt_is_idempotent: deployed_address is stable
- Document the derivation scheme, salt convention (sha256(vault_id)), and guarantee table in contracts/README.md
- Cross-reference src/services/soroban.ts saltFromVaultId

closes #493