### PR TITLE
test: add endpoint performance budgets and index assertions

### DIFF
--- a/PERFORMANCE_TESTS_README.md
+++ b/PERFORMANCE_TESTS_README.md
@@ -46,26 +46,26 @@ npm test -- src/tests/helpers/performanceHelpers.test.ts
 
 ### Successful Test Run
 ```
-✓ Vaults list (no pagination): 245ms
-✓ Vaults list (with pagination): 198ms
-✓ Vaults list (with sorting): 267ms
-✓ Vaults list (with filtering): 223ms
-✓ Vaults list (combined operations): 289ms
+OK Vaults list (no pagination): 245ms
+OK Vaults list (with pagination): 198ms
+OK Vaults list (with sorting): 267ms
+OK Vaults list (with filtering): 223ms
+OK Vaults list (combined operations): 289ms
 
-✓ Transactions list (first page): 312ms
-✓ Transactions list (cursor pagination): 298ms
-✓ Transactions list (with filter): 334ms
-✓ Transactions list (date range filter): 356ms
-✓ Transactions list (by vault): 287ms
-✓ Transactions deep pagination (10 pages): 2145ms
+OK Transactions list (first page): 312ms
+OK Transactions list (cursor pagination): 298ms
+OK Transactions list (with filter): 334ms
+OK Transactions list (date range filter): 356ms
+OK Transactions list (by vault): 287ms
+OK Transactions deep pagination (10 pages): 2145ms
 
-✓ Analytics summary: 45ms
-✓ Analytics overview: 38ms
-✓ Analytics vaults: 42ms
-✓ Analytics vault-specific: 41ms
-✓ Analytics milestone trends: 156ms
-✓ Analytics behavior: 134ms
-✓ Analytics milestone trends (weekly): 178ms
+OK Analytics summary: 45ms
+OK Analytics overview: 38ms
+OK Analytics vaults: 42ms
+OK Analytics vault-specific: 41ms
+OK Analytics milestone trends: 156ms
+OK Analytics behavior: 134ms
+OK Analytics milestone trends (weekly): 178ms
 ```
 
 ### Failed Test (Threshold Violation)
@@ -110,13 +110,13 @@ Response time 3456ms exceeded threshold 2000ms
 
 If tests are consistently failing or passing with too much margin:
 
-1. **Edit test files** in `src/tests/performance/`
+1. **Edit the shared budget table** in `src/tests/helpers/performanceHelpers.ts`
 2. **Adjust thresholds**:
    ```typescript
-   const thresholds: PerformanceThresholds = {
-     maxResponseTime: 1500, // Adjust this value
-     maxQueryCount: 8       // Adjust this value
-   }
+   const thresholds = getPerformanceBudget('transactions.combinedSortFilter', {
+     maxResponseTime: 950,
+     maxQueryCount: 5,
+   })
    ```
 3. **Document changes** in `docs/performance-testing.md`
 
