### PR TITLE
test: cover NotInitialized read paths for pre-init state

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -22,21 +22,24 @@ Implements the vault lifecycle that the backend models off-chain in
 `src/services/vaultTransitions.ts` and parses events for in
 `src/services/eventParser.ts`:
 
-| Function | Purpose |
-|---|---|
-| `create_vault` | Create a `Draft` vault with milestones, verifier, and success/failure destinations. Validates amount, deadline, and that milestone amounts sum to the total. |
-| `stake` | Creator transfers the SEP-41 token into the contract; `Draft` -> `Active`. |
-| `check_in` | Designated verifier confirms a milestone before its `due_date`. |
-| `slash_on_miss` | After the deadline with unverified milestones, slash funds to `failure_destination`; `Active` -> `Failed`. |
-| `claim` | When all milestones are verified, release funds to `success_destination`; `Active` -> `Completed`. |
-| `withdraw` | Cancel/refund an unfunded or unstarted vault to the creator; -> `Cancelled`. |
-| `get_vault` | Read-only accessor for the current vault record. |
+| Function        | Purpose                                                                                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `create_vault`  | Create a `Draft` vault with milestones, verifier, and success/failure destinations. Validates amount, deadline, and that milestone amounts sum to the total. |
+| `stake`         | Creator transfers the SEP-41 token into the contract; `Draft` -> `Active`.                                                                                   |
+| `check_in`      | Designated verifier confirms a milestone before its `due_date`.                                                                                              |
+| `slash_on_miss` | After the deadline with unverified milestones, slash funds to `failure_destination`; `Active` -> `Failed`.                                                   |
+| `claim`         | When all milestones are verified, release funds to `success_destination`; `Active` -> `Completed`.                                                           |
+| `withdraw`      | Cancel/refund an unfunded or unstarted vault to the creator; -> `Cancelled`.                                                                                 |
+| `get_vault`     | Read-only accessor for the current vault record.                                                                                                             |
 
 The `VaultStatus` enum (`Draft`/`Active`/`Completed`/`Failed`/`Cancelled`)
 mirrors `PersistedVault.status` in `src/types/vaults.ts`. Emitted events
 (`vault_created`, `vault_staked`, `milestone_checked_in`, `vault_slashed`,
 `vault_completed`, `vault_cancelled`, `vault_withdrawn`) align with the topics
 consumed by the backend event parser.
+
+**Error Handling and Backend Recoverability:**
+Contract read operations (like `get_vault`) and state transitions (`stake`, `check_in`, `claim`) safely return `Error::NotInitialized` rather than panicking when a `vault_id` is unset in storage. The backend's `src/middleware/errorHandler.ts` relies on this typed error mapping (specifically to `ErrorCode.NOT_FOUND` with status code 404) to gracefully recover from pre-initialization read attempts.
 
 ## Build & test
 
@@ -56,6 +59,7 @@ To prevent accidental bloat in the smart contract, the `accountability_vault` in
 The default limit is set to **100,000 bytes** (~100KB).
 
 If you need to update this budget as the contract grows:
+
 1. Temporarily increase the budget locally by exporting the variable: `export MAX_WASM_SIZE=150000`
 2. Update the default value in `contracts/build-size-check.sh`
 3. Push the changes to update the CI limit.

--- a/contracts/accountability_vault/src/test.rs
+++ b/contracts/accountability_vault/src/test.rs
@@ -727,3 +727,55 @@ fn test_create_vault_failure_destination_equals_creator_fails() {
         &guardian,
     );
 }
+
+// ── pre-init paths ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_vault_not_initialized() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, AccountabilityVault);
+    let contract = AccountabilityVaultClient::new(&env, &contract_id);
+    let vault_id = String::from_str(&env, "v1");
+
+    let result = contract.try_get_vault(&vault_id);
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
+}
+
+#[test]
+fn test_stake_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, AccountabilityVault);
+    let contract = AccountabilityVaultClient::new(&env, &contract_id);
+    let vault_id = String::from_str(&env, "v1");
+    let creator = Address::generate(&env);
+
+    let result = contract.try_stake(&vault_id, &creator);
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
+}
+
+#[test]
+fn test_check_in_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, AccountabilityVault);
+    let contract = AccountabilityVaultClient::new(&env, &contract_id);
+    let vault_id = String::from_str(&env, "v1");
+    let verifier = Address::generate(&env);
+
+    let result = contract.try_check_in(&vault_id, &verifier, &0);
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
+}
+
+#[test]
+fn test_claim_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, AccountabilityVault);
+    let contract = AccountabilityVaultClient::new(&env, &contract_id);
+    let vault_id = String::from_str(&env, "v1");
+    let creator = Address::generate(&env);
+
+    let result = contract.try_claim(&vault_id, &creator);
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
+}


### PR DESCRIPTION
closes #507 

## Title
test: cover NotInitialized read paths for pre-init state

## Description
This PR introduces test coverage for pre-initialization read and write paths in the `accountability_vault` contract to ensure they properly return the `Error::NotInitialized` typed error rather than panicking. 

**Why is this important?**
The backend's `src/middleware/errorHandler.ts` relies on this specific error being returned gracefully so that it can map the Soroban contract error (Code 2) to an HTTP `404 Not Found` (`ErrorCode.NOT_FOUND`). If the contract were to panic, the backend would fail to recover gracefully.

## Changes Included
- Added `test_get_vault_not_initialized` to verify pre-init read attempts.
- Added `test_stake_not_initialized`, `test_check_in_not_initialized`, and `test_claim_not_initialized` to ensure early state transitions are safely rejected.
- Updated `contracts/README.md` to document the contract's error handling and recoverability contract with the backend.

## Related Files
- `contracts/accountability_vault/src/test.rs`
- `contracts/README.md`
- Cross-reference: `src/middleware/errorHandler.ts` (Backend)

## Verification
- [x] Contract tests pass (`cargo test` in `contracts/accountability_vault`)
- [x] Types and formatting are compliant
- [x] Acceptance criteria fully met for the newly introduced behavior
