### PR TITLE
security(export): sanitise export queue PII telemetry

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -32,6 +32,7 @@ _Note: Deletion will permanently remove all vaults associated with the creator f
 
 - IP addresses in logs are masked (e.g., `192.168.x.x`).
 - Request bodies containing PII are filtered before logging in production environments.
+- Export queue DLQ records, metrics-style events, and structured logs must not store raw `userId`, `targetUserId`, Stellar addresses, emails, `creator`, `successDestination`, or `failureDestination`; those values are replaced with deterministic SHA-256 tokens before storage or emission.
 
 ### Retention
 

--- a/docs/privacy-logging.md
+++ b/docs/privacy-logging.md
@@ -28,6 +28,11 @@ All logs include correlation IDs (from `x-correlation-id` or `x-request-id` head
 
 ## Redaction Policy
 
+### Export Queue DLQ and Metrics Events
+Export job failure records and export queue structured events pass through the shared privacy sanitizer before they are persisted or emitted.
+The sanitizer replaces `userId`, `targetUserId`, Stellar account addresses, emails, `creator`, `successDestination`, and `failureDestination` with deterministic 8-character SHA-256 tokens.
+This keeps failed-job diagnostics and metrics correlation stable without exposing raw user identifiers to DLQ storage, logs, or downstream observability tooling.
+
 ### Automatic Redaction Paths
 The following paths are automatically redacted by Pino (value replaced with `***REDACTED***`):
 
@@ -251,6 +256,7 @@ Debugging should rely on non-sensitive identifiers:
 Run privacy logger tests to verify redaction coverage:
 ```bash
 npm test -- src/tests/privacy-logger.test.ts
+npm test -- src/tests/exportQueue.pii.test.ts
 ```
 
 Coverage includes:

--- a/src/services/exportQueue.ts
+++ b/src/services/exportQueue.ts
@@ -1,8 +1,10 @@
 import crypto from 'node:crypto'
+import { Buffer } from 'node:buffer'
 import { stringify as csvStringify } from 'csv-stringify/sync'
 import type { Knex } from 'knex'
 import type { BackgroundJobSystem } from '../jobs/system.js'
 import { resolveS3Config, uploadToS3 } from './exportS3.js'
+import { maskPii, sanitizePrivacyPayload, sanitizePrivacyString } from '../utils/privacy.js'
 
 export type ExportFormat = 'csv' | 'json'
 export type ExportScope = 'vaults' | 'transactions' | 'analytics' | 'all'
@@ -144,6 +146,28 @@ const hashExportRequest = (input: Pick<EnqueueExportJobInput, 'targetUserId' | '
     }))
     .digest('hex')
 }
