### PR TITLE
feat(verifiers): rejection-veto quorum settlement for multi-verifier …

### DIFF
--- a/docs/multi-verifier-thresholds.md
+++ b/docs/multi-verifier-thresholds.md
@@ -4,6 +4,53 @@
 
 The multi-verifier milestone approval system enables vault creators to define M-of-N approval thresholds for milestone validation. Instead of requiring a single designated verifier to approve a milestone, the system allows multiple verifiers to vote on milestone completion, with the milestone being marked as verified only when the threshold is reached.
 
+## Veto Semantics (Rejection-Quorum Settlement)
+
+A milestone transitions to **irrevocably rejected** as soon as it becomes mathematically impossible to ever reach the approval threshold — not only when all verifiers have explicitly rejected.
+
+### Veto Math
+
+Given:
+- **M** = `approvalThreshold` (approvals required)
+- **N** = total verifiers in the pool
+- **approved** = votes cast as `approved`
+- **rejected** = votes cast as `rejected`
+- **remaining** = `N - (approved + rejected)` (verifiers yet to vote)
+
+**maxPossibleApprovals** = `approved + remaining`
+
+A milestone is **vetoed** (`isRejected = true`) when:
+
+```
+maxPossibleApprovals < M
+```
+
+Equivalently: `rejected > N - M` (rejection budget exceeded).
+
+### Examples
+
+| Threshold (M) | Pool (N) | Approved | Rejected | maxPossible | isRejected |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| 2 | 3 | 0 | 1 | 2 | ❌ not yet |
+| 2 | 3 | 0 | 2 | 1 | ✅ vetoed |
+| 2 | 3 | 2 | 1 | 2 | ❌ complete (not vetoed) |
+| 3 | 5 | 0 | 3 | 2 | ✅ vetoed |
+| 1 | 1 | 0 | 1 | 0 | ✅ vetoed |
+
+### Late-Vote Rejection (Settled State)
+
+The `/approve` endpoint checks settlement state **before** recording a vote. If a milestone is already `isComplete` or `isRejected`, the endpoint returns `409 Conflict` — no vote is recorded. `DuplicateVerifierVoteError` is still enforced at the DB layer regardless.
+
+### Legacy / No-N Mode
+
+When `totalVerifiers` (N) is not provided, the system falls back to **any-rejection-vetoes** semantics (`isRejected = rejected > 0`). This preserves backward compatibility with single-verifier milestones (threshold 1).
+
+### `isComplete` vs `isRejected`
+
+- `isComplete = true` requires: `approved >= M` **and** `isRejected = false`
+- Both can be false simultaneously (voting still in progress)
+- Once `isRejected = true`, it cannot be reversed (votes are immutable)
+
 ## Architecture
 
 ### Core Concepts
@@ -197,7 +244,8 @@ Determines if a milestone has received enough approvals to meet its threshold.
 ```typescript
 getMilestoneApprovalProgress(
   milestoneId: string,
-  approvalThreshold: number
+  approvalThreshold: number,
+  totalVerifiers?: number,   // N — enables veto math when provided
 ): Promise<{
   approved: number
   rejected: number
@@ -209,9 +257,7 @@ getMilestoneApprovalProgress(
 }>
 ```
 
-Returns comprehensive approval progress including completion status. A milestone is considered:
-- **Complete**: `approved >= required` AND `rejected === 0`
-- **Rejected**: `rejected > 0` (any rejection fails the milestone)
+Returns comprehensive approval progress. When `totalVerifiers` is supplied, `isRejected` uses veto math (`maxPossibleApprovals < M`). Without it, any rejection vetoes (legacy). `approvalPercentage` = `approved / totalVoted * 100`.
 
 ## Security Considerations
 

--- a/src/routes/milestones.ts
+++ b/src/routes/milestones.ts
@@ -8,11 +8,14 @@ import {
   verifyMilestone,
   validateMilestone,
   allMilestonesVerified,
+  allMilestonesMetThreshold,
 } from '../services/milestones.js'
 import {
   recordMilestoneApproval,
   hasVerifierVoted,
   getMilestoneApprovalProgress,
+  getApprovedVerifiersCount,
+  getMilestoneApprovals,
   hasMilestoneMetThreshold,
   DuplicateVerifierVoteError,
 } from '../services/verifiers.js'
