### PR TITLE
test: cover evidence signed-url tamper checks

### DIFF
--- a/src/services/evidence.ts
+++ b/src/services/evidence.ts
@@ -1,3 +1,4 @@
+import { URL } from 'node:url'
 import { prisma } from '../lib/prisma.js'
 
 export class EvidenceReferenceValidationError extends Error {
@@ -14,6 +15,13 @@ export interface EvidenceReference {
   referenceUrl: string
   expiresAt: string
   createdAt: string
+}
+
+export interface SignedObjectStorageUrlValidationOptions {
+  now?: Date | number
+  expectedKey?: string
+  expectedOrgId?: string
+  signatureVerifier?: (url: URL) => boolean
 }
 
 const EVIDENCE_HASH_PATTERN = /^[A-Za-z0-9_-]{32,128}$/
@@ -62,18 +70,29 @@ function parseExpiryParam(value: string): Date {
   throw new EvidenceReferenceValidationError('Signed URL expiry parameter must be a valid numeric timestamp')
 }
 
-function getSignedUrlExpiry(referenceUrl: string): Date {
-  let url: URL
+function parseReferenceUrl(referenceUrl: string): URL {
   try {
-    url = new URL(referenceUrl)
+    const url = new URL(referenceUrl)
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      throw new EvidenceReferenceValidationError('evidenceReferenceUrl must use http or https')
+    }
+    return url
   } catch (error) {
+    if (error instanceof EvidenceReferenceValidationError) throw error
     throw new EvidenceReferenceValidationError('evidenceReferenceUrl must be a valid URL')
   }
+}
 
-  if (!['http:', 'https:'].includes(url.protocol)) {
-    throw new EvidenceReferenceValidationError('evidenceReferenceUrl must use http or https')
-  }
+function getObjectKey(url: URL): string {
+  return decodeURIComponent(url.pathname.replace(/^\/+/, ''))
+}
 
+function getSignature(url: URL): string | null {
+  const params = url.searchParams
+  return params.get('X-Amz-Signature') ?? params.get('Signature') ?? params.get('signature')
+}
+
+function getSignedUrlExpiry(url: URL): Date {
   const params = url.searchParams
   const rawXAmzExpires = params.get('X-Amz-Expires')
   const rawExpires = params.get('Expires')
@@ -105,11 +124,40 @@ function getSignedUrlExpiry(referenceUrl: string): Date {
   throw new EvidenceReferenceValidationError('Signed object-storage URL missing expiry parameter')
 }
 
-export function validateSignedObjectStorageUrl(referenceUrl: string): Date {
-  const expiry = getSignedUrlExpiry(referenceUrl)
-  if (expiry.getTime() <= Date.now()) {
+export function validateSignedObjectStorageUrl(
+  referenceUrl: string,
+  options: SignedObjectStorageUrlValidationOptions = {},
+): Date {
+  const url = parseReferenceUrl(referenceUrl)
+  const signature = getSignature(url)
+  if (!signature?.trim()) {
+    throw new EvidenceReferenceValidationError('Signed object-storage URL missing signature parameter')
+  }
+
+  const expiry = getSignedUrlExpiry(url)
+  const now = typeof options.now === 'number'
+    ? options.now
+    : options.now instanceof Date
+      ? options.now.getTime()
+      : Date.now()
+
+  if (expiry.getTime() <= now) {
     throw new EvidenceReferenceValidationError('Signed object-storage URL has already expired')
   }
+
+  const objectKey = getObjectKey(url)
+  if (options.expectedKey && objectKey !== options.expectedKey) {
+    throw new EvidenceReferenceValidationError('Signed object-storage URL object key does not match expected evidence key')
+  }
+
+  if (options.expectedOrgId && !objectKey.startsWith(`orgs/${options.expectedOrgId}/`)) {
+    throw new EvidenceReferenceValidationError('Signed object-storage URL is outside the expected organization scope')
+  }
+
+  if (options.signatureVerifier && !options.signatureVerifier(url)) {
+    throw new EvidenceReferenceValidationError('Signed object-storage URL signature verification failed')
+  }
+
   return expiry
 }
 

--- a/src/tests/evidence.service.test.ts
+++ b/src/tests/evidence.service.test.ts
@@ -16,7 +16,10 @@ describe('evidence service', () => {
   })
 
   test('validates AWS v4 signed object-storage URL expiry', () => {
-    const url = 'https://s3.example.com/object.txt?X-Amz-Date=20260527T000000Z&X-Amz-Expires=3600&X-Amz-Signature=abc'
+    const signedAt = new Date(Date.now() + 60_000).toISOString()
+      .replace(/[-:]/g, '')
+      .replace(/\.\d{3}Z$/, 'Z')
+    const url = `https://s3.example.com/object.txt?X-Amz-Date=${signedAt}&X-Amz-Expires=3600&X-Amz-Signature=abc`
     const expiry = validateSignedObjectStorageUrl(url)
     expect(expiry.getTime()).toBeGreaterThan(Date.now())
   })
@@ -29,6 +32,11 @@ describe('evidence service', () => {
   test('rejects signed object-storage URLs missing expiry parameters', () => {
     const url = 'https://s3.example.com/object.txt?X-Amz-Signature=abc'
     expect(() => validateSignedObjectStorageUrl(url)).toThrow('missing expiry parameter')
+  })
+
+  test('rejects signed object-storage URLs missing signature parameters', () => {
+    const url = 'https://s3.example.com/object.txt?Expires=32503680000'
+    expect(() => validateSignedObjectStorageUrl(url)).toThrow('missing signature parameter')
   })
 
   test('persists evidence references via Prisma raw SQL', async () => {

--- a/src/tests/evidence.signedUrl.test.ts
+++ b/src/tests/evidence.signedUrl.test.ts
@@ -1,0 +1,90 @@
+import { createHmac } from 'node:crypto'
+import { URL } from 'node:url'
+import { describe, expect, test } from '@jest/globals'
+import { EvidenceReferenceValidationError, validateSignedObjectStorageUrl } from '../services/evidence.js'
+
+const SECRET = 'local-s3-test-secret'
+const NOW = Date.parse('2026-06-24T00:00:00.000Z')
+const EXPIRES = Math.floor((NOW + 10 * 60 * 1000) / 1000)
+
+function signPathAndExpiry(pathname: string, expires: number): string {
+  return createHmac('sha256', SECRET)
+    .update(`${pathname}:${expires}`)
+    .digest('hex')
+}
+
+function createSignedEvidenceUrl(key = 'orgs/org-a/evidence/verification-1.pdf'): string {
+  const pathname = `/${key}`
+  const signature = signPathAndExpiry(pathname, EXPIRES)
+  return `https://local-s3.example.test${pathname}?Expires=${EXPIRES}&signature=${signature}`
+}
+
+function verifyLocalSignature(url: URL): boolean {
+  const expires = Number(url.searchParams.get('Expires'))
+  const signature = url.searchParams.get('signature')
+  return signature === signPathAndExpiry(url.pathname, expires)
+}
+
+describe('evidence signed URL validation policy', () => {
+  test('accepts an unexpired signed evidence URL scoped to the expected org and key', () => {
+    const key = 'orgs/org-a/evidence/verification-1.pdf'
+    const expiry = validateSignedObjectStorageUrl(createSignedEvidenceUrl(key), {
+      now: NOW,
+      expectedOrgId: 'org-a',
+      expectedKey: key,
+      signatureVerifier: verifyLocalSignature,
+    })
+
+    expect(expiry.toISOString()).toBe(new Date(EXPIRES * 1000).toISOString())
+  })
+
+  test('rejects a signed URL after its expiry window', () => {
+    expect(() =>
+      validateSignedObjectStorageUrl(createSignedEvidenceUrl(), {
+        now: EXPIRES * 1000 + 1,
+        expectedOrgId: 'org-a',
+        signatureVerifier: verifyLocalSignature,
+      }),
+    ).toThrow(EvidenceReferenceValidationError)
+  })
+
+  test('rejects a URL whose object key was tampered after signing', () => {
+    const tampered = createSignedEvidenceUrl().replace(
+      '/orgs/org-a/evidence/verification-1.pdf',
+      '/orgs/org-a/evidence/verification-2.pdf',
+    )
+
+    expect(() =>
+      validateSignedObjectStorageUrl(tampered, {
+        now: NOW,
+        expectedOrgId: 'org-a',
+        signatureVerifier: verifyLocalSignature,
+      }),
+    ).toThrow('signature verification failed')
+  })
+
+  test('rejects a URL whose signature was tampered', () => {
+    const url = new URL(createSignedEvidenceUrl())
+    url.searchParams.set('signature', 'deadbeef')
+
+    expect(() =>
+      validateSignedObjectStorageUrl(url.toString(), {
+        now: NOW,
+        expectedOrgId: 'org-a',
+        signatureVerifier: verifyLocalSignature,
+      }),
+    ).toThrow('signature verification failed')
+  })
+
+  test('rejects a signed URL outside the expected organization scope', () => {
+    const key = 'orgs/org-b/evidence/verification-1.pdf'
+
+    expect(() =>
+      validateSignedObjectStorageUrl(createSignedEvidenceUrl(key), {
+        now: NOW,
+        expectedOrgId: 'org-a',
+        signatureVerifier: verifyLocalSignature,
+      }),
+    ).toThrow('outside the expected organization scope')
+  })
+})


### PR DESCRIPTION
## Summary
- add deterministic evidence signed-URL policy coverage for expiry, object-key tampering, signature tampering, and org-scope isolation
- extend signed object-storage URL validation with optional expected key/org checks and injectable signature verification for local tests
- refresh the existing AWS v4 expiry fixture so it no longer expires as time passes, and reject signed URLs missing a signature parameter

Closes #669

## Verification
- `npm test -- src/tests/evidence.signedUrl.test.ts --runInBand`
- `npm test -- src/tests/evidence.service.test.ts --runInBand`
- `npx eslint src/services/evidence.ts src/tests/evidence.signedUrl.test.ts`
- `git diff --check`

Note: the issue mentions `bun test`, but Bun is not installed in my local environment. I used the repo's existing npm/Jest test path instead.

## Known repo-wide checks
- `npm run build` currently fails on existing repo-wide TypeScript errors outside this change, e.g. duplicate env/export declarations and unrelated route/helper signature issues.
- `npm run lint` currently reports many existing repo-wide lint errors; the modified service file and new signed-URL test file pass targeted ESLint.