+
+const exportPiiValues = (job: Pick<ExportJob, 'userId' | 'targetUserId'>): string[] =>
+  [job.userId, job.targetUserId].filter((value): value is string => typeof value === 'string' && value.length > 0)
+
+const exportUserTokens = (job: Pick<ExportJob, 'userId' | 'targetUserId'>): {
+  requesterUserToken: string
+  targetUserToken?: string
+} => ({
+  requesterUserToken: maskPii(job.userId),
+  ...(job.targetUserId ? { targetUserToken: maskPii(job.targetUserId) } : {}),
+})
+
+const sanitizeExportTelemetry = (
+  payload: Record<string, unknown>,
+  job: Pick<ExportJob, 'userId' | 'targetUserId'>,
+): Record<string, unknown> => sanitizePrivacyPayload(
+  {
+    ...payload,
+    ...exportUserTokens(job),
+  },
+  exportPiiValues(job),
+) as Record<string, unknown>
 
 const sanitizeCsvValue = (value: unknown): string | number => {
   if (value === null || value === undefined) {
@@ -589,7 +613,7 @@ export async function processJob(
     })
 
     console.info(
-      JSON.stringify({
+      JSON.stringify(sanitizeExportTelemetry({
         level: 'info',
         event: 'exports.job_completed',
         jobId: job.id,
@@ -599,10 +623,11 @@ export async function processJob(
         bytes: buffer.length,
         s3: s3Key ? true : false,
         completedAt: new Date().toISOString(),
-      }),
+      }, job)),
     )
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
+    const sanitizedMessage = sanitizePrivacyString(message, exportPiiValues(job))
     const retryable = nextAttempt < job.maxAttempts
 
     await exportJobRepository.update({
@@ -610,13 +635,13 @@ export async function processJob(
       status: retryable ? 'pending' : 'failed',
       attempts: nextAttempt,
       completedAt: retryable ? undefined : new Date().toISOString(),
-      error: message,
+      error: sanitizedMessage,
       result: undefined,
       filename: undefined,
     })
 
     console.error(
-      JSON.stringify({
+      JSON.stringify(sanitizeExportTelemetry({
         level: 'error',
         event: 'exports.job_failed',
         jobId: job.id,
@@ -625,10 +650,12 @@ export async function processJob(
         attempt: nextAttempt,
         retryable,
         error: message,
-      }),
+      }, job)),
     )
 
-    throw error
+    const sanitizedError = new Error(sanitizedMessage)
+    sanitizedError.name = error instanceof Error ? error.name : 'Error'
+    throw sanitizedError
   }
 }
 

--- a/src/tests/exportQueue.pii.test.ts
+++ b/src/tests/exportQueue.pii.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals'
+import { URL } from 'node:url'
+import type { S3Client } from '@aws-sdk/client-s3'
+import {
+  createJob,
+  getJob,
+  processJob,
+  resetExportJobs,
+} from '../services/exportQueue.js'
+import { resetS3ClientFactory, setS3ClientFactory } from '../services/exportS3.js'
+import { maskPii, sanitizePrivacyPayload } from '../utils/privacy.js'
+
+const REQUESTER_USER_ID = 'user-raw-pii-123'
+const TARGET_USER_ID = 'target-raw-pii-456'
+const STELLAR_ADDRESS = 'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
+const EMAIL_ADDRESS = 'privacy@example.com'
+const RAW_PII_VALUES = [REQUESTER_USER_ID, TARGET_USER_ID, STELLAR_ADDRESS, EMAIL_ADDRESS]
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i
+const STELLAR_ACCOUNT_PATTERN = /\bG[A-Z2-7]{55}\b/
+
+const originalEnv = { ...process.env }
+
+const expectNoRawPii = (payload: string): void => {
+  for (const value of RAW_PII_VALUES) {
+    expect(payload).not.toContain(value)
+  }
+  expect(payload).not.toMatch(EMAIL_PATTERN)
+  expect(payload).not.toMatch(STELLAR_ACCOUNT_PATTERN)
+}
+
+const createFailingS3Client = (errorMessage: string): S3Client => {
+  const client = {
+    send: jest.fn().mockRejectedValue(new Error(errorMessage)),
+    config: {
+      requestHandler: { metadata: { handlerProtocol: 'h2' } },
+      endpointProvider: jest.fn().mockResolvedValue({ url: new URL('https://s3.us-east-1.amazonaws.com') }),
+      region: async () => 'us-east-1',
+      credentials: async () => ({
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      }),
+      signerConstructor: jest.fn(),
+      systemClockOffset: 0,
+    },
+    middlewareStack: {
+      clone: jest.fn().mockReturnThis(),
+      use: jest.fn(),
+      concat: jest.fn(),
+      applyToStack: jest.fn(),
+      identify: jest.fn(),
+      identifyOnResolve: jest.fn(),
+      resolve: jest.fn(),
+      addRelativeTo: jest.fn(),
+    },
+  }
+
+  return client as unknown as S3Client
+}
+
+describe('Export queue PII sanitisation', () => {
+  afterEach(async () => {
+    process.env = { ...originalEnv }
+    jest.restoreAllMocks()
+    resetS3ClientFactory()
+    await resetExportJobs()
+  })
+
+  it('sanitises failed job records and structured failure logs', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    const failureMessage = [
+      `upload failed for requester ${REQUESTER_USER_ID}`,
+      `target ${TARGET_USER_ID}`,
+      `destination ${STELLAR_ADDRESS}`,
+      `email ${EMAIL_ADDRESS}`,
+    ].join(' ')
+
+    process.env.EXPORT_S3_BUCKET = 'privacy-export-bucket'
+    process.env.EXPORT_S3_REGION = 'us-east-1'
+    setS3ClientFactory(() => createFailingS3Client(failureMessage))
+
+    const job = await createJob({
+      userId: REQUESTER_USER_ID,
+      isAdmin: true,
+      targetUserId: TARGET_USER_ID,
+      scope: 'vaults',
+      format: 'json',
+      maxAttempts: 1,
+      requestHash: 'hash-pii-failure',
+    })
+
+    let thrownError: unknown
+    try {
+      await processJob(job.id, [
+        {
+          id: 'vault-pii',
+          creator: REQUESTER_USER_ID,
+          amount: '100',
+          status: 'active',
+          successDestination: STELLAR_ADDRESS,
+          failureDestination: EMAIL_ADDRESS,
+          createdAt: '2030-01-01T00:00:00.000Z',
+        },
+      ])
+    } catch (error) {
+      thrownError = error
+    }
+
+    expect(thrownError).toBeInstanceOf(Error)
+    const thrownMessage = thrownError instanceof Error ? thrownError.message : String(thrownError)
+    expect(thrownMessage).not.toBe(failureMessage)
+    expect(thrownMessage).toContain(maskPii(REQUESTER_USER_ID))
+    expect(thrownMessage).toContain(maskPii(TARGET_USER_ID))
+    expectNoRawPii(thrownMessage)
+
+    const failedJob = await getJob(job.id)
+    expect(failedJob?.status).toBe('failed')
+    expect(failedJob?.error).toContain(maskPii(REQUESTER_USER_ID))
+    expect(failedJob?.error).toContain(maskPii(TARGET_USER_ID))
+    expect(failedJob?.error).toContain(maskPii(STELLAR_ADDRESS))
+    expect(failedJob?.error).toContain(maskPii(EMAIL_ADDRESS))
+    expectNoRawPii(failedJob?.error ?? '')
+
+    const failureLog = errorSpy.mock.calls.map(([entry]) => String(entry)).join('\n')
+    expect(failureLog).toContain('"event":"exports.job_failed"')
+    expect(failureLog).toContain(maskPii(REQUESTER_USER_ID))
+    expect(failureLog).toContain(maskPii(TARGET_USER_ID))
+    expectNoRawPii(failureLog)
+  })
+
+  it('emits only deterministic user tokens in completion logs', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined)
+
+    const job = await createJob({
+      userId: REQUESTER_USER_ID,
+      isAdmin: true,
+      targetUserId: TARGET_USER_ID,
+      scope: 'vaults',
+      format: 'json',
+      maxAttempts: 3,
+      requestHash: 'hash-pii-success',
+    })
+
+    await processJob(job.id, [
+      {
+        id: 'vault-pii-success',
+        creator: REQUESTER_USER_ID,
+        amount: '100',
+        status: 'active',
+        successDestination: STELLAR_ADDRESS,
+        failureDestination: EMAIL_ADDRESS,
+        createdAt: '2030-01-01T00:00:00.000Z',
+      },
+    ])
+
+    const completionLog = infoSpy.mock.calls.map(([entry]) => String(entry)).join('\n')
+    expect(completionLog).toContain('"event":"exports.job_completed"')
+    expect(completionLog).toContain(maskPii(REQUESTER_USER_ID))
+    expect(completionLog).toContain(maskPii(TARGET_USER_ID))
+    expectNoRawPii(completionLog)
+  })
+
+  it('recursively sanitises export telemetry payloads', () => {
+    const sanitized = sanitizePrivacyPayload(
+      {
+        userId: REQUESTER_USER_ID,
+        targetUserId: TARGET_USER_ID,
+        context: {
+          creator: STELLAR_ADDRESS,
+          successDestination: STELLAR_ADDRESS,
+          failureDestination: EMAIL_ADDRESS,
+          message: `export for ${REQUESTER_USER_ID} ${TARGET_USER_ID} ${STELLAR_ADDRESS} ${EMAIL_ADDRESS}`,
+        },
+      },
+      [REQUESTER_USER_ID, TARGET_USER_ID],
+    )
+
+    const encodedPayload = JSON.stringify(sanitized)
+    expect(encodedPayload).toContain(maskPii(REQUESTER_USER_ID))
+    expect(encodedPayload).toContain(maskPii(TARGET_USER_ID))
+    expect(encodedPayload).toContain(maskPii(STELLAR_ADDRESS))
+    expect(encodedPayload).toContain(maskPii(EMAIL_ADDRESS))
+    expectNoRawPii(encodedPayload)
+  })
+})

