### PR TITLE
perf(tests): add endpoint latency budgets

### DIFF
--- a/PERFORMANCE_TESTS_README.md
+++ b/PERFORMANCE_TESTS_README.md
@@ -102,7 +102,7 @@ Error: relation "vaults" does not exist
 Response time 3456ms exceeded threshold 2000ms
 ```
 **Solution**: 
-1. Check database indexes with `EXPLAIN ANALYZE`
+1. Check database indexes with `EXPLAIN (ANALYZE, FORMAT JSON)`
 2. Review query patterns for N+1 problems
 3. Consider adjusting thresholds if environment is consistently slower
 
@@ -110,13 +110,10 @@ Response time 3456ms exceeded threshold 2000ms
 
 If tests are consistently failing or passing with too much margin:
 
-1. **Edit test files** in `src/tests/performance/`
-2. **Adjust thresholds**:
+1. **Edit the shared budget table** in `src/tests/helpers/performanceHelpers.ts`
+2. **Adjust the named endpoint budget**:
    ```typescript
-   const thresholds: PerformanceThresholds = {
-     maxResponseTime: 1500, // Adjust this value
-     maxQueryCount: 8       // Adjust this value
-   }
+   const thresholds = getPerformanceBudget('transactions.filteredByType')
    ```
 3. **Document changes** in `docs/performance-testing.md`
 
@@ -144,13 +141,13 @@ Use these logs to:
 
 ## Validating Indexes
 
-To verify indexes are being used:
+To verify indexes are being used manually or with `assertIndexedQueryPlan()`:
 
 ```sql
-EXPLAIN ANALYZE 
+EXPLAIN (ANALYZE, FORMAT JSON)
 SELECT * FROM vaults 
-WHERE creator_id = 'user-123' 
-ORDER BY created_at DESC 
+WHERE status = 'active'
+ORDER BY end_date DESC
 LIMIT 20;
 ```
 

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -49,13 +49,22 @@ These volumes are realistic for smoke testing while keeping test execution time 
 
 ## Performance Thresholds
 
-### Current Thresholds
+### Current Budgets
 
-| Endpoint Type | Max Response Time | Max Query Count |
-|--------------|-------------------|-----------------|
-| Vaults | 2000ms | 10 queries |
-| Transactions | 2000ms | 10 queries |
-| Analytics | 1000ms | N/A |
+The canonical budgets live in `PERFORMANCE_BUDGETS` in `src/tests/helpers/performanceHelpers.ts`.
+Use `getPerformanceBudget()` in endpoint tests instead of copying literal thresholds.
+
+| Budget key | Endpoint scenario | Max response time | Max query count | Index expectation |
+|------------|-------------------|-------------------|-----------------|-------------------|
+| `vaults.list` | first page with default ordering | 1200ms | 5 queries | Sequential scan allowed for unfiltered smoke coverage |
+| `vaults.filteredByStatus` | status filter with deadline ordering | 1500ms | 6 queries | `idx_vaults_status_end_date` |
+| `vaults.deepPage` | deep page with deadline ordering | 2000ms | 6 queries | `idx_vaults_end_date` |
+| `transactions.list` | first cursor page with newest ordering | 1200ms | 5 queries | `idx_transactions_stellar_timestamp` |
+| `transactions.filteredByType` | type filter with created-at ordering | 1500ms | 6 queries | `idx_transactions_type_created_at` |
+| `transactions.byVault` | vault-specific transaction list | 1200ms | 5 queries | `idx_transactions_vault_id` |
+| `analytics.summary` | aggregate summary | 750ms | 4 queries | Sequential scan allowed for small aggregate table |
+| `analytics.vaults` | vault analytics rollup | 1000ms | 5 queries | Sequential scan allowed until this endpoint reads persisted rollups |
+| `analytics.milestoneTrends` | date-range milestone trend query | 1500ms | 6 queries | Sequential scan allowed while milestone events are in memory |
 
 ### Threshold Philosophy
 
@@ -70,16 +79,13 @@ If tests become flaky or too lenient:
 
 1. **Analyze actual performance**: Run tests locally and review logs
 2. **Check for regressions**: Compare current vs. historical performance
-3. **Adjust thresholds**: Update in test files under `src/tests/performance/`
+3. **Adjust thresholds**: Update `PERFORMANCE_BUDGETS` in `src/tests/helpers/performanceHelpers.ts`
 4. **Document changes**: Update this file with rationale
 
 Example threshold adjustment:
 
 ```typescript
