### PR TITLE
feat: add organization residency tagging and residency-aware read DB …

### DIFF
--- a/db/migrations/20260607130000_add_residency_to_organizations.cjs
+++ b/db/migrations/20260607130000_add_residency_to_organizations.cjs
@@ -1,0 +1,36 @@
+/**
+ * Adds a residency label to enterprises and pins read queries to the matching
+ * regional read replica when configured.
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('organizations', (table) => {
+    table.enu('residency', ['EU', 'US'], {
+      useNative: true,
+      enumName: 'residency_enum',
+    }).nullable()
+  })
+
+  // Backfill residency when it can be derived from organization metadata.
+  await knex.raw(`
+    UPDATE organizations
+    SET residency = upper(metadata->>'residency')
+    WHERE metadata ? 'residency'
+      AND upper(metadata->>'residency') IN ('EU', 'US')
+  `)
+
+  await knex.raw(`
+    UPDATE organizations
+    SET residency = upper(metadata->>'region')
+    WHERE residency IS NULL
+      AND metadata ? 'region'
+      AND upper(metadata->>'region') IN ('EU', 'US')
+  `)
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('organizations', (table) => {
+    table.dropColumn('residency')
+  })
+
+  await knex.raw('DROP TYPE IF EXISTS residency_enum')
+}

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -18,11 +18,15 @@ org-scoped endpoint must uphold.
    rejects callers whose role is not in the allowed set with
    `403 Forbidden: requires role <roles>`.
 
-4. **Data scoping** — every query inside a handler filters by the `orgId` from
+4. **Data residency** — organizations may be tagged with a residency label (`EU` or `US`).
+   When present, org-scoped authorization queries are routed to the matching read replica
+   via `READ_DATABASE_URL_EU` or `READ_DATABASE_URL_US`.
+
+5. **Data scoping** — every query inside a handler filters by the `orgId` from
    `req.params`. Client-supplied `orgId` values in query strings or request bodies are
    never trusted for data access decisions.
 
-5. **No cross-org leakage** — pagination, sorting, and filtering are applied *after* the
+6. **No cross-org leakage** — pagination, sorting, and filtering are applied *after* the
    org-scope filter. A filter that matches zero records in the target org returns an empty
    result set, not records from another org.
 

--- a/src/middleware/orgAuth.ts
+++ b/src/middleware/orgAuth.ts
@@ -1,13 +1,74 @@
 import { Request, Response, NextFunction } from 'express'
 import { AuthenticatedRequest } from './auth.js'
+import knex, { Knex } from 'knex'
 import {
   getOrganization,
   getMemberRole as lookupMemberRole,
 } from '../models/organizations.js'
-import type { OrgRole } from '../models/organizations.js'
+import type { OrgRole, Residency } from '../models/organizations.js'
 import db from '../db/index.js'
 
-export type { OrgRole } from '../models/organizations.js'
+export type { OrgRole, Residency } from '../models/organizations.js'
+
+const RESIDENCY_URL_ENV: Record<Residency, keyof NodeJS.ProcessEnv> = {
+  EU: 'READ_DATABASE_URL_EU',
+  US: 'READ_DATABASE_URL_US',
+}
+
+const readDbCache = new Map<string, Knex>()
+
+export function getReadDatabaseUrl(residency?: Residency): string | undefined {
+  if (residency) {
+    const url = process.env[RESIDENCY_URL_ENV[residency]]
+    if (url && url.trim() !== '') {
+      return url
+    }
+  }
+  return process.env.DATABASE_URL
+}
+
+export function getResidencyReadDb(residency?: Residency): Knex {
+  const connectionString = getReadDatabaseUrl(residency)
+  if (!connectionString) {
+    return db
+  }
+
+  if (!readDbCache.has(connectionString)) {
+    readDbCache.set(
+      connectionString,
+      knex({
+        client: 'pg',
+        connection: connectionString,
+        pool: { min: 2, max: 10 },
+      })
+    )
+  }
+
+  return readDbCache.get(connectionString)!
+}
+
+async function getOrgResidency(orgId: string): Promise<Residency | undefined> {
+  const organization = await db('organizations')
+    .where({ id: orgId })
+    .first(['residency'])
+
+  const residency = organization?.residency
+  return residency === 'EU' || residency === 'US' ? residency : undefined
+}
+
+async function getTeamOrganizationId(teamId: string): Promise<string | undefined> {
+  const team = await db('teams').where({ id: teamId }).first(['organization_id'])
+  return team?.organization_id
+}
+
+async function resolveReadDbForOrg(orgId?: string): Promise<Knex> {
+  if (!orgId) {
+    return db
+  }
+
+  const residency = await getOrgResidency(orgId)
+  return getResidencyReadDb(residency)
+}
 
 /**
  * In-memory org access middleware (used by orgVaults routes).
@@ -59,7 +120,8 @@ export const requireOrgRole = (roles: (OrgRole | string)[]) => {
     }
 
     try {
-      const membership = await db('org_members').where({ org_id: orgId, user_id: userId }).first()
+      const readDb = await resolveReadDbForOrg(orgId)
+      const membership = await readDb('org_members').where({ org_id: orgId, user_id: userId }).first()
       if (!membership || !roles.includes(membership.role)) {
         res.status(403).json({ error: `Forbidden: requires organization role ${roles.join(' or ')}` })
         return
@@ -85,7 +147,9 @@ export const requireTeamRole = (roles: (OrgRole | string)[]) => {
     }
 
     try {
-      const membership = await db('team_members').where({ team_id: teamId, user_id: userId }).first()
+      const organizationId = await getTeamOrganizationId(teamId)
+      const readDb = await resolveReadDbForOrg(organizationId)
+      const membership = await readDb('team_members').where({ team_id: teamId, user_id: userId }).first()
       if (!membership || !roles.includes(membership.role)) {
         res.status(403).json({ error: `Forbidden: requires team role ${roles.join(' or ')}` })
         return

--- a/src/models/organizations.ts
+++ b/src/models/organizations.ts
@@ -1,7 +1,10 @@
+export type Residency = 'EU' | 'US'
+
 export interface Organization {
   id: string
   name: string
   createdAt: string
+  residency?: Residency
 }
 
 export type OrgRole = 'owner' | 'admin' | 'member'

--- a/src/services/organization.ts
+++ b/src/services/organization.ts
@@ -6,6 +6,7 @@ export const createOrganization = async (input: CreateOrganizationInput): Promis
     .insert({
       name: input.name,
       slug: input.slug,
+      residency: input.residency || null,
       metadata: input.metadata ? JSON.stringify(input.metadata) : null,
     })
     .returning('*')

--- a/src/tests/residency.test.ts
+++ b/src/tests/residency.test.ts
@@ -1,0 +1,32 @@
+import { getReadDatabaseUrl } from '../middleware/orgAuth.js'
+
+describe('Residency-aware read database URL resolution', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    process.env.DATABASE_URL = 'postgresql://default:5432/db'
+    process.env.READ_DATABASE_URL_EU = 'postgresql://eu:5432/db'
+    process.env.READ_DATABASE_URL_US = 'postgresql://us:5432/db'
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('returns the EU replica URL when residency is EU', () => {
+    expect(getReadDatabaseUrl('EU')).toBe('postgresql://eu:5432/db')
+  })
+
+  it('returns the US replica URL when residency is US', () => {
+    expect(getReadDatabaseUrl('US')).toBe('postgresql://us:5432/db')
+  })
+
+  it('falls back to DATABASE_URL when a regional replica is unset', () => {
+    delete process.env.READ_DATABASE_URL_EU
+    expect(getReadDatabaseUrl('EU')).toBe('postgresql://default:5432/db')
+  })
+
+  it('uses DATABASE_URL when residency is unset', () => {
+    expect(getReadDatabaseUrl(undefined)).toBe('postgresql://default:5432/db')
+  })
+})

--- a/src/types/enterprise.ts
+++ b/src/types/enterprise.ts
@@ -31,10 +31,13 @@ export interface EnterpriseMilestone {
 
 export type EnterpriseResponse<T> = T | { data: T };
 
+export type Residency = 'EU' | 'US'
+
 export interface Organization {
   id: string;
   name: string;
   slug: string;
+  residency?: Residency;
   metadata?: Record<string, unknown> | null;
   created_at?: Date;
   updated_at?: Date;
@@ -43,6 +46,7 @@ export interface Organization {
 export interface CreateOrganizationInput {
   name: string;
   slug: string;
+  residency?: Residency;
   metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
Implemented canonical Soroban event idempotency by deriving a stable event_key from txHash:ledger:eventIndex.

Added a Knex migration to extend processed_events with event_key text unique not null
Backfilled existing rows when possible from current event metadata
Updated [eventParser.ts](https://opulent-telegram-wr56w99gwj6vcg7r.github.dev/) to derive eventKey from Soroban event payload
Updated [eventProcessor.ts](https://opulent-telegram-wr56w99gwj6vcg7r.github.dev/) to use eventKey for duplicate detection and persistence
Added
src/tests/eventProcessor.idempotency.test.ts to verify canonical key generation, duplicate rejection, and storage
Updated [event-processing.md](https://opulent-telegram-wr56w99gwj6vcg7r.github.dev/) to document the new event key contract and idempotency behavior
This makes retry handling safe and deterministic by enforcing uniqueness on the canonical event key rather than relying on weaker or inconsistent event identity fields.
closes #470