@@ -167,26 +170,47 @@ milestonesRouter.post('/:id/approve', authenticate, requireVerifier, async (req:
       return next(AppError.conflict('Verifier has already voted on this milestone'))
     }
 
+    // Reject late votes on already-settled milestones
+    const milestone_record = getMilestoneById(id)
+    const approvalThreshold = (milestone_record as any)?.approvalThreshold || 1
+    const totalVerifiers = (milestone_record as any)?.totalVerifiers as number | undefined
+
+    const priorProgress = await getMilestoneApprovalProgress(id, approvalThreshold, totalVerifiers)
+    if (priorProgress.isComplete || priorProgress.isRejected) {
+      return next(AppError.conflict('Milestone is already settled'))
+    }
+
     // Record the approval
     const approval = await recordMilestoneApproval(id, verifierUserId, approvalStatus as any)
 
     // Get updated approval progress
-    const milestone_record = getMilestoneById(id)
-    const approvalThreshold = (milestone_record as any)?.approvalThreshold || 1
-    const approvalProgress = await getMilestoneApprovalProgress(id, approvalThreshold)
+    const approvalProgress = await getMilestoneApprovalProgress(id, approvalThreshold, totalVerifiers)
 
-    // Check if milestone should be completed (if all approvals met and no rejections)
+    // Settle milestone state
     let milestoneCompleted = false
     let vaultCompleted = false
 
-    if (approvalProgress.isComplete && !approvalProgress.isRejected) {
+    if (approvalProgress.isComplete) {
       milestoneCompleted = true
       milestone.verified = true
       milestone.verifiedAt = new Date().toISOString()
       milestone.verifiedBy = verifierUserId
 
-      // Check if all vault milestones are now verified
-      if (allMilestonesVerified(vaultId) && vault.status === 'active') {
+      // Build approval/rejection counts for veto-aware vault check
+      const vaultMilestones = getMilestonesByVaultId(vaultId)
+      const approvalCounts: Record<string, number> = {}
+      const rejectionCounts: Record<string, number> = {}
+      const totalVerifierCounts: Record<string, number> = {}
+
+      await Promise.all(vaultMilestones.map(async (m) => {
+        const votes = await getMilestoneApprovals(m.id)
+        approvalCounts[m.id] = votes.approved.length
+        rejectionCounts[m.id] = votes.rejected.length
+        const n = (m as any).totalVerifiers as number | undefined
+        if (n !== undefined) totalVerifierCounts[m.id] = n
+      }))
+
+      if (allMilestonesMetThreshold(vaultId, approvalCounts, rejectionCounts, totalVerifierCounts) && vault.status === 'active') {
         const result = completeVault(vaultId)
         vaultCompleted = result.success
       }

--- a/src/services/milestones.ts
+++ b/src/services/milestones.ts
@@ -275,13 +275,40 @@ export const validateMilestoneMultiVerifier = (
 /**
  * Check if all milestones in a vault meet their approval thresholds.
  */
-export const allMilestonesMetThreshold = (vaultId: string, approvalCounts: Record<string, number>): boolean => {
+/**
+ * Check if every milestone in a vault has met its approval threshold,
+ * taking into account veto-by-rejection semantics.
+ *
+ * A milestone is settled (not-vetoed + threshold met) when:
+ *   approved >= threshold  AND  maxPossibleApprovals >= threshold
+ *
+ * where maxPossibleApprovals = approved + (totalVerifiers - totalVoted).
+ * If totalVerifiers is absent for a milestone, any rejection is treated as a veto.
+ */
+export const allMilestonesMetThreshold = (
+  vaultId: string,
+  approvalCounts: Record<string, number>,
+  rejectionCounts: Record<string, number> = {},
+  totalVerifierCounts: Record<string, number> = {},
+): boolean => {
   const vaultMilestones = getMilestonesByVaultId(vaultId)
   if (vaultMilestones.length === 0) return false
 
   return vaultMilestones.every((m) => {
     const threshold = (m as any).approvalThreshold || 1
-    const approvals = approvalCounts[m.id] || 0
-    return approvals >= threshold
+    const approved = approvalCounts[m.id] || 0
+    const rejected = rejectionCounts[m.id] || 0
+    const n = totalVerifierCounts[m.id]
+
+    if (n !== undefined && n > 0) {
+      const totalVoted = approved + rejected
+      const remaining = Math.max(n - totalVoted, 0)
+      const maxPossible = approved + remaining
+      if (maxPossible < threshold) return false // veto: can never reach threshold
+    } else {
+      if (rejected > 0) return false // legacy: any rejection vetoes
+    }
+
+    return approved >= threshold
   })
 }

--- a/src/services/verifiers.ts
+++ b/src/services/verifiers.ts
@@ -522,10 +522,22 @@ export const hasMilestoneMetThreshold = async (
 
 /**
  * Get approval progress for a milestone (X of Y approvals).
+ *
+ * Veto math (when totalVerifiers N is provided):
+ *   A milestone is irrevocably rejected once it is impossible for approvals
+ *   to ever reach the threshold M:
+ *     isRejected = (approved + remaining) < M
+ *   where remaining = N - totalVoted.
+ *
+ *   Equivalently: rejected > N - M  (more rejections than the veto budget).
+ *
+ * When totalVerifiers is omitted (legacy / N unknown), any single rejection
+ * marks the milestone rejected (conservative default).
  */
 export const getMilestoneApprovalProgress = async (
   milestoneId: string,
   approvalThreshold: number,
+  totalVerifiers?: number,
 ): Promise<{
   approved: number
   rejected: number
@@ -533,19 +545,35 @@ export const getMilestoneApprovalProgress = async (
   required: number
   isComplete: boolean
   isRejected: boolean
+  approvalPercentage: number
 }> => {
   const approvals = await getMilestoneApprovals(milestoneId)
   const approved = approvals.approved.length
   const rejected = approvals.rejected.length
   const pending = approvals.pending.length
+  const totalVoted = approved + rejected + pending
+
+  // Veto math: can we still reach threshold?
+  let isRejected: boolean
+  if (totalVerifiers !== undefined && totalVerifiers > 0) {
+    const remaining = totalVerifiers - totalVoted
+    const maxPossibleApprovals = approved + Math.max(remaining, 0)
+    isRejected = maxPossibleApprovals < approvalThreshold
+  } else {
+    // Legacy: any rejection vetoes
+    isRejected = rejected > 0
+  }
+
+  const approvalPercentage = totalVoted === 0 ? 0 : Math.min((approved / totalVoted) * 100, 100)
 
   return {
     approved,
     rejected,
     pending,
     required: approvalThreshold,
-    isComplete: approved >= approvalThreshold,
-    isRejected: rejected > 0, // Reject if any verifier rejects
+    isComplete: approved >= approvalThreshold && !isRejected,
+    isRejected,
+    approvalPercentage,
   }
 }
 

--- a/tests/multiVerifier.veto.test.ts
+++ b/tests/multiVerifier.veto.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Veto-quorum settlement tests for multi-verifier milestones.
+ * Uses the same mock pattern as verifications.transaction.test.ts.
+ */
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
+
+// ---------------------------------------------------------------------------
+// In-memory store for milestone_approvals
+// ---------------------------------------------------------------------------
+type Row = { id: string; milestone_id: string; verifier_user_id: string; approval_status: string; created_at: Date; updated_at: Date }
+let store: Row[] = []
+let idSeq = 0
+
+function makeRow(milestoneId: string, verifierUserId: string, approvalStatus: string): Row {
+  return {
+    id: String(++idSeq),
+    milestone_id: milestoneId,
+    verifier_user_id: verifierUserId,
+    approval_status: approvalStatus,
+    created_at: new Date(),
+    updated_at: new Date(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal knex mock
+// ---------------------------------------------------------------------------
+function buildQuery(table: string) {
+  const q: any = { _table: table, _wheres: {} as Record<string, unknown>, _status: undefined as string | undefined }
+
+  q.where = (conds: Record<string, unknown>) => { Object.assign(q._wheres, conds); return q }
+  q.first = async () => {
+    if (q._table === 'milestone_approvals') {
+      return store.find(r =>
+        Object.entries(q._wheres).every(([k, v]) => (r as any)[k] === v)
+      ) ?? null
+    }
+    return null
+  }
+  q.insert = (data: any) => {
+    const row = { ...makeRow(data.milestone_id, data.verifier_user_id, data.approval_status), ...data }
+    store.push(row)
+    q._inserted = [row]
+    return q
+  }
+  q.returning = (_fields: string) => q._inserted ?? []
+  q.orderBy = () => q
+  q.select = () => q
+  // Make the query itself awaitable (resolves to rows matching wheres)
+  q.then = (resolve: any, reject: any) => {
+    try {
+      const rows = store.filter(r =>
+        Object.entries(q._wheres).every(([k, v]) => (r as any)[k] === v)
+      )
+      resolve(rows)
+    } catch (e) { reject(e) }
+    return Promise.resolve()
+  }
+  q.del = async () => { store = store.filter(r => !Object.entries(q._wheres).every(([k, v]) => (r as any)[k] === v)) }
+  return q
+}
+
+jest.unstable_mockModule('../src/db/knex.js', () => {
+  function db(table: string) { return buildQuery(table) }
+  db.fn = { now: () => new Date() }
+  db.transaction = async (cb: any) => cb(db)
+  return { db, closeDatabase: jest.fn() }
+})
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+const { recordMilestoneApproval, getMilestoneApprovalProgress, DuplicateVerifierVoteError, resetMilestoneApprovals } =
+  await import('../src/services/verifiers.js')
+const { createMilestoneWithThreshold, allMilestonesMetThreshold, resetMilestonesTable } =
+  await import('../src/services/milestones.js')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function reset() {
+  store = []
+  idSeq = 0
+  resetMilestonesTable()
+}
+
+async function vote(mid: string, vid: string, s: 'approved' | 'rejected') {
+  return recordMilestoneApproval(mid, vid, s)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Veto math — getMilestoneApprovalProgress(id, M, N)', () => {
+  const mid = 'veto-ms'
+
+  beforeEach(reset)
+
+  it('1-of-1: approval completes', async () => {
+    await vote(mid, 'v1', 'approved')
+    const p = await getMilestoneApprovalProgress(mid, 1, 1)
+    expect(p.isComplete).toBe(true)
+    expect(p.isRejected).toBe(false)
+  })
+
+  it('1-of-1: rejection → maxPossible=0 < 1 → vetoed', async () => {
+    await vote(mid, 'v1', 'rejected')
+    const p = await getMilestoneApprovalProgress(mid, 1, 1)
+    expect(p.isRejected).toBe(true)
+    expect(p.isComplete).toBe(false)
+  })
+
+  it('2-of-3: one rejection leaves maxPossible=2 ≥ 2 → NOT yet vetoed', async () => {
+    await vote(mid, 'v1', 'rejected')
+    const p = await getMilestoneApprovalProgress(mid, 2, 3)
+    // approved=0, rejected=1, remaining=2 → maxPossible=2 >= 2
+    expect(p.isRejected).toBe(false)
+  })
+
+  it('2-of-3: two rejections → maxPossible=1 < 2 → vetoed', async () => {
+    await vote(mid, 'v1', 'rejected')
+    await vote(mid, 'v2', 'rejected')
+    const p = await getMilestoneApprovalProgress(mid, 2, 3)
+    expect(p.isRejected).toBe(true)
+    expect(p.isComplete).toBe(false)
+  })
+
+  it('2-of-3: two approvals meet threshold', async () => {
+    await vote(mid, 'v1', 'approved')
+    await vote(mid, 'v2', 'approved')
+    const p = await getMilestoneApprovalProgress(mid, 2, 3)
+    expect(p.isComplete).toBe(true)
+    expect(p.isRejected).toBe(false)
+  })
+
+  it('2-of-3: two approvals + one rejection → still complete (threshold met, not vetoed)', async () => {
+    await vote(mid, 'v1', 'approved')
+    await vote(mid, 'v2', 'approved')
+    await vote(mid, 'v3', 'rejected')
+    const p = await getMilestoneApprovalProgress(mid, 2, 3)
+    expect(p.isComplete).toBe(true)
+    expect(p.isRejected).toBe(false)
+  })
+
+  it('3-of-5: two rejections → remaining=3, maxPossible=3 ≥ 3 → not yet vetoed', async () => {
+    await vote(mid, 'v1', 'rejected')
+    await vote(mid, 'v2', 'rejected')
+    const p = await getMilestoneApprovalProgress(mid, 3, 5)
+    expect(p.isRejected).toBe(false)
+  })
+
+  it('3-of-5: three rejections → maxPossible=2 < 3 → vetoed', async () => {
+    await vote(mid, 'v1', 'rejected')
+    await vote(mid, 'v2', 'rejected')
+    await vote(mid, 'v3', 'rejected')
+    const p = await getMilestoneApprovalProgress(mid, 3, 5)
+    expect(p.isRejected).toBe(true)
+  })
+
+  it('all-reject: all three reject on 2-of-3 → vetoed', async () => {
+    await vote(mid, 'v1', 'rejected')
+    await vote(mid, 'v2', 'rejected')
+    await vote(mid, 'v3', 'rejected')
+    const p = await getMilestoneApprovalProgress(mid, 2, 3)
+    expect(p.isRejected).toBe(true)
+    expect(p.isComplete).toBe(false)
+  })
+
+  it('threshold > pool: maxPossible=N < M → vetoed even with no votes', async () => {
+    // M=4, N=3: approved=0, remaining=3, maxPossible=3 < 4
+    const p = await getMilestoneApprovalProgress(mid, 4, 3)
+    expect(p.isRejected).toBe(true)
+  })
+
+  it('late vote after veto: progress still shows vetoed', async () => {
+    await vote(mid, 'v1', 'rejected')
+    await vote(mid, 'v2', 'rejected')
+    // milestone already vetoed (2-of-3, 2 rejections)
+    await vote(mid, 'v3', 'approved')
+    const p = await getMilestoneApprovalProgress(mid, 2, 3)
+    // approved=1, rejected=2, totalVoted=3, remaining=0 → maxPossible=1 < 2
+    expect(p.isRejected).toBe(true)
+    expect(p.isComplete).toBe(false)
+  })
+})
+
+describe('approvalPercentage', () => {
+  const mid = 'pct-ms'
+  beforeEach(reset)
+
+  it('is 0 with no votes', async () => {
+    const p = await getMilestoneApprovalProgress(mid, 2, 3)
+    expect(p.approvalPercentage).toBe(0)
+  })
+
+  it('is 100 when all votes are approvals', async () => {
+    await vote(mid, 'v1', 'approved')
+    await vote(mid, 'v2', 'approved')
+    const p = await getMilestoneApprovalProgress(mid, 2, 2)
+    expect(p.approvalPercentage).toBe(100)
+  })
+
+  it('is ~66.7 for 2 approved out of 3 total votes', async () => {
+    await vote(mid, 'v1', 'approved')
+    await vote(mid, 'v2', 'approved')
+    await vote(mid, 'v3', 'rejected')
+    const p = await getMilestoneApprovalProgress(mid, 2, 3)
+    expect(p.approvalPercentage).toBeCloseTo(66.667, 1)
+  })
+})
+
+describe('Legacy mode — no N', () => {
+  const mid = 'legacy-ms'
+  beforeEach(reset)
+
+  it('isRejected=false with no rejections', async () => {
+    await vote(mid, 'v1', 'approved')
+    const p = await getMilestoneApprovalProgress(mid, 1)
+    expect(p.isRejected).toBe(false)
+    expect(p.isComplete).toBe(true)
+  })
+
+  it('isRejected=true on any single rejection', async () => {
+    await vote(mid, 'v1', 'approved')
+    await vote(mid, 'v2', 'rejected')
+    const p = await getMilestoneApprovalProgress(mid, 2)
+    expect(p.isRejected).toBe(true)
+  })
+})
+
+describe('allMilestonesMetThreshold — veto-aware', () => {
+  beforeEach(reset)
+
+  it('returns false when a milestone is vetoed (2-of-3, 2 rejections)', () => {
+    const vault = 'v-001'
+    const m1 = createMilestoneWithThreshold(vault, 'Step 1', 2)
+    const result = allMilestonesMetThreshold(
+      vault,
+      { [m1.id]: 0 },
+      { [m1.id]: 2 },
+      { [m1.id]: 3 },
+    )
+    expect(result).toBe(false)
+  })
+
+  it('returns true when milestone meets threshold and is not vetoed', () => {
+    const vault = 'v-002'
+    const m1 = createMilestoneWithThreshold(vault, 'Step 1', 2)
+    const result = allMilestonesMetThreshold(
+      vault,
+      { [m1.id]: 2 },
+      { [m1.id]: 0 },
+      { [m1.id]: 3 },
+    )
+    expect(result).toBe(true)
+  })
+
+  it('returns false when one of two milestones is vetoed', () => {
+    const vault = 'v-003'
+    const m1 = createMilestoneWithThreshold(vault, 'Step 1', 1)
+    const m2 = createMilestoneWithThreshold(vault, 'Step 2', 2)
+    const result = allMilestonesMetThreshold(
+      vault,
+      { [m1.id]: 1, [m2.id]: 0 },
+      { [m1.id]: 0, [m2.id]: 2 },
+      { [m1.id]: 1, [m2.id]: 3 },
+    )
+    expect(result).toBe(false)
+  })
+
+  it('legacy: returns false if any rejection present without N', () => {
+    const vault = 'v-004'
+    const m1 = createMilestoneWithThreshold(vault, 'Step 1', 2)
+    const result = allMilestonesMetThreshold(
+      vault,
+      { [m1.id]: 2 },
+      { [m1.id]: 1 },
+      // no totalVerifierCounts → legacy mode
+    )
+    expect(result).toBe(false)
+  })
+
+  it('backward compatible: threshold=1, single approval, no rejections → true', () => {
+    const vault = 'v-005'
+    const m1 = createMilestoneWithThreshold(vault, 'Step 1', 1)
+    const result = allMilestonesMetThreshold(vault, { [m1.id]: 1 })
+    expect(result).toBe(true)
+  })
+})
+
+describe('Duplicate vote prevention', () => {
+  const mid = 'dup-ms'
+  beforeEach(reset)
+
+  it('throws DuplicateVerifierVoteError on second vote by same verifier', async () => {
+    await vote(mid, 'v1', 'approved')
+    await expect(vote(mid, 'v1', 'rejected')).rejects.toThrow(DuplicateVerifierVoteError)
+  })
+
+  it('throws even after milestone is vetoed', async () => {
+    await vote(mid, 'v1', 'rejected')
+    await vote(mid, 'v2', 'rejected')
+    await expect(vote(mid, 'v1', 'approved')).rejects.toThrow(DuplicateVerifierVoteError)
+  })
+})


### PR DESCRIPTION
…milestones

- getMilestoneApprovalProgress: add optional totalVerifiers (N) param for veto math — isRejected when maxPossibleApprovals < M; falls back to any-rejection-vetoes when N is omitted (backward compatible)
- Add approvalPercentage to getMilestoneApprovalProgress return value
- allMilestonesMetThreshold: accept rejectionCounts + totalVerifierCounts to apply veto math per-milestone for vault completion check
- /approve route: reject late votes on already-settled milestones (409); use veto-aware allMilestonesMetThreshold for vaultCompleted flag
- Add tests/multiVerifier.veto.test.ts: 23 tests covering 1-of-1, 2-of-3, 3-of-5, all-reject, threshold>pool, late votes, approvalPercentage, legacy mode, allMilestonesMetThreshold, and duplicate vote prevention
- Update docs/multi-verifier-thresholds.md with veto semantics section, examples table, and updated function signatures

Closes #619