@@ -155,8 +155,8 @@ LIMIT 20;
 ```
 
 Look for:
-- ✅ `Index Scan` or `Index Only Scan`
-- ❌ `Seq Scan` (indicates missing index)
+- OK: `Index Scan`, `Index Only Scan`, or `Bitmap Index Scan`
+- Investigate: `Seq Scan` on high-cardinality list queries
 
 ## CI Integration
 

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -49,13 +49,26 @@ These volumes are realistic for smoke testing while keeping test execution time 
 
 ## Performance Thresholds
 
-### Current Thresholds
+### Current Per-Endpoint Budgets
 
-| Endpoint Type | Max Response Time | Max Query Count |
-|--------------|-------------------|-----------------|
-| Vaults | 2000ms | 10 queries |
-| Transactions | 2000ms | 10 queries |
-| Analytics | 1000ms | N/A |
+Budgets are defined in `src/tests/helpers/performanceHelpers.ts` as
+`ENDPOINT_PERFORMANCE_BUDGETS`. Endpoint tests should call `getPerformanceBudget()`
+instead of duplicating threshold literals.
+
+| Endpoint scenario | Max response time | Max query count | Expected index coverage |
+| --- | ---: | ---: | --- |
+| `vaults.list` | 750ms | 4 | `idx_vaults_status_end_date`, `idx_vaults_end_date` |
+| `vaults.deepPagination` | 1200ms | 6 | `idx_vaults_status_end_date` |
+| `vaults.combinedSortFilter` | 900ms | 5 | `idx_vaults_status_end_date` |
+| `transactions.list` | 900ms | 5 | `idx_transactions_stellar_timestamp` |
+| `transactions.cursorPagination` | 1000ms | 5 | `idx_transactions_stellar_timestamp` |
+| `transactions.byVault` | 900ms | 5 | `idx_transactions_stellar_timestamp` |
+| `transactions.combinedSortFilter` | 1100ms | 6 | `idx_transactions_type_created_at`, `idx_transactions_stellar_timestamp` |
+| `analytics.summary` | 350ms | 2 | constant-time summary path |
+| `analytics.overview` | 250ms | 1 | no DB read expected |
+| `analytics.vaults` | 350ms | 2 | `idx_vaults_status_end_date` |
+| `analytics.milestoneTrends` | 650ms | 3 | in-memory milestone event scan |
+| `analytics.behavior` | 650ms | 3 | in-memory milestone event scan |
 
 ### Threshold Philosophy
 
@@ -70,16 +83,15 @@ If tests become flaky or too lenient:
 
 1. **Analyze actual performance**: Run tests locally and review logs
 2. **Check for regressions**: Compare current vs. historical performance
-3. **Adjust thresholds**: Update in test files under `src/tests/performance/`
+3. **Adjust thresholds**: Update `ENDPOINT_PERFORMANCE_BUDGETS` in `src/tests/helpers/performanceHelpers.ts`
 4. **Document changes**: Update this file with rationale
 
 Example threshold adjustment:
 
 ```typescript
-const thresholds: PerformanceThresholds = {
-  maxResponseTime: 1500, // Reduced from 2000ms
-  maxQueryCount: 8       // Reduced from 10
-}
+const thresholds = getPerformanceBudget('transactions.combinedSortFilter', {
+  maxResponseTime: 950, // tightened after observing stable CI p95
+})
 ```
 
 ## Running Performance Tests
@@ -133,6 +145,41 @@ const result = await measurePerformance(
   },
   { maxResponseTime: 2000 }
 )
+```
+
+#### `measureEndpointPerformance(db, operation, thresholds)`
+
+Measures response time and counts Knex `query` events during the same operation.
+Use this helper for list endpoints where `maxQueryCount` is part of the budget.
+
+```typescript
+const budget = getPerformanceBudget('transactions.cursorPagination')
+const result = await measureEndpointPerformance(
+  db,
+  async () => {
+    await request(app).get('/api/transactions?limit=20').expect(200)
+  },
+  budget,
+)
+
+assertPerformance(result, budget.label)
+```
+
+#### `assertIndexedPlan(plan, options)`
+
+Parses PostgreSQL `EXPLAIN (FORMAT JSON)` output and fails when a representative
+query uses `Seq Scan` unexpectedly or misses one of the configured indexes.
+
+```typescript
+const plan = await explainQueryPlan(
+  db,
+  'SELECT * FROM transactions WHERE type = ? ORDER BY stellar_timestamp DESC LIMIT 20',
+  ['deposit'],
+)
+
+assertIndexedPlan(plan, {
+  expectedIndexes: getPerformanceBudget('transactions.combinedSortFilter').expectedIndexes,
+})
 ```
 
 #### `seedLargeDataset(db, tableName, count, recordFactory)`

