### PR TITLE
feat: reject vaults where creator equals verifier

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -32,6 +32,13 @@ Implements the vault lifecycle that the backend models off-chain in
 | `withdraw` | Cancel/refund an unfunded or unstarted vault to the creator; -> `Cancelled`. |
 | `get_vault` | Read-only accessor for the current vault record. |
 
+### Role-separation invariant
+
+`create_vault` enforces that `creator != verifier`. Allowing the same address to
+fill both roles would let one party both stake funds *and* self-confirm milestones,
+completely undermining the accountability guarantee. Any attempt to create a vault
+where `creator == verifier` returns `Error::CreatorIsVerifier` (code 26).
+
 The `VaultStatus` enum (`Draft`/`Active`/`Completed`/`Failed`/`Cancelled`)
 mirrors `PersistedVault.status` in `src/types/vaults.ts`. Emitted events
 (`vault_created`, `vault_staked`, `milestone_checked_in`, `vault_slashed`,

--- a/contracts/accountability_vault/src/lib.rs
+++ b/contracts/accountability_vault/src/lib.rs
@@ -161,6 +161,8 @@ pub enum Error {
     AlreadyInitialized = 1,
     /// No vault found for the given `vault_id`.
     NotInitialized = 2,
+    /// Creator and verifier are the same address; role separation is required.
+    CreatorIsVerifier = 26,
     /// Amount is zero or negative.
     InvalidAmount = 3,
     /// Deadline is in the past, exceeds vault end, or beyond the 5-year horizon.
@@ -229,6 +231,9 @@ impl AccountabilityVault {
         let key = DataKey::Vault(vault_id);
         if env.storage().persistent().has(&key) {
             return Err(Error::AlreadyInitialized);
+        }
+        if creator == verifier {
+            return Err(Error::CreatorIsVerifier);
         }
         if verifier_set.verifiers.is_empty() {
             return Err(Error::NoVerifiers);

--- a/contracts/accountability_vault/src/test.rs
+++ b/contracts/accountability_vault/src/test.rs
@@ -268,7 +268,121 @@ fn test_withdraw_draft_cancels() {
     assert_eq!(vault.status, VaultStatus::Cancelled);
 }
 
-// ── cross-feature: stake_from then oracle check_in then claim ────────────────
+// ── #486: reject creator == verifier (role separation invariant) ─────────────
+
+#[test]
+fn test_create_vault_creator_equals_verifier_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+
+    let creator = Address::generate(&env);
+    let guardian = Address::generate(&env);
+    let success = Address::generate(&env);
+    let failure = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let (token, _) = create_token(&env, &token_admin);
+
+    let contract_id = env.register(AccountabilityVault, ());
+    let contract = AccountabilityVaultClient::new(&env, &contract_id);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            title: String::from_str(&env, "m"),
+            amount: 500,
+            due_date: 1_200,
+            verified: false,
+            released: false,
+        },
+    ];
+    let vault_id = String::from_str(&env, "v1");
+    // creator and verifier are the SAME address — must fail.
+    let result = contract.try_create_vault(
+        &vault_id,
+        &creator,
+        &creator, // same as creator!
+        &token,
+        &500,
+        &success,
+        &failure,
+        &1_200,
+        &milestones,
+        &guardian,
+    );
+    assert!(
+        matches!(result, Err(Ok(Error::CreatorIsVerifier))),
+        "expected CreatorIsVerifier, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_create_vault_distinct_creator_and_verifier_succeeds() {
+    // Sanity check: distinct addresses must NOT trigger the error.
+    let s = setup(&[100], &[500]);
+    // setup() itself calls create_vault with distinct creator/verifier.
+    let vault = s.contract.get_vault(&s.vault_id);
+    assert_ne!(vault.creator, vault.verifier, "creator and verifier must differ");
+}
+
+#[test]
+#[should_panic]
+fn test_create_vault_creator_equals_verifier_panics() {
+    // Same test via #[should_panic] for ergonomic coverage.
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+
+    let creator = Address::generate(&env);
+    let guardian = Address::generate(&env);
+    let success = Address::generate(&env);
+    let failure = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let (token, _) = create_token(&env, &token_admin);
+
+    let contract_id = env.register(AccountabilityVault, ());
+    let contract = AccountabilityVaultClient::new(&env, &contract_id);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            title: String::from_str(&env, "m"),
+            amount: 500,
+            due_date: 1_200,
+            verified: false,
+            released: false,
+        },
+    ];
+    let vault_id = String::from_str(&env, "v1");
+    contract.create_vault(
+        &vault_id,
+        &creator,
+        &creator, // same as creator — must panic
+        &token,
+        &500,
+        &success,
+        &failure,
+        &1_200,
+        &milestones,
+        &guardian,
+    );
+}
+
+// ── #486 guard: regression — ensure existing role-checked functions unaffected ─
+
+#[test]
+fn test_create_vault_with_roles_separate_then_stake_and_verify() {
+    // Full flow must still succeed with distinct creator and verifier.
+    let s = setup(&[100], &[500]);
+    s.contract.stake(&s.vault_id, &s.creator);
+    s.contract.check_in(&s.vault_id, &s.verifier, &0, &evidence_hash(&s.env, 1));
+    s.contract.claim(&s.vault_id, &s.creator);
+    let vault = s.contract.get_vault(&s.vault_id);
+    assert_eq!(vault.status, VaultStatus::Completed);
+}
 
 #[test]
 fn test_cancel_vault_then_stake_rejected_with_not_draft() {


### PR DESCRIPTION
- Add Error::CreatorIsVerifier (code 26) to the Error enum
- Guard create_vault: return CreatorIsVerifier immediately when creator == verifier, before any other validation
- Tests:
  - test_create_vault_creator_equals_verifier_fails: typed-error path
  - test_create_vault_creator_equals_verifier_panics: should_panic path
  - test_create_vault_distinct_creator_and_verifier_succeeds: sanity check
  - test_create_vault_with_roles_separate_then_stake_and_verify: regression
- Document role-separation invariant in contracts/README.md

closes #486