### PR TITLE
feat(export): add dead-letter queue to ExportQueue with PII-safe entr…

### DIFF
--- a/docs/exports.md
+++ b/docs/exports.md
@@ -99,6 +99,52 @@ The `Retry-After` value is the number of seconds remaining until the quota reset
 | -------------------------- | ------- | -------------------------------------- |
 | `EXPORT_DAILY_QUOTA_LIMIT` | `100`   | Max export requests per tenant per day |
 
+## Dead-Letter Queue (DLQ)
+
+When an export job exhausts all retry attempts and permanently fails, the ExportQueue moves it to an in-memory DLQ with a structured failure record.
+
+### DlqEntry structure
+
+| Field | Description |
+|-------|-------------|
+| `jobId` | Export job identifier |
+| `jobType` | `{scope}:{format}` (e.g. `vaults:csv`) |
+| `failureReason` | `serialization_error`, `data_fetch_error`, or `unknown_error` |
+| `errorMessage` | PII-sanitised error message |
+| `attemptCount` | Number of attempts made |
+| `failedAt` | ISO-8601 UTC timestamp |
+| `sanitisedContext` | Job metadata with `userId`/`targetUserId` replaced by opaque SHA-256 tokens |
+
+### Failure taxonomy
+
+- **`serialization_error`** — error during CSV or JSON serialisation
+- **`data_fetch_error`** — error while fetching export data from vault store or database
+- **`unknown_error`** — any other error (S3, repository, etc.)
+
+### DLQ operations (internal service methods)
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getDlqEntries()` | `DlqEntry[]` | Newest-first read-only snapshot |
+| `getDlqEntry(jobId)` | `DlqEntry \| undefined` | Lookup by job ID |
+| `getDlqDepth()` | `number` | Current entry count |
+| `requeueDlqEntry(jobId)` | `Promise<boolean>` | Remove from DLQ, reset job to `pending` with `attempts: 0` |
+| `discardDlqEntry(jobId)` | `boolean` | Permanently remove from DLQ |
+| `clearDlq()` | `number` | Remove all entries, returns count |
+
+### Configuration
+
+```ts
+configureDlq({ maxSize: 200, metricsHook: myHook })
+```
+
+- `maxSize` — maximum entries (default `100`); oldest entry evicted on overflow
+- `metricsHook` — optional callback `(event: DlqMetricsEvent) => void` invoked on add, requeue, discard, and clear; failures are caught and logged
+
+### PII safety
+
+`userId` and `targetUserId` are replaced with the first 8 characters of their SHA-256 hash via `maskPii` before storage or emission. Raw Stellar addresses, email addresses, and other PII fields listed in `PRIVACY.md` are stripped from `sanitisedContext` and `errorMessage`.
+
 ## CSV behavior
 
 - CSV output uses UTF-8 with BOM for spreadsheet compatibility.

--- a/src/services/exportQueue.ts
+++ b/src/services/exportQueue.ts
@@ -10,6 +10,28 @@ export type ExportFormat = 'csv' | 'json'
 export type ExportScope = 'vaults' | 'transactions' | 'analytics' | 'all'
 export type JobStatus = 'pending' | 'running' | 'done' | 'failed'
 
+export type FailureReason = 'serialization_error' | 'data_fetch_error' | 'unknown_error'
+
+export interface DlqEntry {
+  jobId: string
+  jobType: string
+  failureReason: FailureReason
+  errorMessage: string
+  attemptCount: number
+  failedAt: string
+  sanitisedContext: Record<string, unknown>
+}
+
+export interface DlqMetricsEvent {
+  event: 'entry_added' | 'entry_requeued' | 'entry_discarded' | 'dlq_cleared'
+  jobId: string
+  failureReason?: FailureReason
+  dlqDepth: number
+  timestamp: string
+}
+
+export type DlqMetricsHook = (event: DlqMetricsEvent) => void
+
 export interface ExportJob {
   id: string
   userId: string
@@ -326,6 +348,49 @@ export const configureExportJobRepository = (repository: ExportJobRepository): v
   exportJobRepository = repository
 }
 
+const DEFAULT_MAX_DLQ_SIZE = 100
+
+let dlqStore: DlqEntry[] = []
+let dlqMaxSize = DEFAULT_MAX_DLQ_SIZE
+let dlqMetricsHook: DlqMetricsHook | undefined
+
+export const configureDlq = (options?: { maxSize?: number; metricsHook?: DlqMetricsHook }): void => {
+  if (options?.maxSize !== undefined) {
+    dlqMaxSize = Math.max(1, Math.floor(options.maxSize))
+  }
+  dlqMetricsHook = options?.metricsHook
+}
+
+const sanitiseDlqContext = (job: ExportJob): Record<string, unknown> => {
+  return sanitizePrivacyPayload(
+    { ...exportUserTokens(job), scope: job.scope, format: job.format, isAdmin: job.isAdmin, requestHash: job.requestHash },
+    exportPiiValues(job),
+  ) as Record<string, unknown>
+}
+
+const dlqInsert = (entry: DlqEntry): void => {
+  while (dlqStore.length >= dlqMaxSize) {
+    dlqStore.shift()
+  }
+  dlqStore.push(entry)
+}
+
+const dlqRemove = (jobId: string): DlqEntry | undefined => {
+  const index = dlqStore.findIndex(e => e.jobId === jobId)
+  if (index === -1) return undefined
+  const [entry] = dlqStore.splice(index, 1)
+  return entry
+}
+
+const safeInvokeMetricsHook = (event: DlqMetricsEvent): void => {
+  if (!dlqMetricsHook) return
+  try {
+    dlqMetricsHook(event)
+  } catch {
+    console.warn(JSON.stringify({ level: 'warn', event: 'dlq.metrics_hook_failed', timestamp: new Date().toISOString() }))
+  }
+}
+
 export function createJob(params: Omit<ExportJob, 'id' | 'status' | 'createdAt' | 'attempts'>): Promise<ExportJob> {
   return exportJobRepository.create(params)
 }
@@ -336,6 +401,76 @@ export function getJob(id: string): Promise<ExportJob | undefined> {
 
 export async function resetExportJobs(): Promise<void> {
   await exportJobRepository.reset()
+}
+
+export const getDlqEntries = (): readonly DlqEntry[] => {
+  const copy = [...dlqStore]
+  copy.reverse()
+  return copy
+}
+
+export const getDlqEntry = (jobId: string): DlqEntry | undefined =>
+  dlqStore.find(e => e.jobId === jobId)
+
+export const getDlqDepth = (): number => dlqStore.length
+
+export const requeueDlqEntry = async (jobId: string): Promise<boolean> => {
+  const entry = dlqRemove(jobId)
+  if (!entry) return false
+
+  const job = await exportJobRepository.get(jobId)
+  if (!job) return false
+
+  await exportJobRepository.update({
+    ...job,
+    status: 'pending',
+    attempts: 0,
+    error: undefined,
+    completedAt: undefined,
+  })
+
+  safeInvokeMetricsHook({
+    event: 'entry_requeued',
+    jobId,
+    dlqDepth: dlqStore.length,
+    timestamp: new Date().toISOString(),
+  })
+
+  return true
+}
+
+export const discardDlqEntry = (jobId: string): boolean => {
+  const entry = dlqRemove(jobId)
+  if (!entry) return false
+
+  safeInvokeMetricsHook({
+    event: 'entry_discarded',
+    jobId,
+    dlqDepth: dlqStore.length,
+    timestamp: new Date().toISOString(),
+  })
+
+  return true
+}
+
+export const clearDlq = (): number => {
+  const count = dlqStore.length
+  dlqStore = []
+
+  safeInvokeMetricsHook({
+    event: 'dlq_cleared',
+    jobId: '',
+    dlqDepth: 0,
+    timestamp: new Date().toISOString(),
+  })
+
+  return count
+}
+
+export const resetDlq = (): void => {
+  dlqStore = []
+  dlqMaxSize = DEFAULT_MAX_DLQ_SIZE
+  dlqMetricsHook = undefined
 }
 
 const buildExportDataFromVaultStore = (
@@ -582,12 +717,16 @@ export async function processJob(
     completedAt: undefined,
   })
 
+  let _stage: 'data_fetch' | 'serialization' | undefined
   try {
     const scopedUserId = job.isAdmin ? job.targetUserId : job.userId
+    _stage = 'data_fetch'
     const data = vaultsStore
       ? buildExportDataFromVaultStore(job.scope, scopedUserId, vaultsStore)
       : await buildExportDataFromDatabase(job.scope, scopedUserId)
+    _stage = 'serialization'
     const { buffer, filename } = serializeExportData(data, job.format)
+    _stage = undefined
 
     const s3Config = resolveS3Config()
     let resultBuffer: Buffer | undefined = buffer
@@ -652,6 +791,34 @@ export async function processJob(
         error: message,
       }, job)),
     )
+
+    if (!retryable) {
+      const failureReason: FailureReason = (() => {
+        if (_stage === 'data_fetch') return 'data_fetch_error'
+        if (_stage === 'serialization') return 'serialization_error'
+        return 'unknown_error'
+      })()
+
+      const entry: DlqEntry = {
+        jobId: job.id,
+        jobType: `${job.scope}:${job.format}`,
+        failureReason,
+        errorMessage: sanitizedMessage,
+        attemptCount: nextAttempt,
+        failedAt: new Date().toISOString(),
+        sanitisedContext: sanitiseDlqContext(job),
+      }
+
+      dlqInsert(entry)
+
+      safeInvokeMetricsHook({
+        event: 'entry_added',
+        jobId: entry.jobId,
+        failureReason: entry.failureReason,
+        dlqDepth: dlqStore.length,
+        timestamp: entry.failedAt,
+      })
+    }
 
     const sanitizedError = new Error(sanitizedMessage)
     sanitizedError.name = error instanceof Error ? error.name : 'Error'

--- a/src/tests/exportQueue.dlq.test.ts
+++ b/src/tests/exportQueue.dlq.test.ts
@@ -1,0 +1,321 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals'
+import { URL } from 'node:url'
+import type { S3Client } from '@aws-sdk/client-s3'
+import {
+  createJob,
+  getJob,
+  processJob,
+  resetExportJobs,
+  configureDlq,
+  getDlqEntries,
+  getDlqEntry,
+  getDlqDepth,
+  requeueDlqEntry,
+  discardDlqEntry,
+  clearDlq,
+  resetDlq,
+} from '../services/exportQueue.js'
+import { resetS3ClientFactory, setS3ClientFactory } from '../services/exportS3.js'
+import { maskPii } from '../utils/privacy.js'
+
+const REQUESTER_USER_ID = 'user-raw-pii-123'
+const TARGET_USER_ID = 'target-raw-pii-456'
+const STELLAR_ADDRESS = 'GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB'
+const EMAIL_ADDRESS = 'privacy@example.com'
+const RAW_PII_VALUES = [REQUESTER_USER_ID, TARGET_USER_ID, STELLAR_ADDRESS, EMAIL_ADDRESS]
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i
+const STELLAR_ACCOUNT_PATTERN = /\bG[A-Z2-7]{55}\b/
+
+const originalEnv = { ...process.env }
+
+const expectNoRawPii = (payload: string): void => {
+  for (const value of RAW_PII_VALUES) {
+    expect(payload).not.toContain(value)
+  }
+  expect(payload).not.toMatch(EMAIL_PATTERN)
+  expect(payload).not.toMatch(STELLAR_ACCOUNT_PATTERN)
+}
+
+const createFailingS3Client = (errorMessage: string): S3Client => {
+  const client = {
+    send: jest.fn().mockRejectedValue(new Error(errorMessage)),
+    config: {
+      requestHandler: { metadata: { handlerProtocol: 'h2' } },
+      endpointProvider: jest.fn().mockResolvedValue({ url: new URL('https://s3.us-east-1.amazonaws.com') }),
+      region: async () => 'us-east-1',
+      credentials: async () => ({
+        accessKeyId: 'test-key',
+        secretAccessKey: 'test-secret',
+      }),
+      signerConstructor: jest.fn(),
+      systemClockOffset: 0,
+    },
+    middlewareStack: {
+      clone: jest.fn().mockReturnThis(),
+      use: jest.fn(),
+      concat: jest.fn(),
+      applyToStack: jest.fn(),
+      identify: jest.fn(),
+      identifyOnResolve: jest.fn(),
+      resolve: jest.fn(),
+      addRelativeTo: jest.fn(),
+    },
+  }
+
+  return client as unknown as S3Client
+}
+
+const createFailedJob = async (
+  failureMessage: string,
+  overrides: { maxAttempts?: number; scope?: string; format?: string } = {},
+): Promise<string> => {
+  process.env.EXPORT_S3_BUCKET = 'dlq-test-bucket'
+  process.env.EXPORT_S3_REGION = 'us-east-1'
+  setS3ClientFactory(() => createFailingS3Client(failureMessage))
+
+  const job = await createJob({
+    userId: REQUESTER_USER_ID,
+    isAdmin: true,
+    targetUserId: TARGET_USER_ID,
+    scope: (overrides.scope ?? 'vaults') as any,
+    format: (overrides.format ?? 'json') as any,
+    maxAttempts: overrides.maxAttempts ?? 1,
+    requestHash: `hash-${Date.now()}`,
+  })
+
+  try {
+    await processJob(job.id, [
+      { id: 'vault-1', creator: REQUESTER_USER_ID, amount: '100', status: 'active', createdAt: '2030-01-01T00:00:00.000Z' },
+    ])
+  } catch {
+    // expected to throw
+  }
+
+  return job.id
+}
+
+describe('Export dead-letter queue', () => {
+  afterEach(async () => {
+    process.env = { ...originalEnv }
+    jest.restoreAllMocks()
+    resetS3ClientFactory()
+    await resetExportJobs()
+    resetDlq()
+  })
+
+  describe('entry creation', () => {
+    it('moves permanently failed export jobs to the DLQ', async () => {
+      const jobId = await createFailedJob('permanent S3 failure')
+
+      expect(getDlqDepth()).toBe(1)
+      const entry = getDlqEntry(jobId)
+      expect(entry).toBeDefined()
+      expect(entry!.jobId).toBe(jobId)
+      expect(entry!.jobType).toBe('vaults:json')
+      expect(entry!.failureReason).toBe('unknown_error')
+      expect(entry!.attemptCount).toBe(1)
+      expect(entry!.failedAt).toBeDefined()
+      expect(entry!.errorMessage).toBeDefined()
+    })
+
+    it('does not create DLQ entry for retryable failures', async () => {
+      const jobId = await createFailedJob('transient S3 failure', { maxAttempts: 3 })
+
+      expect(getDlqDepth()).toBe(0)
+    })
+
+    it('populates failureReason based on error context', async () => {
+      const jobId = await createFailedJob('S3 upload failed')
+
+      const entry = getDlqEntry(jobId)
+      expect(entry).toBeDefined()
+      expect(['serialization_error', 'data_fetch_error', 'unknown_error']).toContain(entry!.failureReason)
+    })
+  })
+
+  describe('PII sanitisation', () => {
+    it('sanitises PII fields in DLQ entries', async () => {
+      const failureMessage = [
+        `upload failed for requester ${REQUESTER_USER_ID}`,
+        `target ${TARGET_USER_ID}`,
+        `destination ${STELLAR_ADDRESS}`,
+        `email ${EMAIL_ADDRESS}`,
+      ].join(' ')
+
+      const jobId = await createFailedJob(failureMessage)
+
+      const entry = getDlqEntry(jobId)
+      expect(entry).toBeDefined()
+
+      const entryJson = JSON.stringify(entry)
+      expectNoRawPii(entryJson)
+
+      expect(entryJson).toContain(maskPii(REQUESTER_USER_ID))
+      expect(entryJson).toContain(maskPii(TARGET_USER_ID))
+    })
+  })
+
+  describe('DLQ cap eviction', () => {
+    it('evicts oldest entry when DLQ overflows', async () => {
+      configureDlq({ maxSize: 2 })
+
+      const id1 = await createFailedJob('failure 1')
+      const id2 = await createFailedJob('failure 2')
+      const id3 = await createFailedJob('failure 3')
+
+      expect(getDlqDepth()).toBe(2)
+      expect(getDlqEntry(id1)).toBeUndefined()
+      expect(getDlqEntry(id2)).toBeDefined()
+      expect(getDlqEntry(id3)).toBeDefined()
+    })
+  })
+
+  describe('query interface', () => {
+    it('getDlqEntries returns a read-only snapshot newest-first', async () => {
+      const id1 = await createFailedJob('failure A')
+      const id2 = await createFailedJob('failure B')
+
+      const entries = getDlqEntries()
+      expect(entries).toHaveLength(2)
+      expect(entries[0].jobId).toBe(id2)
+      expect(entries[1].jobId).toBe(id1)
+
+      entries.pop()
+      expect(getDlqDepth()).toBe(2)
+    })
+
+    it('getDlqEntry returns undefined for unknown jobId', async () => {
+      expect(getDlqEntry('nonexistent-job')).toBeUndefined()
+    })
+
+    it('getDlqDepth returns current count', async () => {
+      expect(getDlqDepth()).toBe(0)
+      await createFailedJob('failure X')
+      expect(getDlqDepth()).toBe(1)
+      await createFailedJob('failure Y')
+      expect(getDlqDepth()).toBe(2)
+    })
+  })
+
+  describe('drain operations', () => {
+    it('requeueDlqEntry resets job to pending and removes from DLQ', async () => {
+      const jobId = await createFailedJob('requeue test failure')
+
+      expect(getDlqDepth()).toBe(1)
+
+      const result = await requeueDlqEntry(jobId)
+      expect(result).toBe(true)
+      expect(getDlqEntry(jobId)).toBeUndefined()
+
+      const job = await getJob(jobId)
+      expect(job).toBeDefined()
+      expect(job!.status).toBe('pending')
+      expect(job!.attempts).toBe(0)
+      expect(job!.error).toBeUndefined()
+    })
+
+    it('requeueDlqEntry returns false for unknown jobId', async () => {
+      const result = await requeueDlqEntry('nonexistent-job')
+      expect(result).toBe(false)
+    })
+
+    it('discardDlqEntry removes entry from DLQ', async () => {
+      const jobId = await createFailedJob('discard test failure')
+
+      expect(getDlqDepth()).toBe(1)
+
+      const result = discardDlqEntry(jobId)
+      expect(result).toBe(true)
+      expect(getDlqEntry(jobId)).toBeUndefined()
+      expect(getDlqDepth()).toBe(0)
+    })
+
+    it('discardDlqEntry returns false for unknown jobId', async () => {
+      const result = discardDlqEntry('nonexistent-job')
+      expect(result).toBe(false)
+    })
+
+    it('clearDlq removes all entries and returns count', async () => {
+      await createFailedJob('clear test A')
+      await createFailedJob('clear test B')
+      await createFailedJob('clear test C')
+
+      expect(getDlqDepth()).toBe(3)
+
+      const count = clearDlq()
+      expect(count).toBe(3)
+      expect(getDlqDepth()).toBe(0)
+    })
+
+    it('clearDlq on empty DLQ returns 0', async () => {
+      const count = clearDlq()
+      expect(count).toBe(0)
+    })
+  })
+
+  describe('MetricsHook', () => {
+    it('invokes hook on entry_added with correct event data', async () => {
+      const hook = jest.fn()
+      configureDlq({ metricsHook: hook })
+
+      const jobId = await createFailedJob('metrics entry test')
+
+      expect(hook).toHaveBeenCalledTimes(1)
+      const event = hook.mock.calls[0][0]
+      expect(event.event).toBe('entry_added')
+      expect(event.jobId).toBe(jobId)
+      expect(event.failureReason).toBe('unknown_error')
+      expect(event.dlqDepth).toBe(1)
+      expect(event.timestamp).toBeDefined()
+    })
+
+    it('invokes hook on requeue, discard, and clear', async () => {
+      const hook = jest.fn()
+      configureDlq({ metricsHook: hook })
+
+      const jobId = await createFailedJob('multi-event test')
+      hook.mockClear()
+
+      await requeueDlqEntry(jobId)
+      expect(hook).toHaveBeenCalledTimes(1)
+      expect(hook.mock.calls[0][0].event).toBe('entry_requeued')
+
+      await createFailedJob('event test B')
+      const jobIdB = (await getDlqEntries())[0].jobId
+      hook.mockClear()
+
+      discardDlqEntry(jobIdB)
+      expect(hook).toHaveBeenCalledTimes(1)
+      expect(hook.mock.calls[0][0].event).toBe('entry_discarded')
+
+      await createFailedJob('event test C')
+      hook.mockClear()
+
+      clearDlq()
+      expect(hook).toHaveBeenCalledTimes(1)
+      expect(hook.mock.calls[0][0].event).toBe('dlq_cleared')
+    })
+
+    it('isolates hook errors without crashing normal operation', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+      const hook = jest.fn(() => { throw new Error('hook failure') })
+      configureDlq({ metricsHook: hook })
+
+      const jobId = await createFailedJob('hook error test')
+
+      const entry = getDlqEntry(jobId)
+      expect(entry).toBeDefined()
+      expect(hook).toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalled()
+    })
+
+    it('operates normally when no MetricsHook is configured', async () => {
+      resetDlq()
+
+      const jobId = await createFailedJob('no hook test')
+
+      expect(getDlqDepth()).toBe(1)
+      expect(getDlqEntry(jobId)).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #613

This PR implements an in-memory Dead-Letter Queue (DLQ) for permanently failed export jobs in `ExportQueue`, preserving failure context while keeping the public REST API unchanged.

### What changed

* Added DLQ support to `src/services/exportQueue.ts`

  * Introduced `FailureReason`, `DlqEntry`, `DlqMetricsEvent`, and metrics hook types.
  * Added a bounded in-memory DLQ with configurable capacity (default: **100**) and oldest-first eviction.
  * Added PII-safe context sanitization by reusing the existing privacy utilities.
  * Wired DLQ insertion into the permanent failure path of `processJob()`.
  * Added query and drain operations:

    * `getDlqEntries()`
    * `getDlqEntry()`
    * `getDlqDepth()`
    * `requeueDlqEntry()`
    * `discardDlqEntry()`
    * `clearDlq()`
  * Added an optional metrics hook that fails safely if the callback throws.

* Added comprehensive regression tests in `src/tests/exportQueue.dlq.test.ts`

  * Permanent failure creates a DLQ entry
  * Retryable failures are not added to the DLQ
  * PII sanitization
  * Capacity eviction
  * Query operations
  * Requeue, discard, and clear operations
  * Metrics hook behavior and failure isolation
  * Edge cases and cleanup

* Updated `docs/exports.md`

  * Documented the DLQ contract
  * Failure reason taxonomy
  * PII guarantees
  * Drain operations
  * Configuration

### Security

* Raw user identifiers, Stellar addresses, and email addresses are never stored in the DLQ.
* Sanitized context reuses the existing privacy utilities to generate deterministic opaque tokens.
* Metrics hook failures are isolated and do not interrupt export processing.

### Validation

- [x] Added 18 regression tests covering the DLQ lifecycle and edge cases.
- [x]  All new tests pass.
- [x] No changes to the existing REST API surface.
- [x] Existing export processing behavior remains unchanged for successful and retryable jobs.
