### PR TITLE
test(privacy): add property-based logger redaction tests

### DIFF
--- a/docs/privacy-logging.md
+++ b/docs/privacy-logging.md
@@ -261,6 +261,19 @@ Coverage includes:
 - ✅ Pino JSON structure verification
 - ✅ PII leakage regression tests
 
+### Property-Based Invariants
+
+`src/tests/privacy-logger.test.ts` also uses `fast-check` with at least 100
+generated cases per property to enforce:
+
+- Sensitive keys are redacted at every nesting depth.
+- Safe objects without sensitive keys or PII-pattern values remain deep-equal.
+- `redact()` never mutates its input.
+- Email-shaped and JWT-shaped values are redacted regardless of key name.
+- Array elements are recursively redacted into a new array.
+- Structured privacy log events contain only the documented key set.
+- IPv4 masks keep the first two octets; IPv6 masks keep the first three groups.
+
 ## Compliance
 
 This logging architecture supports compliance with:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,6 +2,16 @@ import { initEnv, getEnv, type Env, type EnvWarning } from './env.js'
 
 export { initEnv, getEnv, type Env, type EnvWarning }
 
+export const config = {
+  nodeEnv: process.env.NODE_ENV ?? 'development',
+  logLevel: process.env.LOG_LEVEL ?? 'info',
+  serviceName: process.env.SERVICE_NAME ?? 'disciplr-backend',
+  corsOrigins: parseCorsOrigins(
+    process.env.CORS_ORIGINS,
+    process.env.NODE_ENV ?? 'development',
+  ),
+}
+
 /**
  * Resolves the list of allowed CORS origins from the CORS_ORIGINS env var.
  */

--- a/src/middleware/privacy-logger.ts
+++ b/src/middleware/privacy-logger.ts
@@ -1,8 +1,12 @@
 import { Request, Response, NextFunction } from 'express'
+import { Buffer } from 'node:buffer'
+import { isIP } from 'node:net'
 import { logger, withCorrelationId, getOrGenerateCorrelationId } from './logger.js'
 import { utcNow } from '../utils/timestamps.js'
 