--- a/src/tests/helpers/performanceHelpers.test.ts
+++ b/src/tests/helpers/performanceHelpers.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import type { Knex } from 'knex'
+import {
+  ENDPOINT_PERFORMANCE_BUDGETS,
+  assertIndexedPlan,
+  assertPerformance,
+  collectPerformanceViolations,
+  explainQueryPlan,
+  getPerformanceBudget,
+  measureEndpointPerformance,
+  measurePerformance,
+  summarizeExplainPlan,
+  trackQueries,
+} from './performanceHelpers.js'
+
+interface MockKnex extends Knex {
+  emitQuery: () => void
+}
+
+function makeMockKnex(rawResult?: unknown): MockKnex {
+  const handlers = new Map<string, Array<() => void>>()
+  const db: Partial<Knex> & { emitQuery?: () => void } = {}
+
+  db.on = jest.fn((event: string, handler: () => void) => {
+    handlers.set(event, [...(handlers.get(event) ?? []), handler])
+    return db as Knex
+  }) as unknown as Knex['on']
+  db.off = jest.fn((event: string, handler: () => void) => {
+    handlers.set(
+      event,
+      (handlers.get(event) ?? []).filter((registered) => registered !== handler),
+    )
+    return db as Knex
+  }) as unknown as Knex['off']
+  db.raw = jest.fn(async () => rawResult) as unknown as Knex['raw']
+
+  db.emitQuery = () => {
+    for (const handler of handlers.get('query') ?? []) handler()
+  }
+
+  return db as MockKnex
+}
+
+const indexedPlan = [
+  {
+    Plan: {
+      'Node Type': 'Nested Loop',
+      Plans: [
+        {
+          'Node Type': 'Index Scan',
+          'Index Name': 'idx_transactions_stellar_timestamp',
+        },
+        {
+          'Node Type': 'Index Only Scan',
+          'Index Name': 'idx_transactions_type_created_at',
+        },
+      ],
+    },
+  },
+]
+
+describe('performance budget helpers', () => {
+  it('defines per-endpoint response-time and query-count budgets', () => {
+    expect(ENDPOINT_PERFORMANCE_BUDGETS['vaults.list']).toMatchObject({
+      maxResponseTime: expect.any(Number),
+      maxQueryCount: expect.any(Number),
+      expectedIndexes: expect.arrayContaining(['idx_vaults_status_end_date']),
+    })
+    expect(ENDPOINT_PERFORMANCE_BUDGETS['transactions.combinedSortFilter'].expectedIndexes).toEqual(
+      expect.arrayContaining(['idx_transactions_type_created_at']),
+    )
+    expect(ENDPOINT_PERFORMANCE_BUDGETS['analytics.overview'].allowSequentialScan).toBe(true)
+  })
+
+  it('returns a budget with safe overrides', () => {
+    expect(
+      getPerformanceBudget('transactions.list', {
+        maxResponseTime: 123,
+        expectedIndexes: ['idx_custom'],
+      }),
+    ).toMatchObject({
+      label: 'GET /api/transactions list page',
+      maxResponseTime: 123,
+      maxQueryCount: 5,
+      expectedIndexes: ['idx_custom'],
+    })
+  })
+
+  it('collects response-time and query-count violations', () => {
+    expect(collectPerformanceViolations({ responseTime: 20, queryCount: 2 }, { maxResponseTime: 50, maxQueryCount: 3 }))
+      .toEqual([])
+
+    expect(collectPerformanceViolations({ responseTime: 60, queryCount: 4 }, { maxResponseTime: 50, maxQueryCount: 3 }))
+      .toEqual([
+        'Response time 60ms exceeded threshold 50ms',
+        'Query count 4 exceeded threshold 3',
+      ])
+  })
+})
+
+describe('performance measurement helpers', () => {
+  it('measures successful operations', async () => {
+    const result = await measurePerformance(async () => undefined, { maxResponseTime: 1000 })
+
+    expect(result.passed).toBe(true)
+    expect(result.responseTime).toBeGreaterThanOrEqual(0)
+  })
+
+  it('preserves operation errors while measuring response time', async () => {
+    await expect(
+      measurePerformance(async () => {
+        throw new Error('operation failed')
+      }, { maxResponseTime: 1000 }),
+    ).rejects.toThrow('operation failed')
+  })
+
+  it('tracks Knex query events and removes the listener after the operation', async () => {
+    const db = makeMockKnex()
+    const count = await trackQueries(db, async () => {
+      db.emitQuery()
+      db.emitQuery()
+    })
+
+    expect(count).toBe(2)
+    expect(db.on).toHaveBeenCalledWith('query', expect.any(Function))
+    expect(db.off).toHaveBeenCalledWith('query', expect.any(Function))
+
+    db.emitQuery()
+    expect(count).toBe(2)
+  })
+
+  it('returns query-count violations from endpoint measurements', async () => {
+    const db = makeMockKnex()
+    const result = await measureEndpointPerformance(
+      db,
+      async () => {
+        db.emitQuery()
+        db.emitQuery()
+      },
+      { maxResponseTime: 1000, maxQueryCount: 1 },
+    )
+
+    expect(result.queryCount).toBe(2)
+    expect(result.passed).toBe(false)
+    expect(result.violations).toContain('Query count 2 exceeded threshold 1')
+  })
+
+  it('throws readable assertion errors for failed performance results', () => {
+    expect(() =>
+      assertPerformance(
+        {
+          responseTime: 1500,
+          queryCount: 8,
+          passed: false,
+          violations: ['Response time 1500ms exceeded threshold 1000ms'],
+        },
+        'vaults.list',
+      ),
+    ).toThrow('Performance test "vaults.list" failed')
+  })
+})
+
+describe('EXPLAIN plan helpers', () => {
+  it('summarizes nested EXPLAIN JSON plans', () => {
+    expect(summarizeExplainPlan(indexedPlan)).toEqual({
+      nodeTypes: ['Nested Loop', 'Index Scan', 'Index Only Scan'],
+      indexNames: ['idx_transactions_stellar_timestamp', 'idx_transactions_type_created_at'],
+    })
+  })
+
+  it('passes when the expected indexes are present and no sequential scan is used', () => {
+    expect(
+      assertIndexedPlan(indexedPlan, {
+        expectedIndexes: ['idx_transactions_stellar_timestamp'],
+      }),
+    ).toMatchObject({
+      indexNames: expect.arrayContaining(['idx_transactions_stellar_timestamp']),
+    })
+  })
+
+  it('fails when a sequential scan appears without an explicit allowance', () => {
+    expect(() =>
+      assertIndexedPlan([{ Plan: { 'Node Type': 'Seq Scan' } }], {
+        expectedIndexes: [],
+      }),
+    ).toThrow('EXPLAIN plan used Seq Scan')
+  })
+
+  it('allows sequential scans for constant-time analytics endpoints', () => {
+    expect(assertIndexedPlan([{ Plan: { 'Node Type': 'Seq Scan' } }], { allowSequentialScan: true }))
+      .toEqual({ nodeTypes: ['Seq Scan'], indexNames: [] })
+  })
+
+  it('fails when an expected index is missing', () => {
+    expect(() =>
+      assertIndexedPlan(indexedPlan, {
+        expectedIndexes: ['idx_missing'],
+      }),
+    ).toThrow('did not use expected index "idx_missing"')
+  })
+
+  it('extracts JSON plans from pg-style raw results', async () => {
+    const db = makeMockKnex({
+      rows: [
+        {
+          'QUERY PLAN': indexedPlan,
+        },
+      ],
+    })
+
+    await expect(explainQueryPlan(db, 'SELECT * FROM transactions WHERE type = ?', ['deposit']))
+      .resolves.toBe(indexedPlan)
+    expect(db.raw).toHaveBeenCalledWith(
+      'EXPLAIN (FORMAT JSON) SELECT * FROM transactions WHERE type = ?',
+      ['deposit'],
+    )
+  })
+
+  it('extracts JSON plans from mysql-style raw results', async () => {
+    const db = makeMockKnex([[{ query_plan: indexedPlan }]])
+
+    await expect(explainQueryPlan(db, 'SELECT 1')).resolves.toBe(indexedPlan)
+  })
+})