-const thresholds: PerformanceThresholds = {
-  maxResponseTime: 1500, // Reduced from 2000ms
-  maxQueryCount: 8       // Reduced from 10
-}
+const thresholds = getPerformanceBudget('transactions.filteredByType')
 ```
 
 ## Running Performance Tests
@@ -133,6 +139,40 @@ const result = await measurePerformance(
   },
   { maxResponseTime: 2000 }
 )
+```
+
+#### `getPerformanceBudget(name)`
+
+Returns the named endpoint budget from `PERFORMANCE_BUDGETS`.
+
+```typescript
+const thresholds = getPerformanceBudget('vaults.filteredByStatus')
+```
+
+#### `assertQueryCount(queryCount, thresholds, testName)`
+
+Fails when the measured query count exceeds the endpoint budget.
+
+```typescript
+const queryCount = await trackQueries(db, async () => {
+  await request(app).get('/api/transactions?type=deposit').expect(200)
+})
+
+assertQueryCount(queryCount, getPerformanceBudget('transactions.filteredByType'), 'transactions_filtered_by_type')
+```
+
+#### `assertIndexedQueryPlan(plan, thresholds, testName)`
+
+Parses PostgreSQL `EXPLAIN (FORMAT JSON)` output or copied text plans and verifies that representative filtered/sorted queries use the expected indexes.
+
+```typescript
+const plan = await explainQueryPlan(
+  db,
+  'SELECT * FROM transactions WHERE type = ? ORDER BY created_at DESC LIMIT 20',
+  ['deposit']
+)
+
+assertIndexedQueryPlan(plan, getPerformanceBudget('transactions.filteredByType'), 'transactions_filtered_by_type_plan')
 ```
 
 #### `seedLargeDataset(db, tableName, count, recordFactory)`
@@ -202,6 +242,7 @@ Performance tests validate that appropriate indexes exist. Current indexes:
 CREATE INDEX idx_vaults_creator_id ON vaults(creator_id);
 CREATE INDEX idx_vaults_status ON vaults(status);
 CREATE INDEX idx_vaults_end_date ON vaults(end_date);
+CREATE INDEX idx_vaults_status_end_date ON vaults(status, end_date);
 ```
 
 ### Transactions Table
@@ -211,18 +252,18 @@ CREATE INDEX idx_transactions_user_id ON transactions(user_id);
 CREATE INDEX idx_transactions_vault_id ON transactions(vault_id);
 CREATE INDEX idx_transactions_stellar_timestamp ON transactions(stellar_timestamp);
 CREATE INDEX idx_transactions_type ON transactions(type);
-CREATE INDEX idx_transactions_cursor ON transactions(stellar_timestamp, id);
+CREATE INDEX idx_transactions_type_created_at ON transactions(type, created_at);
 ```
 
 ### Validating Indexes
 
-To verify indexes are being used, check query plans:
+To verify indexes are being used, check query plans manually or use `assertIndexedQueryPlan()` in performance tests:
 
 ```sql
-EXPLAIN ANALYZE 
+EXPLAIN (ANALYZE, FORMAT JSON)
 SELECT * FROM vaults 
-WHERE creator_id = 'user-123' 
-ORDER BY created_at DESC 
+WHERE status = 'active'
+ORDER BY end_date DESC
 LIMIT 20;
 ```
 