-const SENSITIVE_FIELDS = new Set([
+export const REDACTION_MARKER = '***REDACTED***'
+
+export const SENSITIVE_KEYS = new Set([
     'email',
     'password',
     'token',
@@ -20,15 +24,33 @@ const SENSITIVE_FIELDS = new Set([
     'x-api-key'
 ])
 
+const PII_VALUE_PATTERNS = [
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+    /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/,
+]
+
 export function shouldRedact(key: string): boolean {
-    return SENSITIVE_FIELDS.has(key.toLowerCase())
+    return SENSITIVE_KEYS.has(key.toLowerCase())
 }
 
-export function redact(value: any, seen = new WeakSet()): any {
+function shouldRedactValue(value: string): boolean {
+    return PII_VALUE_PATTERNS.some(pattern => pattern.test(value))
+}
+
+type RequestWithPrivacyContext = Request & {
+    correlationId?: string
+    logger?: ReturnType<typeof withCorrelationId>
+}
+
+export function redact(value: unknown, seen = new WeakSet<object>()): unknown {
     if (value === null || value === undefined) {
         return value
     }
     
+    if (typeof value === 'string') {
+        return shouldRedactValue(value) ? REDACTION_MARKER : value
+    }
+
     // Primitive values
     if (typeof value !== 'object') {
         return value
@@ -55,10 +77,10 @@ export function redact(value: any, seen = new WeakSet()): any {
         return '[Buffer]'
     }
     
-    const result: Record<string, any> = {}
+    const result: Record<string, unknown> = {}
     for (const [k, v] of Object.entries(value)) {
         if (shouldRedact(k)) {
-            result[k] = '***REDACTED***'
+            result[k] = REDACTION_MARKER
         } else {
             result[k] = redact(v, seen)
         }
@@ -90,8 +112,9 @@ export const privacyLogger = (req: Request, _res: Response, next: NextFunction) 
     const url = req.url
 
     // Store correlation ID and logger on request for downstream handlers
-    ;(req as any).correlationId = correlationId
-    ;(req as any).logger = privacyLog
+    const requestWithContext = req as RequestWithPrivacyContext
+    requestWithContext.correlationId = correlationId
+    requestWithContext.logger = privacyLog
 
     // Redact sensitive fields before logging
     // (Pino will also redact based on its configuration, but we do it here
@@ -122,14 +145,21 @@ export const privacyLogger = (req: Request, _res: Response, next: NextFunction) 
 }
 
 export function maskIp(ip: string): string {
-    if (ip.includes(':')) {
-        // IPv6
-        return ip.split(':').slice(0, 3).join(':') + ':xxxx:xxxx:xxxx:xxxx:xxxx'
+    if (isIP(ip) === 6) {
+        const [left, right = ''] = ip.split('::')
+        const leftGroups = left ? left.split(':') : []
+        const rightGroups = right ? right.split(':') : []
+        const missingGroups = Math.max(0, 8 - leftGroups.length - rightGroups.length)
+        const groups = right
+            ? [...leftGroups, ...Array(missingGroups).fill('0'), ...rightGroups]
+            : leftGroups
+        return `${groups[0]}:${groups[1]}:${groups[2]}:xxxx:xxxx:xxxx:xxxx:xxxx`
     }
-    // IPv4
-    const parts = ip.split('.')
-    if (parts.length === 4) {
+
+    if (isIP(ip) === 4) {
+        const parts = ip.split('.')
         return `${parts[0]}.${parts[1]}.x.x`
     }
+
     return 'x.x.x.x'
 }

--- a/src/tests/privacy-logger.test.ts
+++ b/src/tests/privacy-logger.test.ts
@@ -1,31 +1,75 @@
+/* global describe, it, expect, beforeEach, afterEach, Buffer */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { jest } from '@jest/globals'
+import fc from 'fast-check'
 import { Request, Response, NextFunction } from 'express'
-import { privacyLogger, redact, maskIp, shouldRedact } from '../middleware/privacy-logger.js'
+import {
+    privacyLogger,
+    redact,
+    maskIp,
+    shouldRedact,
+    REDACTION_MARKER,
+    SENSITIVE_KEYS,
+} from '../middleware/privacy-logger.js'
 import * as loggerModule from '../middleware/logger.js'
 
-// Mock the logger module
-jest.mock('../middleware/logger.js', () => ({
-    logger: {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-        child: jest.fn(function(this: any) {
-            return this
-        }),
-    },
-    withCorrelationId: jest.fn((log, cid) => ({
-        ...log,
-        child: jest.fn(function() {
-            return this
-        }),
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    })),
-    getOrGenerateCorrelationId: jest.fn((req) => req.headers['x-correlation-id'] || 'default-cid'),
-}))
+const PROPERTY_RUNS = { numRuns: 100 }
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const JWT_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/
+const KEY_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_'.split('')
+const BASE64URL_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-'.split('')
+
+const safeKeyArb = fc
+    .array(fc.constantFrom(...KEY_CHARS), { minLength: 1, maxLength: 12 })
+    .map(chars => chars.join(''))
+    .filter(key => !SENSITIVE_KEYS.has(key.toLowerCase()))
+
+const safeStringArb = fc
+    .string({ maxLength: 40 })
+    .filter(value => !EMAIL_PATTERN.test(value) && !JWT_PATTERN.test(value))
+
+const safePrimitiveArb = fc.oneof(
+    safeStringArb,
+    fc.integer(),
+    fc.boolean(),
+    fc.constant(null),
+)
+
+const safeJsonArb: fc.Arbitrary<unknown> = fc.letrec(tie => ({
+    value: fc.oneof(
+        safePrimitiveArb,
+        fc.array(tie('value'), { maxLength: 3 }),
+        fc.dictionary(safeKeyArb, tie('value'), { maxKeys: 4 }),
+    ),
+})).value
+
+const safeObjectArb = fc.dictionary(safeKeyArb, safeJsonArb, { maxKeys: 4 })
+
+const jwtArb = fc
+    .tuple(
+        fc.array(fc.constantFrom(...BASE64URL_CHARS), { minLength: 1, maxLength: 16 }),
+        fc.array(fc.constantFrom(...BASE64URL_CHARS), { minLength: 1, maxLength: 16 }),
+        fc.array(fc.constantFrom(...BASE64URL_CHARS), { minLength: 1, maxLength: 16 }),
+    )
+    .map(parts => parts.map(chars => chars.join('')).join('.'))
+
+const ipv4Arb = fc
+    .tuple(
+        fc.integer({ min: 0, max: 255 }),
+        fc.integer({ min: 0, max: 255 }),
+        fc.integer({ min: 0, max: 255 }),
+        fc.integer({ min: 0, max: 255 }),
+    )
+    .map(parts => parts.join('.'))
+
+const ipv6Arb = fc
+    .array(fc.integer({ min: 0, max: 0xffff }), { minLength: 8, maxLength: 8 })
+    .map(groups => groups.map(group => group.toString(16).padStart(4, '0')).join(':'))
+
+function cloneJson<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value))
+}
 
 describe('Privacy Logger', () => {
     describe('Redaction Engine', () => {
@@ -136,6 +180,161 @@ describe('Privacy Logger', () => {
         })
     })
 
+    describe('Property-based privacy invariants', () => {
+        it('redacts every sensitive key at arbitrary nesting depths', () => {
+            // Feature: privacy-logger, Property 1: sensitive keys are redacted at every depth.
+            fc.assert(
+                fc.property(
+                    fc.constantFrom(...Array.from(SENSITIVE_KEYS)),
+                    safePrimitiveArb,
+                    fc.integer({ min: 0, max: 5 }),
+                    (sensitiveKey, sensitiveValue, depth) => {
+                        const wrappers = Array.from({ length: depth }, (_, index) => `level${index}`)
+                        let input: Record<string, unknown> = { [sensitiveKey]: sensitiveValue }
+
+                        for (const wrapper of [...wrappers].reverse()) {
+                            input = { [wrapper]: input }
+                        }
+
+                        let output: any = redact(input)
+                        for (const wrapper of wrappers) {
+                            output = output[wrapper]
+                        }
+
+                        expect(output[sensitiveKey]).toBe(REDACTION_MARKER)
+                    },
+                ),
+                PROPERTY_RUNS,
+            )
+        })
+
+        it('preserves safe objects without sensitive keys or PII-pattern values', () => {
+            // Feature: privacy-logger, Property 2: safe values are preserved deep-equal.
+            fc.assert(
+                fc.property(safeObjectArb, safeObject => {
+                    expect(redact(safeObject)).toEqual(safeObject)
+                }),
+                PROPERTY_RUNS,
+            )
+        })
+
+        it('does not mutate its input object', () => {
+            // Feature: privacy-logger, Property 3: redact is immutable.
+            fc.assert(
+                fc.property(safeObjectArb, safeObject => {
+                    const before = cloneJson(safeObject)
+                    redact(safeObject)
+                    expect(safeObject).toEqual(before)
+                }),
+                PROPERTY_RUNS,
+            )
+        })
+
+        it('redacts email-shaped string values regardless of key name', () => {
+            // Feature: privacy-logger, Property 4: email-pattern values are redacted.
+            fc.assert(
+                fc.property(safeKeyArb, fc.emailAddress(), (key, email) => {
+                    expect(redact({ [key]: email })).toEqual({ [key]: REDACTION_MARKER })
+                }),
+                PROPERTY_RUNS,
+            )
+        })
+
+        it('redacts JWT-shaped string values regardless of key name', () => {
+            // Feature: privacy-logger, Property 5: JWT-pattern values are redacted.
+            fc.assert(
+                fc.property(safeKeyArb, jwtArb, (key, jwt) => {
+                    expect(redact({ [key]: jwt })).toEqual({ [key]: REDACTION_MARKER })
+                }),
+                PROPERTY_RUNS,
+            )
+        })
+
+        it('redacts array elements recursively into a new array', () => {
+            // Feature: privacy-logger, Property 6: array elements are recursively redacted.
+            fc.assert(
+                fc.property(
+                    fc.array(
+                        fc.record({
+                            safeKey: safeKeyArb,
+                            sensitiveKey: fc.constantFrom(...Array.from(SENSITIVE_KEYS)),
+                            value: safePrimitiveArb,
+                        }),
+                        { minLength: 1, maxLength: 8 },
+                    ),
+                    entries => {
+                        const input = entries.map(entry => ({
+                            [entry.safeKey]: 'safe-value',
+                            nested: { [entry.sensitiveKey]: entry.value },
+                        }))
+
+                        const output = redact(input)
+
+                        expect(output).not.toBe(input)
+                        output.forEach((item: any, index: number) => {
+                            expect(item).not.toBe(input[index])
+                            expect(item.nested[entries[index].sensitiveKey]).toBe(REDACTION_MARKER)
+                        })
+                    },
+                ),
+                PROPERTY_RUNS,
+            )
+        })
+
+        it('emits only the documented structured log keys', () => {
+            // Feature: privacy-logger, Property 7: emitted log line has the required key set only.
+            fc.assert(
+                fc.property(
+                    fc.constantFrom('GET', 'POST', 'PUT', 'PATCH', 'DELETE'),
+                    fc.webPath(),
+                    safeObjectArb,
+                    safeObjectArb,
+                    (method, url, body, headers) => {
+                        const mockLogger = {
+                            debug: jest.fn(),
+                            info: jest.fn(),
+                            warn: jest.fn(),
+                            error: jest.fn(),
+                        }
+                        const next = jest.fn()
+                        const childSpy = jest
+                            .spyOn(loggerModule.logger, 'child')
+                            .mockReturnValue(mockLogger as any)
+
+                        try {
+                            privacyLogger(
+                                {
+                                    ip: '203.0.113.42',
+                                    method,
+                                    url,
+                                    body,
+                                    headers,
+                                    socket: {} as any,
+                                } as Request,
+                                {} as Response,
+                                next,
+                            )
+
+                            const logObject = mockLogger.debug.mock.calls[0][0]
+                            expect(Object.keys(logObject).sort()).toEqual(['event', 'ip', 'request', 'timestamp'])
+                            expect(Object.keys(logObject.ip).sort()).toEqual(['masked', 'original'])
+                            expect(Object.keys(logObject.request).sort()).toEqual([
+                                'body',
+                                'headers',
+                                'method',
+                                'url',
+                            ])
+                            expect(next).toHaveBeenCalledTimes(1)
+                        } finally {
+                            childSpy.mockRestore()
+                        }
+                    },
+                ),
+                PROPERTY_RUNS,
+            )
+        })
+    })
+
     describe('IP Masking', () => {
         it('should mask IPv4 address', () => {
             expect(maskIp('192.168.1.1')).toBe('192.168.x.x')
@@ -147,6 +346,30 @@ describe('Privacy Logger', () => {
 
         it('should mask IPv6 address', () => {
             expect(maskIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toBe('2001:0db8:85a3:xxxx:xxxx:xxxx:xxxx:xxxx')
+        })
+
+        it('masks arbitrary IPv4 and IPv6 values into stable shapes', () => {
+            // Feature: privacy-logger, Property 8: IP masking keeps only the allowed prefix.
+            fc.assert(
+                fc.property(ipv4Arb, ip => {
+                    expect(maskIp(ip)).toMatch(/^\d+\.\d+\.x\.x$/)
+                }),
+                PROPERTY_RUNS,
+            )
+
+            fc.assert(
+                fc.property(ipv6Arb, ip => {
+                    const masked = maskIp(ip)
+                    const maskedGroups = masked.split(':')
+
+                    expect(maskedGroups).toHaveLength(8)
+                    expect(maskedGroups.slice(0, 3)).toEqual(ip.split(':').slice(0, 3))
+                    expect(maskedGroups.slice(3)).toEqual(['xxxx', 'xxxx', 'xxxx', 'xxxx', 'xxxx'])
+                }),
+                PROPERTY_RUNS,
+            )
+
+            expect(maskIp('2001:db8::1')).toBe('2001:db8:0:xxxx:xxxx:xxxx:xxxx:xxxx')
         })
     })
 
@@ -181,8 +404,7 @@ describe('Privacy Logger', () => {
             res = {}
             next = jest.fn()
 
-            // Mock withCorrelationId to return our mock logger
-            ;(loggerModule.withCorrelationId as jest.Mock).mockReturnValue(mockLogger)
+            jest.spyOn(loggerModule.logger, 'child').mockReturnValue(mockLogger as any)
         })
 
         afterEach(() => {
@@ -237,7 +459,7 @@ describe('Privacy Logger', () => {
         it('should handle correlation IDs from request headers', () => {
             privacyLogger(req as Request, res as Response, next)
             
-            expect(loggerModule.getOrGenerateCorrelationId).toHaveBeenCalledWith(req)
+            expect((req as any).correlationId).toBe('test-corr-id')
         })
 
         it('should ensure regression against PII leakage in structured logs', () => {
@@ -294,7 +516,7 @@ describe('Privacy Logger', () => {
             res = {}
             next = jest.fn()
 
-            ;(loggerModule.withCorrelationId as jest.Mock).mockReturnValue(mockLogger)
+            jest.spyOn(loggerModule.logger, 'child').mockReturnValue(mockLogger as any)
         })
 
         it('should emit complete and valid JSON structure', () => {
@@ -321,4 +543,3 @@ describe('Privacy Logger', () => {
         })
     })
 })
-


### PR DESCRIPTION
## Summary

- add fast-check property coverage for privacy logger redaction, immutability, structured event shape, and IPv4/IPv6 masking
- extend redaction to catch email-shaped and JWT-shaped string values regardless of object key
- harden `maskIp()` for valid IPv4/IPv6 inputs and document the privacy invariants
- restore the config compatibility export needed by logger/app imports during the focused privacy logger test run

Closes #621

## Validation

- `npm test -- src/tests/privacy-logger.test.ts --runInBand` — 27 passed
- `npx eslint src/config/index.ts src/middleware/privacy-logger.ts src/tests/privacy-logger.test.ts`
- `git diff --check`

## Notes

- `npm run build` is currently blocked by an existing untouched syntax error: `src/jobs/handlers.ts(78,1): error TS1005: ')' expected.`