--- a/src/tests/helpers/performanceHelpers.ts
+++ b/src/tests/helpers/performanceHelpers.ts
@@ -12,6 +12,108 @@ export interface PerformanceThresholds {
   maxQueryCount?: number
 }
 
+export type PerformanceEndpointKey =
+  | 'vaults.list'
+  | 'vaults.deepPagination'
+  | 'vaults.combinedSortFilter'
+  | 'transactions.list'
+  | 'transactions.cursorPagination'
+  | 'transactions.byVault'
+  | 'transactions.combinedSortFilter'
+  | 'analytics.summary'
+  | 'analytics.overview'
+  | 'analytics.vaults'
+  | 'analytics.milestoneTrends'
+  | 'analytics.behavior'
+
+export interface EndpointPerformanceBudget extends PerformanceThresholds {
+  /** Human-readable endpoint/scenario label for logs and docs */
+  label: string
+  /** Indexes that should appear in representative EXPLAIN plans */
+  expectedIndexes: string[]
+  /** Whether a sequential scan is acceptable for this scenario */
+  allowSequentialScan?: boolean
+}
+
+export const ENDPOINT_PERFORMANCE_BUDGETS: Record<PerformanceEndpointKey, EndpointPerformanceBudget> = {
+  'vaults.list': {
+    label: 'GET /api/vaults list page',
+    maxResponseTime: 750,
+    maxQueryCount: 4,
+    expectedIndexes: ['idx_vaults_status_end_date', 'idx_vaults_end_date'],
+  },
+  'vaults.deepPagination': {
+    label: 'GET /api/vaults deep pagination',
+    maxResponseTime: 1200,
+    maxQueryCount: 6,
+    expectedIndexes: ['idx_vaults_status_end_date'],
+  },
+  'vaults.combinedSortFilter': {
+    label: 'GET /api/vaults status filter plus sort',
+    maxResponseTime: 900,
+    maxQueryCount: 5,
+    expectedIndexes: ['idx_vaults_status_end_date'],
+  },
+  'transactions.list': {
+    label: 'GET /api/transactions list page',
+    maxResponseTime: 900,
+    maxQueryCount: 5,
+    expectedIndexes: ['idx_transactions_stellar_timestamp'],
+  },
+  'transactions.cursorPagination': {
+    label: 'GET /api/transactions cursor page',
+    maxResponseTime: 1000,
+    maxQueryCount: 5,
+    expectedIndexes: ['idx_transactions_stellar_timestamp'],
+  },
+  'transactions.byVault': {
+    label: 'GET /api/transactions/vault/:vaultId',
+    maxResponseTime: 900,
+    maxQueryCount: 5,
+    expectedIndexes: ['idx_transactions_stellar_timestamp'],
+  },
+  'transactions.combinedSortFilter': {
+    label: 'GET /api/transactions type/date filter plus sort',
+    maxResponseTime: 1100,
+    maxQueryCount: 6,
+    expectedIndexes: ['idx_transactions_type_created_at', 'idx_transactions_stellar_timestamp'],
+  },
+  'analytics.summary': {
+    label: 'GET /api/analytics/summary',
+    maxResponseTime: 350,
+    maxQueryCount: 2,
+    expectedIndexes: [],
+    allowSequentialScan: true,
+  },
+  'analytics.overview': {
+    label: 'GET /api/analytics/overview',
+    maxResponseTime: 250,
+    maxQueryCount: 1,
+    expectedIndexes: [],
+    allowSequentialScan: true,
+  },
+  'analytics.vaults': {
+    label: 'GET /api/analytics/vaults',
+    maxResponseTime: 350,
+    maxQueryCount: 2,
+    expectedIndexes: ['idx_vaults_status_end_date'],
+  },
+  'analytics.milestoneTrends': {
+    label: 'GET /api/analytics/milestones/trends',
+    maxResponseTime: 650,
+    maxQueryCount: 3,
+    expectedIndexes: [],
+    allowSequentialScan: true,
+  },
+  'analytics.behavior': {
+    label: 'GET /api/analytics/behavior',
+    maxResponseTime: 650,
+    maxQueryCount: 3,
+    expectedIndexes: [],
+    allowSequentialScan: true,
+  },
+}
+
 export interface PerformanceResult {
   /** Response time in milliseconds */
   responseTime: number
@@ -29,16 +131,11 @@ export interface PerformanceResult {
  * @returns Performance result with timing information
  */
 export async function measurePerformance(
-  operation: () => Promise<any>,
+  operation: () => Promise<unknown>,
   thresholds: PerformanceThresholds
 ): Promise<PerformanceResult> {
   const startTime = Date.now()
-  
-  try {
-    await operation()
-  } catch (error) {
-    throw error
-  }
+  await operation()
   
   const endTime = Date.now()
   const responseTime = endTime - startTime
@@ -58,6 +155,17 @@ export async function measurePerformance(
   }
 }
 
+export function getPerformanceBudget(
+  endpoint: PerformanceEndpointKey,
+  overrides: Partial<EndpointPerformanceBudget> = {},
+): EndpointPerformanceBudget {
+  return {
+    ...ENDPOINT_PERFORMANCE_BUDGETS[endpoint],
+    ...overrides,
+    expectedIndexes: overrides.expectedIndexes ?? ENDPOINT_PERFORMANCE_BUDGETS[endpoint].expectedIndexes,
+  }
+}
+
 /**
  * Track database queries during an operation
  * This is a simplified version - in production you'd use query logging
@@ -67,7 +175,7 @@ export async function measurePerformance(
  */
 export async function trackQueries(
   db: Knex,
-  operation: () => Promise<any>
+  operation: () => Promise<unknown>
 ): Promise<number> {
   let queryCount = 0
   
@@ -85,6 +193,49 @@ export async function trackQueries(
   }
   
   return queryCount
+}
+
+export async function measureEndpointPerformance(
+  db: Knex,
+  operation: () => Promise<unknown>,
+  thresholds: PerformanceThresholds,
+): Promise<PerformanceResult> {
+  const startTime = Date.now()
+  const queryCount = await trackQueries(db, operation)
+  const responseTime = Date.now() - startTime
+  const violations = collectPerformanceViolations({ responseTime, queryCount }, thresholds)
+
+  return {
+    responseTime,
+    queryCount,
+    passed: violations.length === 0,
+    violations,
+  }
+}
+
+export function collectPerformanceViolations(
+  result: Pick<PerformanceResult, 'responseTime' | 'queryCount'>,
+  thresholds: PerformanceThresholds,
+): string[] {
+  const violations: string[] = []
+
+  if (result.responseTime > thresholds.maxResponseTime) {
+    violations.push(
+      `Response time ${result.responseTime}ms exceeded threshold ${thresholds.maxResponseTime}ms`
+    )
+  }
+
+  if (
+    typeof thresholds.maxQueryCount === 'number' &&
+    typeof result.queryCount === 'number' &&
+    result.queryCount > thresholds.maxQueryCount
+  ) {
+    violations.push(
+      `Query count ${result.queryCount} exceeded threshold ${thresholds.maxQueryCount}`
+    )
+  }
+
+  return violations
 }
 
 /**
@@ -203,13 +354,105 @@ export async function cleanupPerfTestData(db: Knex): Promise<void> {
  * @param testName - Name of the test for error messages
  */
 export function assertPerformance(result: PerformanceResult, testName: string): void {
+  const violationMessages = result.violations.join(', ')
+
   if (!result.passed) {
-    const violationMessages = result.violations.join(', ')
     throw new Error(
       `Performance test "${testName}" failed: ${violationMessages}. ` +
       `Response time: ${result.responseTime}ms`
     )
   }
+}
+
+interface ExplainNodeSummary {
+  nodeTypes: string[]
+  indexNames: string[]
+}
+
+interface ExplainPlanNode {
+  'Node Type'?: string
+  'Index Name'?: string
+  Plans?: ExplainPlanNode[]
+}
+
+export interface IndexedPlanOptions {
+  expectedIndexes?: string[]
+  allowSequentialScan?: boolean
+}
+
+export function summarizeExplainPlan(explainPlan: unknown): ExplainNodeSummary {
+  const summary: ExplainNodeSummary = {
+    nodeTypes: [],
+    indexNames: [],
+  }
+
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(visit)
+      return
+    }
+
+    if (!value || typeof value !== 'object') return
+
+    const maybeNode = value as ExplainPlanNode & { Plan?: ExplainPlanNode }
+
+    if (maybeNode.Plan) {
+      visit(maybeNode.Plan)
+      return
+    }
+
+    if (maybeNode['Node Type']) {
+      summary.nodeTypes.push(maybeNode['Node Type'])
+    }
+
+    if (maybeNode['Index Name']) {
+      summary.indexNames.push(maybeNode['Index Name'])
+    }
+
+    if (maybeNode.Plans) {
+      visit(maybeNode.Plans)
+    }
+  }
+
+  visit(explainPlan)
+
+  return {
+    nodeTypes: Array.from(new Set(summary.nodeTypes)),
+    indexNames: Array.from(new Set(summary.indexNames)),
+  }
+}
+
+export function assertIndexedPlan(
+  explainPlan: unknown,
+  options: IndexedPlanOptions = {},
+): ExplainNodeSummary {
+  const summary = summarizeExplainPlan(explainPlan)
+  const sequentialScan = summary.nodeTypes.includes('Seq Scan')
+
+  if (sequentialScan && !options.allowSequentialScan) {
+    throw new Error(`EXPLAIN plan used Seq Scan; node types: ${summary.nodeTypes.join(', ')}`)
+  }
+
+  for (const expectedIndex of options.expectedIndexes ?? []) {
+    if (!summary.indexNames.includes(expectedIndex)) {
+      throw new Error(
+        `EXPLAIN plan did not use expected index "${expectedIndex}". ` +
+        `Indexes used: ${summary.indexNames.join(', ') || 'none'}`
+      )
+    }
+  }
+
+  return summary
+}
+
+export async function explainQueryPlan(
+  db: Knex,
+  sql: string,
+  bindings: readonly Knex.RawBinding[] = [],
+): Promise<unknown> {
+  const result = await db.raw(`EXPLAIN (FORMAT JSON) ${sql}`, bindings)
+  const firstRow = result.rows?.[0] ?? result[0]?.[0]
+  return firstRow?.['QUERY PLAN'] ?? firstRow?.query_plan ?? firstRow
 }
 
 /**

--- a/src/tests/performance/endpointBudgets.perf.test.ts
+++ b/src/tests/performance/endpointBudgets.perf.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from '@jest/globals'
+import {
+  ENDPOINT_PERFORMANCE_BUDGETS,
+  assertIndexedPlan,
+  getPerformanceBudget,
+  type PerformanceEndpointKey,
+} from '../helpers/performanceHelpers.js'
+
+const listEndpointScenarios: PerformanceEndpointKey[] = [
+  'vaults.list',
+  'vaults.deepPagination',
+  'vaults.combinedSortFilter',
+  'transactions.list',
+  'transactions.cursorPagination',
+  'transactions.byVault',
+  'transactions.combinedSortFilter',
+  'analytics.summary',
+  'analytics.overview',
+  'analytics.vaults',
+  'analytics.milestoneTrends',
+  'analytics.behavior',
+]
+
+describe('performance endpoint budget contract', () => {
+  it('defines budgets for every documented list endpoint scenario', () => {
+    expect(Object.keys(ENDPOINT_PERFORMANCE_BUDGETS).sort()).toEqual([...listEndpointScenarios].sort())
+
+    for (const scenario of listEndpointScenarios) {
+      const budget = getPerformanceBudget(scenario)
+      expect(budget.label).toContain('GET /api/')
+      expect(budget.maxResponseTime).toBeGreaterThan(0)
+      expect(budget.maxQueryCount).toBeGreaterThan(0)
+    }
+  })
+
+  it('requires indexes for database-backed vault and transaction scenarios', () => {
+    const databaseBacked = listEndpointScenarios.filter(
+      (scenario) => scenario.startsWith('vaults.') || scenario.startsWith('transactions.'),
+    )
+
+    for (const scenario of databaseBacked) {
+      expect(getPerformanceBudget(scenario).expectedIndexes.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('keeps analytics constant-time scenarios explicit about sequential scans', () => {
+    expect(getPerformanceBudget('analytics.overview').allowSequentialScan).toBe(true)
+    expect(getPerformanceBudget('analytics.milestoneTrends').allowSequentialScan).toBe(true)
+    expect(getPerformanceBudget('analytics.behavior').allowSequentialScan).toBe(true)
+  })
+
+  it('validates representative index plans for the configured transaction budget', () => {
+    const budget = getPerformanceBudget('transactions.combinedSortFilter')
+    const plan = [
+      {
+        Plan: {
+          'Node Type': 'Index Scan',
+          'Index Name': 'idx_transactions_type_created_at',
+        },
+      },
+    ]
+
+    expect(() =>
+      assertIndexedPlan(plan, {
+        expectedIndexes: [budget.expectedIndexes[0]!],
+      }),
+    ).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds shared per-endpoint latency/query-count budgets for vault, transaction, and analytics list scenarios.
- Adds endpoint measurement helpers that enforce Knex query-count budgets alongside response-time budgets.
- Adds PostgreSQL `EXPLAIN (FORMAT JSON)` helpers and index-plan assertions for representative indexed queries.
- Documents the budget table and tuning workflow in the performance docs and quick-start README.

## Validation
- `npm test -- src/tests/helpers/performanceHelpers.test.ts src/tests/performance/endpointBudgets.perf.test.ts --coverage --collectCoverageFrom=src/tests/helpers/performanceHelpers.ts`
- `npm run test:perf`
- `npx tsc --noEmit --pretty false --target ES2022 --module NodeNext --moduleResolution NodeNext --esModuleInterop --skipLibCheck --types jest,node src/tests/helpers/performanceHelpers.ts src/tests/helpers/performanceHelpers.test.ts src/tests/performance/endpointBudgets.perf.test.ts`
- `npx eslint src/tests/helpers/performanceHelpers.ts src/tests/helpers/performanceHelpers.test.ts src/tests/performance/endpointBudgets.perf.test.ts --ext .ts`
- `git diff --check`

Note: full `npm run build` and full `npm run lint` are currently blocked by pre-existing repository issues outside this PR, including `src/jobs/handlers.ts(78,1): error TS1005: ')' expected` and existing lint configuration/global errors.

Closes #632