@@ -319,14 +360,14 @@ import { db } from '../../db/index.js'
 import {
   measurePerformance,
   assertPerformance,
+  assertIndexedQueryPlan,
+  explainQueryPlan,
+  getPerformanceBudget,
   logPerformanceMetrics
 } from '../helpers/performanceHelpers.js'
 
 describe('GET /api/new-endpoint - Performance Smoke Tests', () => {
-  const thresholds = {
-    maxResponseTime: 2000,
-    maxQueryCount: 10
-  }
+  const thresholds = getPerformanceBudget('vaults.filteredByStatus')
 
   beforeAll(async () => {
     // Seed test data
@@ -347,6 +388,16 @@ describe('GET /api/new-endpoint - Performance Smoke Tests', () => {
     
     logPerformanceMetrics('new_endpoint', result)
     assertPerformance(result, 'new_endpoint')
+  })
+
+  it('should use the expected index for filtered queries', async () => {
+    const plan = await explainQueryPlan(
+      db,
+      'SELECT * FROM vaults WHERE status = ? ORDER BY end_date DESC LIMIT 20',
+      ['active']
+    )
+
+    assertIndexedQueryPlan(plan, thresholds, 'new_endpoint_plan')
   })
 })
 ```

--- a/src/tests/helpers/performanceHelpers.test.ts
+++ b/src/tests/helpers/performanceHelpers.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from '@jest/globals'
+import {
+  PERFORMANCE_BUDGETS,
+  analyseQueryPlan,
+  assertIndexedQueryPlan,
+  assertPerformance,
+  assertQueryCount,
+  evaluatePerformanceThresholds,
+  getPerformanceBudget
+} from './performanceHelpers.js'
+
+describe('performanceHelpers', () => {
+  it('defines endpoint-specific budgets instead of a single blanket threshold', () => {
+    expect(getPerformanceBudget('vaults.filteredByStatus')).toMatchObject({
+      endpoint: 'GET /api/vaults?status=active&sortBy=endTimestamp',
+      maxResponseTime: 1500,
+      maxQueryCount: 6,
+      expectedIndexes: ['idx_vaults_status_end_date']
+    })
+
+    expect(PERFORMANCE_BUDGETS['analytics.summary'].maxResponseTime).toBeLessThan(
+      PERFORMANCE_BUDGETS['vaults.deepPage'].maxResponseTime
+    )
+  })
+
+  it('reports both response-time and query-count budget violations', () => {
+    const result = evaluatePerformanceThresholds(
+      1750,
+      { maxResponseTime: 1000, maxQueryCount: 3 },
+      5
+    )
+
+    expect(result.passed).toBe(false)
+    expect(result.violations).toEqual([
+      'Response time 1750ms exceeded threshold 1000ms',
+      'Query count 5 exceeded threshold 3'
+    ])
+  })
+
+  it('keeps existing assertPerformance error context intact', () => {
+    const result = evaluatePerformanceThresholds(2500, { maxResponseTime: 1000 })
+
+    expect(() => assertPerformance(result, 'vaults_list')).toThrow(
+      'Performance test "vaults_list" failed: Response time 2500ms exceeded threshold 1000ms. Response time: 2500ms'
+    )
+  })
+
+  it('rejects query-count regressions independently from response time', () => {
+    expect(() => assertQueryCount(9, { maxResponseTime: 1000, maxQueryCount: 6 }, 'transactions_list'))
+      .toThrow('Performance test "transactions_list" failed: Query count 9 exceeded threshold 6')
+
+    expect(() => assertQueryCount(6, { maxResponseTime: 1000, maxQueryCount: 6 }, 'transactions_list'))
+      .not.toThrow()
+  })
+
+  it('extracts indexes from PostgreSQL JSON explain plans', () => {
+    const plan = [
+      {
+        'QUERY PLAN': [
+          {
+            Plan: {
+              'Node Type': 'Nested Loop',
+              Plans: [
+                {
+                  'Node Type': 'Index Scan',
+                  'Index Name': 'idx_vaults_status_end_date',
+                  'Relation Name': 'vaults'
+                },
+                {
+                  'Node Type': 'Index Only Scan',
+                  'Index Name': 'idx_transactions_vault_id',
+                  'Relation Name': 'transactions'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+
+    const analysis = assertIndexedQueryPlan(
+      plan,
+      { maxResponseTime: 1500, expectedIndexes: ['idx_vaults_status_end_date', 'idx_transactions_vault_id'] },
+      'indexed_join'
+    )
+
+    expect(analysis.nodeTypes).toEqual(['Nested Loop', 'Index Scan', 'Index Only Scan'])
+    expect(analysis.usedIndexes).toEqual(['idx_vaults_status_end_date', 'idx_transactions_vault_id'])
+    expect(analysis.sequentialScanTables).toEqual([])
+  })
+
+  it('rejects sequential scans and missing expected indexes', () => {
+    const plan = [
+      {
+        Plan: {
+          'Node Type': 'Seq Scan',
+          'Relation Name': 'transactions'
+        }
+      }
+    ]
+
+    expect(() =>
+      assertIndexedQueryPlan(
+        plan,
+        { maxResponseTime: 1500, expectedIndexes: ['idx_transactions_stellar_timestamp'] },
+        'transactions_date_filter'
+      )
+    ).toThrow(
+      'Performance query plan "transactions_date_filter" failed: Sequential scan detected on transactions, Expected index idx_transactions_stellar_timestamp was not used'
+    )
+  })
+
+  it('allows documented sequential scans for aggregate-only analytics budgets', () => {
+    const plan = [{ Plan: { 'Node Type': 'Seq Scan', 'Relation Name': 'analytics_vault_summary' } }]
+
+    const analysis = assertIndexedQueryPlan(
+      plan,
+      { maxResponseTime: 750, allowSequentialScan: true },
+      'analytics_summary'
+    )
+
+    expect(analysis.sequentialScanTables).toEqual(['analytics_vault_summary'])
+  })
+
+  it('parses text explain output from local debugging sessions', () => {
+    const textPlan = `
+Limit
+  ->  Index Scan using idx_transactions_type_created_at on transactions
+        Index Cond: (type = 'deposit'::text)
+`
+
+    expect(analyseQueryPlan(textPlan)).toEqual({
+      nodeTypes: ['Index Scan'],
+      usedIndexes: ['idx_transactions_type_created_at'],
+      sequentialScanTables: []
+    })
+  })
+})

--- a/src/tests/helpers/performanceHelpers.ts
+++ b/src/tests/helpers/performanceHelpers.ts
@@ -10,6 +10,10 @@ export interface PerformanceThresholds {
   maxResponseTime: number
   /** Maximum acceptable query count (if available) */
   maxQueryCount?: number
+  /** Indexes expected to appear in representative EXPLAIN plans */
+  expectedIndexes?: readonly string[]
+  /** Allow sequential scans for tiny aggregate queries where indexes are not useful */
+  allowSequentialScan?: boolean
 }
 
 export interface PerformanceResult {
@@ -23,39 +27,135 @@ export interface PerformanceResult {
   violations: string[]
 }
 
+export interface EndpointPerformanceBudget extends PerformanceThresholds {
+  /** Human-readable route or query shape covered by the budget */
+  endpoint: string
+  /** Query scenario covered by this budget */
+  scenario: string
+}
+
+export interface QueryPlanAnalysis {
+  nodeTypes: string[]
+  usedIndexes: string[]
+  sequentialScanTables: string[]
+}
+
+export const PERFORMANCE_BUDGETS = {
+  'vaults.list': {
+    endpoint: 'GET /api/vaults',
+    scenario: 'first page with default ordering',
+    maxResponseTime: 1200,
+    maxQueryCount: 5,
+    allowSequentialScan: true
+  },
+  'vaults.filteredByStatus': {
+    endpoint: 'GET /api/vaults?status=active&sortBy=endTimestamp',
+    scenario: 'status filter with deadline ordering',
+    maxResponseTime: 1500,
+    maxQueryCount: 6,
+    expectedIndexes: ['idx_vaults_status_end_date']
+  },
+  'vaults.deepPage': {
+    endpoint: 'GET /api/vaults?page=10&pageSize=50&sortBy=endTimestamp',
+    scenario: 'deep offset page with deadline ordering',
+    maxResponseTime: 2000,
+    maxQueryCount: 6,
+    expectedIndexes: ['idx_vaults_end_date']
+  },
+  'transactions.list': {
+    endpoint: 'GET /api/transactions',
+    scenario: 'first cursor page with newest ordering',
+    maxResponseTime: 1200,
+    maxQueryCount: 5,
+    expectedIndexes: ['idx_transactions_stellar_timestamp']
+  },
+  'transactions.filteredByType': {
+    endpoint: 'GET /api/transactions?type=deposit&sortBy=created_at',
+    scenario: 'type filter with created-at ordering',
+    maxResponseTime: 1500,
+    maxQueryCount: 6,
+    expectedIndexes: ['idx_transactions_type_created_at']
+  },
+  'transactions.byVault': {
+    endpoint: 'GET /api/transactions/vault/:vaultId',
+    scenario: 'vault-specific transaction list',
+    maxResponseTime: 1200,
+    maxQueryCount: 5,
+    expectedIndexes: ['idx_transactions_vault_id']
+  },
+  'analytics.summary': {
+    endpoint: 'GET /api/analytics/summary',
+    scenario: 'aggregate summary',
+    maxResponseTime: 750,
+    maxQueryCount: 4,
+    allowSequentialScan: true
+  },
+  'analytics.vaults': {
+    endpoint: 'GET /api/analytics/vaults',
+    scenario: 'vault analytics rollup',
+    maxResponseTime: 1000,
+    maxQueryCount: 5,
+    allowSequentialScan: true
+  },
+  'analytics.milestoneTrends': {
+    endpoint: 'GET /api/analytics/milestones/trends',
+    scenario: 'date-range milestone trend query',
+    maxResponseTime: 1500,
+    maxQueryCount: 6,
+    allowSequentialScan: true
+  }
+} as const satisfies Record<string, EndpointPerformanceBudget>
+
+export type PerformanceBudgetName = keyof typeof PERFORMANCE_BUDGETS
+
+export function getPerformanceBudget(name: PerformanceBudgetName): EndpointPerformanceBudget {
+  return PERFORMANCE_BUDGETS[name]
+}
+
+export function evaluatePerformanceThresholds(
+  responseTime: number,
+  thresholds: PerformanceThresholds,
+  queryCount?: number
+): PerformanceResult {
+  const violations: string[] = []
+
+  if (responseTime > thresholds.maxResponseTime) {
+    violations.push(
+      `Response time ${responseTime}ms exceeded threshold ${thresholds.maxResponseTime}ms`
+    )
+  }
+
+  if (queryCount !== undefined && thresholds.maxQueryCount !== undefined && queryCount > thresholds.maxQueryCount) {
+    violations.push(
+      `Query count ${queryCount} exceeded threshold ${thresholds.maxQueryCount}`
+    )
+  }
+
+  return {
+    responseTime,
+    queryCount,
+    passed: violations.length === 0,
+    violations
+  }
+}
+
 /**
  * Measure response time for an async operation
  * @param operation - The async operation to measure
  * @returns Performance result with timing information
  */
 export async function measurePerformance(
-  operation: () => Promise<any>,
+  operation: () => Promise<unknown>,
   thresholds: PerformanceThresholds
 ): Promise<PerformanceResult> {
   const startTime = Date.now()
-  
-  try {
-    await operation()
-  } catch (error) {
-    throw error
-  }
-  
+
+  await operation()
+
   const endTime = Date.now()
   const responseTime = endTime - startTime
-  
-  const violations: string[] = []
-  
-  if (responseTime > thresholds.maxResponseTime) {
-    violations.push(
-      `Response time ${responseTime}ms exceeded threshold ${thresholds.maxResponseTime}ms`
-    )
-  }
-  
-  return {
-    responseTime,
-    passed: violations.length === 0,
-    violations
-  }
+
+  return evaluatePerformanceThresholds(responseTime, thresholds)
 }
 
 /**
@@ -67,7 +167,7 @@ export async function measurePerformance(
  */
 export async function trackQueries(
   db: Knex,
-  operation: () => Promise<any>
+  operation: () => Promise<unknown>
 ): Promise<number> {
   let queryCount = 0
   
@@ -85,6 +185,119 @@ export async function trackQueries(
   }
   
   return queryCount
+}
+
+export async function explainQueryPlan(
+  db: Knex,
+  sql: string,
+  bindings: readonly unknown[] = []
+): Promise<unknown> {
+  const result = await db.raw(`EXPLAIN (FORMAT JSON) ${sql}`, bindings)
+  return result.rows ?? result
+}
+
+export function analyseQueryPlan(plan: unknown): QueryPlanAnalysis {
+  const analysis: QueryPlanAnalysis = {
+    nodeTypes: [],
+    usedIndexes: [],
+    sequentialScanTables: []
+  }
+
+  visitPlanNode(plan, analysis)
+
+  return {
+    nodeTypes: unique(analysis.nodeTypes),
+    usedIndexes: unique(analysis.usedIndexes),
+    sequentialScanTables: unique(analysis.sequentialScanTables)
+  }
+}
+
+export function assertIndexedQueryPlan(
+  plan: unknown,
+  thresholds: PerformanceThresholds,
+  testName: string
+): QueryPlanAnalysis {
+  const analysis = analyseQueryPlan(plan)
+  const violations: string[] = []
+
+  if (!thresholds.allowSequentialScan && analysis.sequentialScanTables.length > 0) {
+    violations.push(
+      `Sequential scan detected on ${analysis.sequentialScanTables.join(', ')}`
+    )
+  }
+
+  for (const expectedIndex of thresholds.expectedIndexes ?? []) {
+    if (!analysis.usedIndexes.includes(expectedIndex)) {
+      violations.push(`Expected index ${expectedIndex} was not used`)
+    }
+  }
+
+  if (violations.length > 0) {
+    throw new Error(`Performance query plan "${testName}" failed: ${violations.join(', ')}`)
+  }
+
+  return analysis
+}
+
+function visitPlanNode(plan: unknown, analysis: QueryPlanAnalysis): void {
+  if (Array.isArray(plan)) {
+    for (const item of plan) {
+      visitPlanNode(item, analysis)
+    }
+    return
+  }
+
+  if (typeof plan === 'string') {
+    visitTextPlan(plan, analysis)
+    return
+  }
+
+  if (!plan || typeof plan !== 'object') {
+    return
+  }
+
+  const node = plan as Record<string, unknown>
+  const nodeType = stringValue(node['Node Type'])
+  if (nodeType) {
+    analysis.nodeTypes.push(nodeType)
+  }
+
+  const indexName = stringValue(node['Index Name'])
+  if (indexName) {
+    analysis.usedIndexes.push(indexName)
+  }
+
+  if (nodeType?.toLowerCase() === 'seq scan') {
+    analysis.sequentialScanTables.push(stringValue(node['Relation Name']) ?? 'unknown')
+  }
+
+  visitPlanNode(node['QUERY PLAN'], analysis)
+  visitPlanNode(node.Plan, analysis)
+  visitPlanNode(node.Plans, analysis)
+}
+
+function visitTextPlan(plan: string, analysis: QueryPlanAnalysis): void {
+  for (const line of plan.split(/\r?\n/)) {
+    const seqScan = line.match(/\bSeq Scan on\s+([^\s]+)/i)
+    if (seqScan) {
+      analysis.nodeTypes.push('Seq Scan')
+      analysis.sequentialScanTables.push(seqScan[1])
+    }
+
+    const indexScan = line.match(/\bIndex(?: Only)? Scan using\s+([^\s]+)/i)
+    if (indexScan) {
+      analysis.nodeTypes.push(line.includes('Index Only Scan') ? 'Index Only Scan' : 'Index Scan')
+      analysis.usedIndexes.push(indexScan[1])
+    }
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)]
 }
 
 /**
@@ -209,6 +422,19 @@ export function assertPerformance(result: PerformanceResult, testName: string): 
       `Performance test "${testName}" failed: ${violationMessages}. ` +
       `Response time: ${result.responseTime}ms`
     )
+  }
+}
+
+export function assertQueryCount(
+  queryCount: number,
+  thresholds: PerformanceThresholds,
+  testName: string
+): void {
+  const result = evaluatePerformanceThresholds(0, thresholds, queryCount)
+  const queryViolations = result.violations.filter((violation) => violation.startsWith('Query count'))
+
+  if (queryViolations.length > 0) {
+    throw new Error(`Performance test "${testName}" failed: ${queryViolations.join(', ')}`)
   }
 }
 


### PR DESCRIPTION
Closes #632

## Problem

The performance helper layer still used coarse response-time thresholds and had no reusable way to assert query budgets or representative index usage. That made it easy for endpoint tests to drift and hard to catch N+1 or missing-index regressions consistently.

## Root cause

Thresholds were documented as endpoint categories, not named budgets tied to specific query shapes. Query-count and EXPLAIN plan validation also had to be repeated manually in each future performance test.

## Solution

- Added shared `PERFORMANCE_BUDGETS` for vault, transaction, and analytics scenarios.
- Added helpers for query-count assertions and PostgreSQL EXPLAIN plan analysis.
- Added unit coverage for response/query budget failures, JSON and text EXPLAIN parsing, expected-index checks, and sequential-scan rejection.
- Updated performance docs to point contributors at the shared budget table and current migration-backed index names.

## Verification

- `npm ci`
- `npm test -- src/tests/helpers/performanceHelpers.test.ts --runInBand`
- `npx eslint src/tests/helpers/performanceHelpers.ts src/tests/helpers/performanceHelpers.test.ts`
- `git diff --check`

`npm run build` still stops on the existing upstream syntax error in `src/jobs/handlers.ts(78,1): error TS1005: ')' expected.`
