### PR TITLE
test: concurrent export-quota enforcement

### DIFF
--- a/src/services/exportQuota.ts
+++ b/src/services/exportQuota.ts
@@ -18,10 +18,14 @@ interface OrgQuotaRecord {
   updated_at: string
 }
 
+type OrgQuotaIncrementResult = OrgQuotaEntry & { granted?: boolean }
+
 interface OrgQuotaRepository {
-  /** Atomically increment count for org/date/metric. Returns the new entry.
-   *  Creates the row with count=1 if it does not exist yet. */
-  increment(orgId: string, date: string, metric: string, dailyLimit: number): Promise<OrgQuotaEntry>
+  /**
+   * Atomically grants one quota unit when count is still below dailyLimit.
+   * Implementations must leave count unchanged and return granted=false once exhausted.
+   */
+  increment(orgId: string, date: string, metric: string, dailyLimit: number): Promise<OrgQuotaIncrementResult>
   get(orgId: string, date: string, metric: string): Promise<OrgQuotaEntry | undefined>
   reset(): Promise<void>
 }
@@ -36,16 +40,18 @@ const createInMemoryOrgQuotaRepository = (): OrgQuotaRepository => {
     async increment(orgId, date, metric, dailyLimit) {
       const k = key(orgId, date, metric)
       const existing = store.get(k)
+      const count = existing?.count ?? 0
+      const granted = count < dailyLimit
       const entry: OrgQuotaEntry = {
         orgId,
         quotaDate: date,
         metric,
-        count: (existing?.count ?? 0) + 1,
+        count: granted ? count + 1 : count,
         limit: dailyLimit,
-        updatedAt: new Date().toISOString(),
+        updatedAt: granted || !existing ? new Date().toISOString() : existing.updatedAt,
       }
       store.set(k, entry)
-      return { ...entry }
+      return { ...entry, granted }
     },
     async get(orgId, date, metric) {
       const entry = store.get(key(orgId, date, metric))
@@ -57,43 +63,72 @@ const createInMemoryOrgQuotaRepository = (): OrgQuotaRepository => {
   }
 }
 
+const firstRawRow = <T>(result: unknown): T | undefined => {
+  if (result && typeof result === 'object' && 'rows' in result) {
+    return ((result as { rows?: T[] }).rows ?? [])[0]
+  }
+
+  if (Array.isArray(result)) {
+    const [first] = result as unknown[]
+    if (Array.isArray(first)) return first[0] as T | undefined
+    return first as T | undefined
+  }
+
+  return undefined
+}
+
+const toQuotaEntry = (row: OrgQuotaRecord): OrgQuotaEntry => ({
+  orgId: row.org_id,
+  quotaDate: row.quota_date,
+  metric: row.metric,
+  count: row.count,
+  limit: row.limit,
+  updatedAt: row.updated_at,
+})
+
+const emptyQuotaEntry = (orgId: string, date: string, metric: string, dailyLimit: number): OrgQuotaEntry => ({
+  orgId,
+  quotaDate: date,
+  metric,
+  count: 0,
+  limit: dailyLimit,
+  updatedAt: new Date().toISOString(),
+})
+
 export const createKnexOrgQuotaRepository = (db: Knex): OrgQuotaRepository => ({
   async increment(orgId, date, metric, dailyLimit) {
+    if (dailyLimit <= 0) {
+      const row = await db<OrgQuotaRecord>('org_quotas')
+        .where({ org_id: orgId, quota_date: date, metric })
+        .first()
+      return { ...(row ? toQuotaEntry(row) : emptyQuotaEntry(orgId, date, metric, dailyLimit)), granted: false }
+    }
+
     const now = new Date().toISOString()
-    // Upsert: increment count atomically
-    await db.raw(
+    const result = await db.raw(
       `INSERT INTO org_quotas (org_id, quota_date, metric, count, "limit", updated_at)
        VALUES (:orgId, :date, :metric, 1, :limit, :now)
        ON CONFLICT (org_id, quota_date, metric)
-       DO UPDATE SET count = org_quotas.count + 1, updated_at = :now`,
+       DO UPDATE SET count = org_quotas.count + 1, "limit" = :limit, updated_at = :now
+       WHERE org_quotas.count < :limit
+       RETURNING org_id, quota_date, metric, count, "limit", updated_at`,
       { orgId, date, metric, limit: dailyLimit, now },
     )
+    const grantedRow = firstRawRow<OrgQuotaRecord>(result)
+    if (grantedRow) return { ...toQuotaEntry(grantedRow), granted: true }
+
     const row = await db<OrgQuotaRecord>('org_quotas')
       .where({ org_id: orgId, quota_date: date, metric })
       .first()
 
-    return {
-      orgId: row!.org_id,
-      quotaDate: row!.quota_date,
-      metric: row!.metric,
-      count: row!.count,
-      limit: row!.limit,
-      updatedAt: row!.updated_at,
-    }
+    return { ...(row ? toQuotaEntry(row) : emptyQuotaEntry(orgId, date, metric, dailyLimit)), granted: false }
   },
   async get(orgId, date, metric) {
     const row = await db<OrgQuotaRecord>('org_quotas')
       .where({ org_id: orgId, quota_date: date, metric })
       .first()
     if (!row) return undefined
-    return {
-      orgId: row.org_id,
-      quotaDate: row.quota_date,
-      metric: row.metric,
-      count: row.count,
-      limit: row.limit,
-      updatedAt: row.updated_at,
-    }
+    return toQuotaEntry(row)
   },
   async reset() {
     await db('org_quotas').delete()
@@ -117,17 +152,13 @@ export const checkAndIncrementExportQuota = async (
   orgId: string,
   dailyLimit: number,
 ): Promise<{ allowed: true } | { allowed: false; retryAfter: number }> => {
-  const today = utcDateString()
-
-  // Read first to avoid incrementing over-quota requests
-  const existing = await orgQuotaRepository.get(orgId, today, EXPORT_QUOTA_METRIC)
-  if (existing && existing.count >= existing.limit) {
+  if (dailyLimit <= 0) {
     return { allowed: false, retryAfter: secondsUntilEndOfUtcDay() }
   }
 
+  const today = utcDateString()
   const entry = await orgQuotaRepository.increment(orgId, today, EXPORT_QUOTA_METRIC, dailyLimit)
-  if (entry.count > entry.limit) {
-    // Raced past the limit (concurrent requests); still reject
+  if (entry.granted === false || entry.count > entry.limit) {
     return { allowed: false, retryAfter: secondsUntilEndOfUtcDay() }
   }
 
@@ -142,5 +173,11 @@ const secondsUntilEndOfUtcDay = (): number => {
 }
 
 export const resetOrgQuotas = (): Promise<void> => orgQuotaRepository.reset()
+
+export const getOrgQuotaEntry = (
+  orgId: string,
+  date = utcDateString(),
+  metric = EXPORT_QUOTA_METRIC,
+): Promise<OrgQuotaEntry | undefined> => orgQuotaRepository.get(orgId, date, metric)
 
 export { utcDateString }

--- a/src/tests/exports.quota.concurrency.test.ts
+++ b/src/tests/exports.quota.concurrency.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals'
+import type { Request, Response } from 'express'
+import {
+  EXPORT_QUOTA_METRIC,
+  getOrgQuotaEntry,
+  resetOrgQuotas,
+  utcDateString,
+} from '../services/exportQuota.js'
+import { resetExportJobs } from '../services/exportQueue.js'
+
+const testEnv = {
+  EXPORT_DAILY_QUOTA_LIMIT: 100,
+}
+
+jest.unstable_mockModule('../config/index.js', () => ({
+  getEnv: () => testEnv,
+  initEnv: () => ({ env: testEnv, warnings: [] }),
+  _resetEnvForTesting: () => undefined,
+}))
+
+jest.unstable_mockModule('../middleware/auth.js', () => ({
+  authenticate: (_req: Request, _res: Response, next: () => void) => next(),
+  requireAdmin: (_req: Request, _res: Response, next: () => void) => next(),
+  signDownloadToken: () => 'mock-token',
+  verifyDownloadToken: () => null,
+}))
+
+type MockResponse = {
+  status: (code: number) => MockResponse
+  json: (body: unknown) => MockResponse
+  setHeader: (name: string, value: string | number) => MockResponse
+  send: (body: unknown) => MockResponse
+  statusCode?: number
+  jsonBody?: unknown
+  headers: Record<string, string | number>
+}
+
+const mockRes = (): MockResponse => {
+  const r: MockResponse = {
+    headers: {},
+    status(code) {
+      r.statusCode = code
+      return r
+    },
+    json(body) {
+      r.jsonBody = body
+      return r
+    },
+    setHeader(name, value) {
+      r.headers[name] = value
+      return r
+    },
+    send(body) {
+      void body
+      return r
+    },
+  }
+  return r
+}
+
+const createMockJobSystem = () => ({
+  enqueue: jest.fn(() => ({
+    id: `job-${Math.random().toString(16).slice(2)}`,
+    type: 'export.generate',
+    runAt: new Date().toISOString(),
+    maxAttempts: 3,
+  })),
+})
+
+let createExportRouter: typeof import('../routes/exports.js').createExportRouter
+
+type RouteLayer = {
+  route?: {
+    path?: string
+    methods?: Partial<Record<'post' | 'get', boolean>>
+    stack?: Array<{ handle: unknown }>
+  }
+}
+
+const getHandler = (path: string, method: 'post' | 'get', jobSystem = createMockJobSystem()) => {
+  const router = createExportRouter(jobSystem as never)
+  const stack = router.stack as unknown as RouteLayer[]
+  const layer = stack.find((e) => e.route?.path === path && Boolean(e.route?.methods?.[method]))
+  if (!layer?.route?.stack?.length) throw new Error(`Handler not found: ${method.toUpperCase()} ${path}`)
+  return {
+    jobSystem,
+    handle: layer.route.stack[layer.route.stack.length - 1].handle as (
+      req: Request,
+      res: Response,
+    ) => Promise<void>,
+  }
+}
+
+const makeReq = (orgId: string, userId = 'quota-burst-user') =>
+  ({
+    query: { format: 'json', scope: 'vaults' },
+    user: { userId, role: 'USER' },
+    orgId,
+    header: () => undefined,
+  }) as unknown as Request
+
+const withQuotaLimit = async (limit: number, fn: () => Promise<void>): Promise<void> => {
+  const original = testEnv.EXPORT_DAILY_QUOTA_LIMIT
+  testEnv.EXPORT_DAILY_QUOTA_LIMIT = limit
+  try {
+    await fn()
+  } finally {
+    testEnv.EXPORT_DAILY_QUOTA_LIMIT = original
+  }
+}
+
+const runBurst = async (orgId: string, burstSize: number) => {
+  const { handle, jobSystem } = getHandler('/me', 'post')
+  const responses = Array.from({ length: burstSize }, () => mockRes())
+
+  await Promise.all(
+    responses.map((res, index) =>
+      handle(makeReq(orgId, `quota-burst-user-${index}`), res as unknown as Response),
+    ),
+  )
+
+  return { responses, jobSystem }
+}
+
+beforeEach(async () => {
+  testEnv.EXPORT_DAILY_QUOTA_LIMIT = 100
+  if (!createExportRouter) {
+    createExportRouter = (await import('../routes/exports.js')).createExportRouter
+  }
+  await resetOrgQuotas()
+  await resetExportJobs()
+  jest.restoreAllMocks()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+describe('export quota concurrency', () => {
+  it('accepts exactly K concurrent exports and rejects the rest with 429 without over-counting', async () => {
+    await withQuotaLimit(3, async () => {
+      const orgId = 'org-concurrent-burst'
+      const { responses, jobSystem } = await runBurst(orgId, 10)
+
+      const accepted = responses.filter((res) => res.statusCode === 202)
+      const rejected = responses.filter((res) => res.statusCode === 429)
+
+      expect(accepted).toHaveLength(3)
+      expect(rejected).toHaveLength(7)
+      expect(jobSystem.enqueue).toHaveBeenCalledTimes(3)
+
+      for (const res of rejected) {
+        expect(res.headers['Retry-After']).toBeDefined()
+        expect(Number(res.headers['Retry-After'])).toBeGreaterThan(0)
+        expect((res.jsonBody as { error?: string }).error).toMatch(/quota exceeded/i)
+        expect((res.jsonBody as { retryAfter?: number }).retryAfter).toBeGreaterThan(0)
+      }
+
+      const quota = await getOrgQuotaEntry(orgId, utcDateString(), EXPORT_QUOTA_METRIC)
+      expect(quota?.count).toBe(3)
+      expect(quota?.limit).toBe(3)
+    })
+  })
+
+  it('refreshes the quota budget when the UTC quota date changes', async () => {
+    jest.useFakeTimers()
+
+    await withQuotaLimit(2, async () => {
+      jest.setSystemTime(new Date('2030-06-15T23:59:50.000Z'))
+      const orgId = 'org-concurrent-reset-window'
+
+      const firstWindow = await runBurst(orgId, 5)
+      expect(firstWindow.responses.filter((res) => res.statusCode === 202)).toHaveLength(2)
+      expect(firstWindow.responses.filter((res) => res.statusCode === 429)).toHaveLength(3)
+      expect((await getOrgQuotaEntry(orgId, '2030-06-15', EXPORT_QUOTA_METRIC))?.count).toBe(2)
+
+      jest.setSystemTime(new Date('2030-06-16T00:00:01.000Z'))
+      const secondWindow = await runBurst(orgId, 2)
+      expect(secondWindow.responses.filter((res) => res.statusCode === 202)).toHaveLength(2)
+      expect(secondWindow.responses.filter((res) => res.statusCode === 429)).toHaveLength(0)
+      expect((await getOrgQuotaEntry(orgId, '2030-06-16', EXPORT_QUOTA_METRIC))?.count).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
Closes #679.

## Summary
- Add deterministic concurrent export quota coverage using `Promise.all`.
- Prove a burst of N requests against quota K accepts exactly K and rejects N-K with 429.
- Keep the stored quota counter capped at the limit and verify the UTC reset window refreshes the budget.
- Make quota increment grant-or-noop so over-limit requests do not leave the counter above the limit.
- Use an atomic guarded PostgreSQL upsert for persisted quota increments.

## Validation
- PASS `npm test -- src/tests/exports.quota.concurrency.test.ts --runInBand`
- PASS `npx eslint src/services/exportQuota.ts src/tests/exports.quota.concurrency.test.ts`
- PASS `git diff --check`
- PASS public-bound secret/private marker scan on changed files

## Baseline note
The repository baseline currently fails outside this PR's scope:
- `npm run build` fails on existing TypeScript/config errors such as duplicate `config` declarations and unrelated route/job/service type errors.
- `npm run lint` reports repo-wide pre-existing lint issues.
- `npm test -- --runInBand` fails on existing suites such as Soroban/config-related tests.
- `bun` is not installed in my local environment, so the equivalent npm/Jest commands above were used.