--- a/src/utils/privacy.ts
+++ b/src/utils/privacy.ts
@@ -1,4 +1,18 @@
+import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
+
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const STELLAR_ACCOUNT_PATTERN = /\bG[A-Z2-7]{55}\b/g;
+const PII_FIELD_NAMES = new Set([
+  'creator',
+  'creatoraddress',
+  'email',
+  'failuredestination',
+  'requesteruserid',
+  'successdestination',
+  'targetuserid',
+  'userid',
+]);
 
 /**
  * Masks sensitive information using a deterministic one-way hash.
@@ -12,4 +26,75 @@ export function maskPii(value: string | undefined | null): string {
     .update(value)
     .digest('hex')
     .substring(0, 8);
+}
+
+const normalizePrivacyKey = (key: string): string => key.replace(/[_-]/g, '').toLowerCase();
+
+const knownPiiTokens = (values: readonly unknown[]): string[] => {
+  return Array.from(
+    new Set(
+      values
+        .filter((value): value is string => typeof value === 'string' && value.length > 0)
+        .sort((left, right) => right.length - left.length),
+    ),
+  );
+};
+
+export function isPrivacySensitiveField(key: string): boolean {
+  return PII_FIELD_NAMES.has(normalizePrivacyKey(key));
+}
+
+export function sanitizePrivacyString(value: string, knownPiiValues: readonly unknown[] = []): string {
+  let sanitized = value;
+
+  for (const token of knownPiiTokens(knownPiiValues)) {
+    sanitized = sanitized.split(token).join(maskPii(token));
+  }
+
+  return sanitized
+    .replace(EMAIL_PATTERN, (match) => maskPii(match))
+    .replace(STELLAR_ACCOUNT_PATTERN, (match) => maskPii(match));
+}
+
+export function sanitizePrivacyPayload(value: unknown, knownPiiValues: readonly unknown[] = [], seen = new WeakSet<object>()): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return sanitizePrivacyString(value, knownPiiValues);
+  }
+
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+  seen.add(value);
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return '[Buffer]';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizePrivacyPayload(item, knownPiiValues, seen));
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, entryValue] of Object.entries(value)) {
+    if (isPrivacySensitiveField(key) && typeof entryValue !== 'object') {
+      sanitized[key] = maskPii(String(entryValue));
+      continue;
+    }
+
+    sanitized[key] = sanitizePrivacyPayload(entryValue, knownPiiValues, seen);
+  }
+
+  return sanitized;
 }


### PR DESCRIPTION
## Summary
- centralise privacy sanitisation for export queue telemetry and failed job diagnostics
- store and log deterministic tokens for requester/target users, Stellar addresses, and emails instead of raw values
- rethrow sanitized export errors so queue dead-letter history does not persist raw PII
- add export queue regression coverage and document the DLQ/logging guarantee

Fixes #629

## Verification
- `npm.cmd test -- src/tests/exportQueue.pii.test.ts --runInBand`
- `npm.cmd test -- src/tests/exportQueue.s3.test.ts --runInBand`
- `npx.cmd eslint src/utils/privacy.ts src/services/exportQueue.ts src/tests/exportQueue.pii.test.ts`
- `git diff --check`

Additional checks:
- `npm.cmd run build` is currently blocked by existing `src/jobs/handlers.ts(78,1): error TS1005: ')' expected`
- `npm.cmd test -- src/tests/jobs.deadletter.test.ts --runInBand --detectOpenHandles --forceExit` currently fails on existing queue metrics / Supertest issues unrelated to this change (`sessions.cleanup` metrics entry and `mime.getType`)
- `npm.cmd test -- --testMatch **/src/routes/exports.test.ts --runInBand` previously showed 6/7 passing with the existing env bootstrap failure `Environment not validated yet - call initEnv() first`