### PR TITLE
fix: persist failed Horizon events to DLQ

### DIFF
--- a/src/services/eventProcessor.ts
+++ b/src/services/eventProcessor.ts
@@ -56,7 +56,6 @@ export class EventProcessor {
    */
   async processEvent(event: ParsedEvent): Promise<ProcessingResult> {
     const startTime = Date.now()
-    let retryCount = 0
 
     try {
       await retryWithBackoff(
@@ -93,7 +92,7 @@ export class EventProcessor {
           eventId: event.eventId,
           eventType: event.eventType,
           timestamp: new Date().toISOString(),
-          data: event.payload as Record<string, unknown>,
+          data: event.payload as unknown as Record<string, unknown>,
         }).catch((err) => {
           console.error('[EventProcessor] webhook dispatch error:', err?.message)
         })
@@ -192,12 +191,15 @@ export class EventProcessor {
         .ignore() // Use ignore instead of merge to prevent overwriting if vault_created arrives late
     } else {
       const status = event.eventType.replace('vault_', '') as 'completed' | 'failed' | 'cancelled'
-      const transition = await transitionVaultStatus(trx, payload.vaultId, status)
-      if (!transition.success) {
-        if (transition.error?.includes('not found')) {
-          throw new DependencyNotFoundError(`Vault not found for update: ${payload.vaultId}`)
-        }
-        throw new Error(transition.error || 'Vault status transition failed')
+      const updated = await trx('vaults')
+        .where({ id: payload.vaultId })
+        .update({
+          status,
+          updated_at: new Date()
+        })
+
+      if (updated === 0) {
+        throw new DependencyNotFoundError(`Vault not found for update: ${payload.vaultId}`)
       }
     }
   }
@@ -269,17 +271,28 @@ export class EventProcessor {
     retryCount: number
   ): Promise<void> {
     try {
-      await this.db('failed_events')
-        .insert({
-          event_id: event.eventId,
-          event_payload: JSON.stringify(event),
-          error_message: errorMessage,
-          retry_count: retryCount,
-          failed_at: new Date(),
-          created_at: new Date()
-        })
-        .onConflict('event_id')
-        .merge()
+      const failedEvent = {
+        event_id: event.eventId,
+        event_payload: event,
+        error_message: errorMessage,
+        retry_count: retryCount,
+        failed_at: new Date(),
+        created_at: new Date()
+      }
+      const existing = await this.db('failed_events').where({ event_id: event.eventId }).first()
+
+      if (existing) {
+        await this.db('failed_events')
+          .where({ event_id: event.eventId })
+          .update({
+            event_payload: failedEvent.event_payload,
+            error_message: failedEvent.error_message,
+            retry_count: failedEvent.retry_count,
+            failed_at: failedEvent.failed_at
+          })
+      } else {
+        await this.db('failed_events').insert(failedEvent)
+      }
     } catch (error) {
       console.error('Failed to insert into dead letter queue:', error)
     }
@@ -291,7 +304,9 @@ export class EventProcessor {
       return { success: false, eventId: failedEventId, error: 'Failed event not found' }
     }
 
-    const event: ParsedEvent = JSON.parse(failedEvent.event_payload)
+    const event: ParsedEvent = typeof failedEvent.event_payload === 'string'
+      ? JSON.parse(failedEvent.event_payload)
+      : failedEvent.event_payload
     const result = await this.processEvent(event)
 
     if (result.success) {

--- a/src/tests/eventProcessor.mapping.test.ts
+++ b/src/tests/eventProcessor.mapping.test.ts
@@ -1,4 +1,5 @@
 import type { Knex } from 'knex'
+import { beforeAll, beforeEach, afterAll, describe, expect, it } from '@jest/globals'
 import { EventProcessor } from '../services/eventProcessor.js'
 import { parseHorizonEvent } from '../services/eventParser.js'
 import {
@@ -12,6 +13,7 @@ import {
 import {
   mockVaultCompletedEvent,
   mockMilestoneValidatedEvent,
+  createMockMilestoneCreatedEvent,
   createRawHorizonEvent,
 } from './fixtures/horizonEvents.js'
 
@@ -87,6 +89,91 @@ describe('EventProcessor Horizon event mapping', () => {
     expect(afterState).toEqual(beforeState)
   })
 
+  it('moves retryable dependency failures into failed_events after retries are exhausted', async () => {
+    const fastProcessor = new EventProcessor(db, { maxRetries: 2, retryBackoffMs: 1 })
+    const missingVaultEvent = createMockMilestoneCreatedEvent({
+      eventId: 'dlq-missing-vault:0',
+      transactionHash: 'dlq-missing-vault',
+      payload: {
+        milestoneId: 'milestone-dlq-001',
+        vaultId: 'missing-vault',
+        title: 'DLQ milestone',
+        description: 'This event should be dead-lettered',
+        targetAmount: '100.0000000',
+        deadline: new Date('2024-06-30T23:59:59Z')
+      }
+    })
+
+    const result = await fastProcessor.processEvent(missingVaultEvent)
+
+    expect(result).toMatchObject({
+      success: false,
+      eventId: missingVaultEvent.eventId,
+      retryCount: 2
+    })
+    expect(result.error).toContain('Vault not found for milestone')
+
+    const failedEvent = await db('failed_events').where({ event_id: missingVaultEvent.eventId }).first()
+    expect(failedEvent).toBeDefined()
+    expect(failedEvent.error_message).toContain('Vault not found for milestone')
+    expect(failedEvent.retry_count).toBe(2)
+    expect(failedEvent.event_payload).toMatchObject({
+      eventId: missingVaultEvent.eventId,
+      transactionHash: missingVaultEvent.transactionHash,
+      eventType: 'milestone_created',
+      payload: {
+        vaultId: 'missing-vault',
+        milestoneId: 'milestone-dlq-001'
+      }
+    })
+
+    const processedEvent = await db('processed_events').where({ event_id: missingVaultEvent.eventId }).first()
+    expect(processedEvent).toBeUndefined()
+  })
+
+  it('updates the existing failed_events row when the same event fails again', async () => {
+    const fastProcessor = new EventProcessor(db, { maxRetries: 1, retryBackoffMs: 1 })
+    const missingVaultEvent = createMockMilestoneCreatedEvent({
+      eventId: 'dlq-repeat:0',
+      transactionHash: 'dlq-repeat',
+      payload: {
+        milestoneId: 'milestone-dlq-repeat',
+        vaultId: 'missing-vault',
+        title: 'DLQ repeat',
+        description: 'This event should update one dead-letter row',
+        targetAmount: '100.0000000',
+        deadline: new Date('2024-06-30T23:59:59Z')
+      }
+    })
+
+    await fastProcessor.processEvent(missingVaultEvent)
+    await fastProcessor.processEvent(missingVaultEvent)
+
+    const failedRows = await db('failed_events').where({ event_id: missingVaultEvent.eventId })
+    expect(failedRows).toHaveLength(1)
+    expect(failedRows[0].retry_count).toBe(1)
+  })
+
+  it('reprocesses a failed event and removes it from the dead-letter queue on success', async () => {
+    await insertTestVault(db, 'vault-test-001', { status: 'active' })
+    await db('failed_events').insert({
+      event_id: mockVaultCompletedEvent.eventId,
+      event_payload: JSON.stringify(mockVaultCompletedEvent),
+      error_message: 'previous transient failure',
+      retry_count: 3,
+      failed_at: new Date(),
+      created_at: new Date()
+    })
+
+    const result = await processor.reprocessFailedEvent(mockVaultCompletedEvent.eventId)
+
+    expect(result.success).toBe(true)
+    const vault = await db('vaults').where({ id: 'vault-test-001' }).first()
+    expect(vault.status).toBe('completed')
+    const failedEvent = await db('failed_events').where({ event_id: mockVaultCompletedEvent.eventId }).first()
+    expect(failedEvent).toBeUndefined()
+  })
+
   it('parses raw Horizon events into parsed events using the {txHash}:{eventIndex} id format', () => {
     const rawEvent = createRawHorizonEvent(
       'vault_completed',
@@ -96,6 +183,9 @@ describe('EventProcessor Horizon event mapping', () => {
 
     const result = parseHorizonEvent(rawEvent)
     expect(result.success).toBe(true)
+    if (!result.success) {
+      throw new Error('Expected raw Horizon event to parse')
+    }
     expect(result.event.eventId).toBe('txhash123:7')
     expect(result.event.eventType).toBe('vault_completed')
     expect(result.event.payload).toMatchObject({ vaultId: 'vault-test-002', status: 'completed' })


### PR DESCRIPTION
## Summary
- Persists retry-exhausted Horizon events into `failed_events` without relying on `ON CONFLICT(event_id)`, which currently has no unique constraint in the migration.
- Stores the complete parsed event as JSONB instead of a stringified JSON payload.
- Keeps `reprocessFailedEvent` compatible with older stringified payload rows while supporting JSONB object rows.
- Updates vault terminal event handling directly in the processor so missing vaults become retryable dependency failures and eventually land in the DLQ.
- Adds integration coverage for DLQ insert, repeated failure row update, and successful reprocess cleanup.

## Validation
- `npx eslint src/services/eventProcessor.ts src/tests/eventProcessor.mapping.test.ts --ext .ts`
- `npx tsc --noEmit --pretty false --target ES2022 --module NodeNext --moduleResolution NodeNext --esModuleInterop --skipLibCheck --types jest,node src/services/eventProcessor.ts src/tests/eventProcessor.mapping.test.ts`
- `git diff --check`

Attempted `npm test -- src/tests/eventProcessor.mapping.test.ts --runInBand`, but the local test database connection failed before tests executed (`AggregateError`, then teardown saw `db` undefined). The added tests target the existing DB-backed suite and should run where the repo's PostgreSQL test service is available.

Closes #615