### PR TITLE
fix: harden event parser routing validation

### DIFF
--- a/src/services/eventParser.ts
+++ b/src/services/eventParser.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { xdr, scValToNative } from '@stellar/stellar-sdk'
 import { 
   ParsedEvent, 
@@ -65,6 +66,21 @@ function decodePayloadRecord(xdrData: string): DecodedPayload | null {
   }
 
   return null
+}
+
+function decodeScValRecord(xdrData: string, context: string): DecodedPayload | null {
+  try {
+    const scVal = xdr.ScVal.fromXDR(xdrData, 'base64')
+    const nativeVal = scValToNative(scVal)
+    if (nativeVal && typeof nativeVal === 'object' && !Array.isArray(nativeVal)) {
+      return nativeVal as DecodedPayload
+    }
+    console.error(`${context} payload did not decode to an object`)
+    return null
+  } catch (error) {
+    console.error(`Error parsing ${context} payload XDR:`, error)
+    return null
+  }
 }
 
 // UUID v4 (and general UUID) regex used to validate backend-generated vault ids
@@ -182,22 +198,11 @@ function parseVaultPayload(
   // Try JSON decoding first (test fixtures and fallback path)
   const decoded = decodePayloadRecord(xdrData)
 
-  let nativeVal: any
-  if (decoded) {
-    nativeVal = decoded
-  } else {
-    try {
-      const scVal = xdr.ScVal.fromXDR(xdrData, 'base64')
-      nativeVal = scValToNative(scVal)
-    } catch (error) {
-      console.error('Error parsing vault payload XDR:', error)
-      return null
-    }
-  }
+  const nativeVal = decoded ?? decodeScValRecord(xdrData, 'vault')
+  if (!nativeVal) return null
 
   const vaultId = readStringField(nativeVal, 'vaultId') ??
-    readStringField(nativeVal, 'vault_id') ??
-    (typeof nativeVal === 'string' ? nativeVal : `vault_${Date.now()}`)
+    readStringField(nativeVal, 'vault_id')
 
   let payload: VaultEventPayload
 
@@ -205,18 +210,20 @@ function parseVaultPayload(
     case 'vault_created': {
       payload = {
         vaultId,
-        creator: readStringField(nativeVal, 'creator') || 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        amount: (nativeVal.amount?.toString()) || '1000.0000000',
+        creator: readStringField(nativeVal, 'creator'),
+        amount: nativeVal.amount == null ? undefined : nativeVal.amount.toString(),
         startTimestamp: readDateField(nativeVal, 'startTimestamp') ??
-          (nativeVal.start_date ? new Date(nativeVal.start_date * 1000) : new Date()),
+          readDateField(nativeVal, 'start_timestamp') ??
+          readDateField(nativeVal, 'start_date'),
         endTimestamp: readDateField(nativeVal, 'endTimestamp') ??
-          (nativeVal.end_date ? new Date(nativeVal.end_date * 1000) : new Date(Date.now() + 86400000)),
+          readDateField(nativeVal, 'end_timestamp') ??
+          readDateField(nativeVal, 'end_date'),
         successDestination: readStringField(nativeVal, 'successDestination') ??
-          readStringField(nativeVal, 'success_destination') ?? 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+          readStringField(nativeVal, 'success_destination'),
         failureDestination: readStringField(nativeVal, 'failureDestination') ??
-          readStringField(nativeVal, 'failure_destination') ?? 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+          readStringField(nativeVal, 'failure_destination'),
         status: 'active'
-      }
+      } as VaultEventPayload
       const createdError = validateVaultCreatedPayload(payload)
       if (createdError) {
         console.error(`Vault created validation error: ${createdError}`)
@@ -300,31 +307,22 @@ function validateMilestonePayload(payload: MilestoneEventPayload): string | null
 function parseMilestonePayload(xdrData: string): MilestoneEventPayload | null {
   const decoded = decodePayloadRecord(xdrData)
 
-  let nativeVal: any
-  if (decoded) {
-    nativeVal = decoded
-  } else {
-    try {
-      const scVal = xdr.ScVal.fromXDR(xdrData, 'base64')
-      nativeVal = scValToNative(scVal)
-    } catch (error) {
-      console.error('Error parsing milestone payload XDR:', error)
-      return null
-    }
-  }
+  const nativeVal = decoded ?? decodeScValRecord(xdrData, 'milestone')
+  if (!nativeVal) return null
 
   const payload: MilestoneEventPayload = {
     milestoneId: readStringField(nativeVal, 'milestoneId') ??
-      readStringField(nativeVal, 'milestone_id') ?? `milestone_${Date.now()}`,
+      readStringField(nativeVal, 'milestone_id'),
     vaultId: readStringField(nativeVal, 'vaultId') ??
-      readStringField(nativeVal, 'vault_id') ?? `vault_${Date.now()}`,
-    title: readStringField(nativeVal, 'title') ?? 'Milestone Title',
-    description: readStringField(nativeVal, 'description') ?? 'Milestone Description',
-    targetAmount: (nativeVal.targetAmount?.toString()) ??
-      (nativeVal.amount?.toString()) ?? '500.0000000',
+      readStringField(nativeVal, 'vault_id'),
+    title: readStringField(nativeVal, 'title'),
+    description: readStringField(nativeVal, 'description') ?? '',
+    targetAmount: nativeVal.targetAmount == null && nativeVal.amount == null
+      ? undefined
+      : (nativeVal.targetAmount ?? nativeVal.amount).toString(),
     deadline: readDateField(nativeVal, 'deadline') ??
-      (nativeVal.due_date ? new Date(nativeVal.due_date * 1000) : new Date(Date.now() + 86400000))
-  }
+      readDateField(nativeVal, 'due_date')
+  } as MilestoneEventPayload
 
   const error = validateMilestonePayload(payload)
   if (error) {
@@ -384,33 +382,26 @@ function validateValidationPayload(payload: ValidationEventPayload): string | nu
 function parseValidationPayload(xdrData: string): ValidationEventPayload | null {
   const decoded = decodePayloadRecord(xdrData)
 
-  let nativeVal: any
-  if (decoded) {
-    nativeVal = decoded
-  } else {
-    try {
-      const scVal = xdr.ScVal.fromXDR(xdrData, 'base64')
-      nativeVal = scValToNative(scVal)
-    } catch (error) {
-      console.error('Error parsing validation payload XDR:', error)
-      return null
-    }
-  }
+  const nativeVal = decoded ?? decodeScValRecord(xdrData, 'validation')
+  if (!nativeVal) return null
 
   const payload: ValidationEventPayload = {
     validationId: readStringField(nativeVal, 'validationId') ??
-      readStringField(nativeVal, 'validation_id') ?? `validation_${Date.now()}`,
+      readStringField(nativeVal, 'validation_id'),
     milestoneId: readStringField(nativeVal, 'milestoneId') ??
-      readStringField(nativeVal, 'milestone_id') ?? `milestone_${Date.now()}`,
+      readStringField(nativeVal, 'milestone_id'),
     validatorAddress: readStringField(nativeVal, 'validatorAddress') ??
-      readStringField(nativeVal, 'validator') ?? 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      readStringField(nativeVal, 'validator_address') ??
+      readStringField(nativeVal, 'validator'),
     validationResult: (readStringField(nativeVal, 'validationResult') ??
-      readStringField(nativeVal, 'result') ?? 'approved') as ValidationEventPayload['validationResult'],
+      readStringField(nativeVal, 'validation_result') ??
+      readStringField(nativeVal, 'result')) as ValidationEventPayload['validationResult'],
     evidenceHash: readStringField(nativeVal, 'evidenceHash') ??
-      readStringField(nativeVal, 'evidence_hash') ?? `hash_${Date.now()}`,
+      readStringField(nativeVal, 'evidence_hash') ?? '',
     validatedAt: readDateField(nativeVal, 'validatedAt') ??
-      (nativeVal.timestamp ? new Date(nativeVal.timestamp * 1000) : new Date())
-  }
+      readDateField(nativeVal, 'validated_at') ??
+      readDateField(nativeVal, 'timestamp')
+  } as ValidationEventPayload
 
   const error = validateValidationPayload(payload)
   if (error) {
@@ -460,13 +451,13 @@ function routeToPayloadParser(
  * `scValToNative` they become plain JavaScript strings, so the mapping below
  * works transparently for both on-chain and off-chain consumers.
  *
- * Short topics (≤ 9 chars) use `symbol_short!` on the Rust side; longer
+ * Short topics (? 9 chars) use `symbol_short!` on the Rust side; longer
  * topics use `Symbol::new`.  The decoded string value is identical either way.
  *
- * Contract → parser topic mapping
- * ─────────────────────────────────────────────────────────────────────────────
+ * Contract ? parser topic mapping
+ * ?????????????????????????????????????????????????????????????????????????????
  * On-chain Symbol topic       Parser EventType (or handled inline)
- * ─────────────────────────────────────────────────────────────────────────────
+ * ?????????????????????????????????????????????????????????????????????????????
  * vault_created               vault_created
  * vault_staked                vault_staked        (informational, no DB write)
  * milestone_checked_in        milestone_checked_in (informational)
@@ -478,11 +469,11 @@ function routeToPayloadParser(
  * vault_paused                vault_paused        (informational)
  * vault_unpaused              vault_unpaused      (informational)
  * milestone_claimed           milestone_created   (partial-release, informational)
- * ─────────────────────────────────────────────────────────────────────────────
+ * ?????????????????????????????????????????????????????????????????????????????
  *
  * Sources for check_in `source` topic:
- *   symbol_short!("oracle")    → "oracle"
- *   symbol_short!("verifier")  → "verifier"
+ *   symbol_short!("oracle")    ? "oracle"
+ *   symbol_short!("verifier")  ? "verifier"
  */
 
 /**
@@ -553,7 +544,7 @@ export function parseHorizonEvent(rawEvent: HorizonEvent): ParseResult {
       milestone_created:       'milestone_created',
       milestone_validated:     'milestone_validated',
       settlement_summary:      'settlement_summary',
-      // Aliases: contract emits these Symbol topics → mapped EventType
+      // Aliases: contract emits these Symbol topics ? mapped EventType
       vault_slashed:           'vault_failed',    // slash = failure destination
       vault_withdrawn:         'vault_cancelled', // withdraw = cancelled state
       vault_failed:            'vault_failed',    // explicit legacy alias

--- a/src/tests/eventParser.routing.test.ts
+++ b/src/tests/eventParser.routing.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from '@jest/globals'
+import { parseHorizonEvent } from '../services/eventParser.js'
+import { createRawHorizonEvent } from './fixtures/horizonEvents.js'
+import type { ValidationEventPayload, VaultEventPayload } from '../types/horizonSync.js'
+
+const VAULT_ID = '550e8400-e29b-41d4-a716-446655440100'
+
+describe('eventParser deterministic routing and validation', () => {
+  it('routes by topic and preserves deterministic Horizon metadata', () => {
+    const rawEvent = createRawHorizonEvent(
+      'vault_created',
+      {
+        vaultId: VAULT_ID,
+        creator: 'GCREATORADDRESS',
+        amount: '1000.0000000',
+        startTimestamp: '2026-01-01T00:00:00.000Z',
+        endTimestamp: '2026-02-01T00:00:00.000Z',
+        successDestination: 'GSUCCESSDEST',
+        failureDestination: 'GFAILUREDEST'
+      },
+      { id: 'txhashabc-7', txHash: 'txhashabc', ledger: 456 }
+    )
+
+    const result = parseHorizonEvent(rawEvent)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.event.eventId).toBe('txhashabc:7')
+    expect(result.event.transactionHash).toBe('txhashabc')
+    expect(result.event.eventIndex).toBe(7)
+    expect(result.event.ledgerNumber).toBe(456)
+    expect(result.event.eventType).toBe('vault_created')
+    expect((result.event.payload as VaultEventPayload).vaultId).toBe(VAULT_ID)
+  })
+
+  it('maps contract slash topics onto the persisted vault_failed event type', () => {
+    const rawEvent = createRawHorizonEvent(
+      'vault_failed',
+      {
+        vaultId: VAULT_ID,
+        status: 'failed'
+      },
+      { topic: ['vault_slashed'] }
+    )
+
+    const result = parseHorizonEvent(rawEvent)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.event.eventType).toBe('vault_failed')
+    expect((result.event.payload as VaultEventPayload).status).toBe('failed')
+  })
+
+  it('accepts snake_case milestone validation payloads from contract events', () => {
+    const rawEvent = createRawHorizonEvent('milestone_validated', {
+      validation_id: 'validation-123',
+      milestone_id: 'milestone-456',
+      validator_address: 'GVALIDATORADDRESS',
+      validation_result: 'approved',
+      evidence_hash: 'hash-789',
+      validated_at: '2026-03-01T12:00:00.000Z'
+    })
+
+    const result = parseHorizonEvent(rawEvent)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    const payload = result.event.payload as ValidationEventPayload
+    expect(result.event.eventType).toBe('milestone_validated')
+    expect(payload.validationId).toBe('validation-123')
+    expect(payload.milestoneId).toBe('milestone-456')
+    expect(payload.validatorAddress).toBe('GVALIDATORADDRESS')
+    expect(payload.validationResult).toBe('approved')
+    expect(payload.evidenceHash).toBe('hash-789')
+  })
+
+  it('returns a structured parse failure for malformed required payload fields', () => {
+    const rawEvent = createRawHorizonEvent('vault_created', {
+      vaultId: VAULT_ID,
+      amount: '1000.0000000',
+      startTimestamp: '2026-01-01T00:00:00.000Z',
+      endTimestamp: '2026-02-01T00:00:00.000Z',
+      successDestination: 'GSUCCESSDEST',
+      failureDestination: 'GFAILUREDEST'
+    })
+
+    const result = parseHorizonEvent(rawEvent)
+
+    expect(result.success).toBe(false)
+    expect(result).toMatchObject({
+      error: 'Failed to parse payload for event type: vault_created',
+      details: { eventType: 'vault_created' }
+    })
+  })
+})

--- a/src/tests/eventParser.status.test.ts
+++ b/src/tests/eventParser.status.test.ts
@@ -18,18 +18,24 @@ import type { VaultEventPayload } from '../types/horizonSync.js'
  * longer falls through to `default` for valid input.
  */
 describe('eventParser vault status events', () => {
+  const validVaultIds = [
+    '550e8400-e29b-41d4-a716-446655440001',
+    '550e8400-e29b-41d4-a716-446655440002',
+    '550e8400-e29b-41d4-a716-446655440003'
+  ]
+
   const statusFixtures = [
-    { fixture: mockVaultCompletedEvent, status: 'completed' as const },
-    { fixture: mockVaultFailedEvent, status: 'failed' as const },
-    { fixture: mockVaultCancelledEvent, status: 'cancelled' as const }
+    { fixture: mockVaultCompletedEvent, status: 'completed' as const, vaultId: validVaultIds[0] },
+    { fixture: mockVaultFailedEvent, status: 'failed' as const, vaultId: validVaultIds[1] },
+    { fixture: mockVaultCancelledEvent, status: 'cancelled' as const, vaultId: validVaultIds[2] }
   ]
 
   it.each(statusFixtures)(
     'parses a valid $status vault status event',
-    ({ fixture, status }) => {
+    ({ fixture, status, vaultId }) => {
       const rawEvent = createRawHorizonEvent(
         fixture.eventType,
-        fixture.payload as Record<string, unknown>,
+        { ...(fixture.payload as unknown as Record<string, unknown>), vaultId },
         { id: `${fixture.transactionHash}-${fixture.eventIndex}`, txHash: fixture.transactionHash, ledger: fixture.ledgerNumber }
       )
 
@@ -40,14 +46,14 @@ describe('eventParser vault status events', () => {
 
       expect(result.event.eventType).toBe(fixture.eventType)
       const payload = result.event.payload as VaultEventPayload
-      expect(payload.vaultId).toBe((fixture.payload as VaultEventPayload).vaultId)
+      expect(payload.vaultId).toBe(vaultId)
       expect(payload.status).toBe(status)
     }
   )
 
   it('derives the status from the event type when the payload omits it', () => {
     const rawEvent = createRawHorizonEvent('vault_completed', {
-      vaultId: 'vault-no-status'
+      vaultId: '550e8400-e29b-41d4-a716-446655440004'
     })
 
     const result = parseHorizonEvent(rawEvent)
@@ -56,19 +62,18 @@ describe('eventParser vault status events', () => {
     if (!result.success) return
     const payload = result.event.payload as VaultEventPayload
     expect(payload.status).toBe('completed')
-    expect(payload.vaultId).toBe('vault-no-status')
+    expect(payload.vaultId).toBe('550e8400-e29b-41d4-a716-446655440004')
   })
 
   it('rejects a status event with an invalid status value', () => {
     const rawEvent = createRawHorizonEvent('vault_completed', {
-      vaultId: 'vault-bad-status',
+      vaultId: '550e8400-e29b-41d4-a716-446655440005',
       status: 'not_a_real_status'
     })
 
     const result = parseHorizonEvent(rawEvent)
 
     expect(result.success).toBe(false)
-    if (result.success) return
-    expect(result.error).toContain('Failed to parse payload')
+    expect(result).toMatchObject({ error: expect.stringContaining('Failed to parse payload') })
   })
 })

--- a/src/tests/eventParser.vaultId.test.ts
+++ b/src/tests/eventParser.vaultId.test.ts
@@ -1,4 +1,7 @@
+import { describe, expect, test } from '@jest/globals'
 import { parseHorizonEvent } from '../services/eventParser.js'
+import type { HorizonEvent } from '../services/eventParser.js'
+import type { VaultEventPayload } from '../types/horizonSync.js'
 
 describe('eventParser vaultId format validation', () => {
   const txHash = 'abcdef1234567890'
@@ -14,7 +17,7 @@ describe('eventParser vaultId format validation', () => {
       failureDestination: 'GFAILUREDEST'
     }
 
-    const rawEvent = {
+    const rawEvent: HorizonEvent = {
       type: 'contract_event',
       ledger: 123,
       ledgerClosedAt: new Date().toISOString(),
@@ -27,10 +30,10 @@ describe('eventParser vaultId format validation', () => {
       txHash
     }
 
-    const result = parseHorizonEvent(rawEvent as any)
+    const result = parseHorizonEvent(rawEvent)
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.event.payload.vaultId).toBe(payload.vaultId)
+      expect((result.event.payload as VaultEventPayload).vaultId).toBe(payload.vaultId)
     }
   })
 
@@ -45,7 +48,7 @@ describe('eventParser vaultId format validation', () => {
       failureDestination: 'GFAILUREDEST'
     }
 
-    const rawEvent = {
+    const rawEvent: HorizonEvent = {
       type: 'contract_event',
       ledger: 124,
       ledgerClosedAt: new Date().toISOString(),
@@ -58,7 +61,7 @@ describe('eventParser vaultId format validation', () => {
       txHash
     }
 
-    const result = parseHorizonEvent(rawEvent as any)
+    const result = parseHorizonEvent(rawEvent)
     expect(result.success).toBe(false)
   })
 })


### PR DESCRIPTION
Closes #620

## Summary
- Routes deterministic Horizon topics through the canonical event parser path, including `vault_slashed` -> `vault_failed`.
- Removes permissive fallback payload defaults so malformed contract events return structured parse failures instead of silently inventing required fields.
- Adds snake_case payload support for contract-style validation events (`validation_id`, `validator_address`, `validation_result`, etc.).
- Adds focused routing coverage for event id generation, ledger metadata, alias routing, snake_case validation payloads, and malformed required fields.
- Updates existing status/vault-id parser tests to align with strict UUID validation and typed Horizon events.

## Verification
- `npm test -- src/tests/eventParser.routing.test.ts src/tests/eventParser.status.test.ts src/tests/eventParser.vaultId.test.ts --runInBand`
- `npx eslint src/services/eventParser.ts src/tests/eventParser.routing.test.ts src/tests/eventParser.status.test.ts src/tests/eventParser.vaultId.test.ts --ext .ts`
- `npx tsc --noEmit --pretty false --module NodeNext --moduleResolution NodeNext --target ES2022 --esModuleInterop --skipLibCheck --types jest,node src/services/eventParser.ts src/tests/eventParser.routing.test.ts src/tests/eventParser.status.test.ts src/tests/eventParser.vaultId.test.ts`
- `git diff --check`

No payment details are posted publicly; reward coordination can happen privately if this is accepted.