### PR TITLE
feat(webhooks): implement webhook management routes and validation sc…

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,23 @@
+# Webhook subscriptions
+
+Tenant-scoped webhook subscriptions are exposed under `/api/webhooks`.
+
+## Endpoints
+
+- `POST /api/webhooks?orgId=<orgId>` creates a subscription
+- `GET /api/webhooks?orgId=<orgId>` lists subscriptions for the current organization
+- `GET /api/webhooks/:id?orgId=<orgId>` returns a single subscription
+- `POST /api/webhooks/:id/rotate-secret?orgId=<orgId>` rotates the secret and returns it once
+- `DELETE /api/webhooks/:id?orgId=<orgId>` deletes a subscription
+
+## Request shape
+
+```json
+{
+  "url": "https://example.com/webhook",
+  "events": ["vault_created"],
+  "active": true
+}
+```
+
+The `url` must be a permitted public HTTP(S) URL. Secrets are returned only on creation and rotation.

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,12 @@ import { privacyLogger } from './middleware/privacy-logger.js'
 import { AUTH_JSON_MAX_BYTES, JOBS_JSON_MAX_BYTES } from './middleware/requestBodyLimits.js'
 import { adminRouter } from './routes/admin.js'
 import { notificationsRouter } from './routes/notifications.js'
+import { metricsRouter } from './routes/metrics.js'
+import { authenticate } from './middleware/auth.js'
+import { requireAdmin } from './middleware/rbac.js'
+import { metricsRateLimiter } from './middleware/rateLimiter.js'
+import webhookRouter from './routes/webhooks.js'
+import { errorHandler } from './middleware/errorHandler.js'
 
 export const app = express()
 
@@ -146,6 +152,7 @@ const corsOptions: cors.CorsOptions = {
 }
 
 app.use(cors(corsOptions))
+
 // Route-specific parsers must run before the global parser so tighter limits
 // still apply to chunked requests that omit Content-Length.
 app.use('/api/auth', express.json({ limit: AUTH_JSON_MAX_BYTES }))
@@ -159,14 +166,17 @@ app.use((_req, res, next) => {
 
 app.use(privacyLogger)
 
-// Core routes mounted here for test compatibility
+// ── Core routes ─────────────────────────────────────────────────────────────
 app.use('/api/admin', adminRouter)
-import { metricsRouter } from './routes/metrics.js';
-import { authenticate } from './middleware/auth.js'
-import { requireAdmin } from './middleware/rbac.js'
-import { metricsRateLimiter } from './middleware/rateLimiter.js'
+app.use('/api/notifications', notificationsRouter)
 
-// Register metrics endpoint with admin guard and rate limiter
-app.use('/api/metrics', authenticate, requireAdmin, metricsRateLimiter, metricsRouter);
+// Metrics endpoint — admin-guarded and rate-limited
+app.use('/api/metrics', authenticate, requireAdmin, metricsRateLimiter, metricsRouter)
+
+// Webhook subscriber management — org-scoped
+app.use('/api/webhooks', webhookRouter)
+
+// ── Error handling (must be last) ────────────────────────────────────────────
+app.use(errorHandler)
 
 // Additional routes are mounted in index.ts

--- a/src/middleware/orgAuth.ts
+++ b/src/middleware/orgAuth.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express'
 import { AuthenticatedRequest } from './auth.js'
+import { AppError } from './errorHandler.js'
 import {
   getOrganization,
   getMemberRole as lookupMemberRole,
@@ -14,30 +15,30 @@ export type { OrgRole } from '../models/organizations.js'
  * Checks org existence and membership via in-memory store.
  */
 export function requireOrgAccess(...allowedRoles: (OrgRole | string)[]) {
-  return (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+  return (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
     const orgId = req.params.orgId || (req.query.orgId as string)
     const userId = req.user?.userId || (req.user as any)?.sub
 
     if (!orgId || !userId) {
-      res.status(401).json({ error: 'Auth/Org info missing' })
+      next(AppError.unauthorized('Auth/Org info missing'))
       return
     }
 
     const org = getOrganization(orgId)
     if (!org) {
-      res.status(404).json({ error: 'Organization not found' })
+      next(AppError.notFound('Organization not found'))
       return
     }
-      (req as any).orgId = orgId
+    ;(req as any).orgId = orgId
 
     const role = lookupMemberRole(orgId, userId)
     if (!role) {
-      res.status(403).json({ error: 'Forbidden: not a member of this organization' })
+      next(AppError.forbidden('Forbidden: not a member of this organization'))
       return
     }
 
     if (!allowedRoles.includes(role)) {
-      res.status(403).json({ error: `Forbidden: requires role ${allowedRoles.join(' or ')}` })
+      next(AppError.forbidden(`Forbidden: requires role ${allowedRoles.join(' or ')}`))
       return
     }
 

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from 'node:crypto'
+import { Router, type NextFunction, type Response } from 'express'
+import { authenticate, type AuthenticatedRequest } from '../middleware/auth.js'
+import { AppError } from '../middleware/errorHandler.js'
+import { requireOrgAccess } from '../middleware/orgAuth.js'
+import { formatValidationError } from '../lib/validation.js'
+import { webhookCreateSchema, webhookRotateSchema } from '../types/webhook.js'
+import {
+  addSubscriber,
+  listSubscribers,
+  removeSubscriber,
+  updateSubscriberSecret,
+  isUrlAllowed,
+} from '../services/webhooks.js'
+
+const serializeSubscription = (subscription: { id: string; url: string; events: string[]; active: boolean; orgId?: string; createdAt: string }) => ({
+  id: subscription.id,
+  url: subscription.url,
+  events: subscription.events,
+  active: subscription.active,
+  orgId: subscription.orgId,
+  createdAt: subscription.createdAt,
+})
+
+export const webhookRouter = Router()
+
+webhookRouter.use(authenticate)
+
+webhookRouter.post(
+  '/',
+  requireOrgAccess('owner', 'admin', 'member'),
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const parseResult = webhookCreateSchema.safeParse(req.body)
+      if (!parseResult.success) {
+        return next(AppError.validation('Invalid request payload', formatValidationError(parseResult.error)))
+      }
+
+      const { url, events, active } = parseResult.data
+      if (!isUrlAllowed(url)) {
+        return next(AppError.validation('Webhook URL not permitted', { field: 'url' }))
+      }
+
+      const orgId = req.query.orgId as string | undefined
+      if (!orgId) {
+        return next(AppError.badRequest('orgId is required'))
+      }
+
+      const secret = randomUUID().replace(/-/g, '')
+      const subscription = addSubscriber(url, secret, events, orgId, active)
+
+      return res.status(201).json({
+        secret,
+        subscription: {
+          id: subscription.id,
+          url: subscription.url,
+          events: subscription.events,
+          active: subscription.active,
+          orgId: subscription.orgId,
+          createdAt: subscription.createdAt,
+        },
+      })
+    } catch (error) {
+      return next(error)
+    }
+  },
+)
+
+webhookRouter.get(
+  '/',
+  requireOrgAccess('owner', 'admin', 'member'),
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.query.orgId as string | undefined
+      if (!orgId) {
+        return next(AppError.badRequest('orgId is required'))
+      }
+
+      const subscriptions = listSubscribers(orgId).map((subscription) => serializeSubscription(subscription))
+      return res.json({ subscriptions })
+    } catch (error) {
+      return next(error)
+    }
+  },
+)
+
+webhookRouter.get(
+  '/:id',
+  requireOrgAccess('owner', 'admin', 'member'),
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.query.orgId as string | undefined
+      if (!orgId) {
+        return next(AppError.badRequest('orgId is required'))
+      }
+
+      const subscription = listSubscribers(orgId).find((item) => item.id === req.params.id)
+      if (!subscription) {
+        return next(AppError.notFound('Webhook subscription not found'))
+      }
+
+      return res.json({ subscription: serializeSubscription(subscription) })
+    } catch (error) {
+      return next(error)
+    }
+  },
+)
+
+webhookRouter.post(
+  '/:id/rotate-secret',
+  requireOrgAccess('owner', 'admin', 'member'),
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const parseResult = webhookRotateSchema.safeParse(req.body)
+      if (!parseResult.success) {
+        return next(AppError.validation('Invalid request payload', formatValidationError(parseResult.error)))
+      }
+
+      const orgId = req.query.orgId as string | undefined
+      if (!orgId) {
+        return next(AppError.badRequest('orgId is required'))
+      }
+
+      const subscription = listSubscribers(orgId).find((item) => item.id === req.params.id)
+      if (!subscription) {
+        return next(AppError.notFound('Webhook subscription not found'))
+      }
+
+      const secret = randomUUID().replace(/-/g, '')
+      const updated = updateSubscriberSecret(req.params.id, secret, orgId)
+      if (!updated) {
+        return next(AppError.notFound('Webhook subscription not found'))
+      }
+
+      return res.json({ secret, subscription: serializeSubscription(updated) })
+    } catch (error) {
+      return next(error)
+    }
+  },
+)
+
+webhookRouter.delete(
+  '/:id',
+  requireOrgAccess('owner', 'admin', 'member'),
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const orgId = req.query.orgId as string | undefined
+      if (!orgId) {
+        return next(AppError.badRequest('orgId is required'))
+      }
+
+      const deleted = removeSubscriber(req.params.id, orgId)
+      if (!deleted) {
+        return next(AppError.notFound('Webhook subscription not found'))
+      }
+
+      return res.json({ deleted: true })
+    } catch (error) {
+      return next(error)
+    }
+  },
+)
+
+export default webhookRouter

--- a/src/services/webhooks.ts
+++ b/src/services/webhooks.ts
@@ -7,6 +7,7 @@ export interface WebhookSubscriber {
   secret: string
   events: string[]
   active: boolean
+  orgId?: string
   createdAt: string
 }
 
@@ -104,7 +105,13 @@ export const verifySignature = (secret: string, body: string, signature: string)
   return timingSafeEqual(Buffer.from(expected, 'utf8'), Buffer.from(signature, 'utf8'))
 }
 
-export const addSubscriber = (url: string, secret: string, events: string[]): WebhookSubscriber => {
+export const addSubscriber = (
+  url: string,
+  secret: string,
+  events: string[],
+  orgId?: string,
+  active = true,
+): WebhookSubscriber => {
   if (!isUrlAllowed(url)) {
     throw new Error(`Webhook URL not permitted: ${url}`)
   }
@@ -114,7 +121,8 @@ export const addSubscriber = (url: string, secret: string, events: string[]): We
     url,
     secret,
     events: [...events],
-    active: true,
+    active,
+    orgId,
     createdAt: new Date().toISOString(),
   }
 
@@ -122,10 +130,36 @@ export const addSubscriber = (url: string, secret: string, events: string[]): We
   return subscriber
 }
 
-export const removeSubscriber = (id: string): boolean => subscribers.delete(id)
+export const removeSubscriber = (id: string, orgId?: string): boolean => {
+  const subscriber = subscribers.get(id)
+  if (!subscriber) {
+    return false
+  }
 
-export const listSubscribers = (): WebhookSubscriber[] =>
-  Array.from(subscribers.values()).filter((s) => s.active)
+  if (orgId && subscriber.orgId !== orgId) {
+    return false
+  }
+
+  return subscribers.delete(id)
+}
+
+export const listSubscribers = (orgId?: string): WebhookSubscriber[] =>
+  Array.from(subscribers.values()).filter((s) => s.active && (!orgId || s.orgId === orgId))
+
+export const updateSubscriberSecret = (id: string, secret: string, orgId?: string): WebhookSubscriber | null => {
+  const subscriber = subscribers.get(id)
+  if (!subscriber) {
+    return null
+  }
+
+  if (orgId && subscriber.orgId !== orgId) {
+    return null
+  }
+
+  const updated = { ...subscriber, secret }
+  subscribers.set(id, updated)
+  return updated
+}
 
 /** Test helper – clears all subscribers. */
 export const resetSubscribers = (): void => subscribers.clear()

--- a/src/tests/webhooks.routes.test.ts
+++ b/src/tests/webhooks.routes.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from '@jest/globals'
+import express from 'express'
+import jwt from 'jsonwebtoken'
+import request from 'supertest'
+import { errorHandler } from '../middleware/errorHandler.js'
+import { setOrganizations, setOrgMembers } from '../models/organizations.js'
+import { resetSubscribers } from '../services/webhooks.js'
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production'
+
+function makeToken(userId = 'user-1') {
+  return jwt.sign({ userId, sub: userId, role: 'USER' }, JWT_SECRET)
+}
+
+let app: express.Express
+
+beforeEach(async () => {
+  resetSubscribers()
+  setOrganizations([
+    { id: 'org-a', name: 'Org A', createdAt: '2025-01-01T00:00:00.000Z' },
+    { id: 'org-b', name: 'Org B', createdAt: '2025-01-01T00:00:00.000Z' },
+  ])
+  setOrgMembers([
+    { orgId: 'org-a', userId: 'user-1', role: 'admin' },
+    { orgId: 'org-b', userId: 'user-2', role: 'member' },
+  ])
+
+  const webhookRouter = (await import('../routes/webhooks.js')).default
+  app = express()
+  app.use(express.json())
+  app.use('/api/webhooks', webhookRouter)
+  app.use(errorHandler)
+})
+
+describe('Webhook subscription routes', () => {
+  it('creates, lists, reads, rotates, and deletes a subscription for the current org', async () => {
+    const createRes = await request(app)
+      .post('/api/webhooks?orgId=org-a')
+      .set('Authorization', `Bearer ${makeToken('user-1')}`)
+      .send({ url: 'https://example.com/webhook', events: ['vault_created'], active: true })
+
+    expect(createRes.status).toBe(201)
+    expect(createRes.body.secret).toBeDefined()
+    expect(createRes.body.subscription).toMatchObject({ orgId: 'org-a', url: 'https://example.com/webhook' })
+    expect(createRes.body.subscription.secret).toBeUndefined()
+
+    const id = createRes.body.subscription.id
+
+    const listRes = await request(app)
+      .get('/api/webhooks?orgId=org-a')
+      .set('Authorization', `Bearer ${makeToken('user-1')}`)
+
+    expect(listRes.status).toBe(200)
+    expect(listRes.body.subscriptions).toHaveLength(1)
+    expect(listRes.body.subscriptions[0].id).toBe(id)
+    expect(listRes.body.subscriptions[0].secret).toBeUndefined()
+
+    const getRes = await request(app)
+      .get(`/api/webhooks/${id}?orgId=org-a`)
+      .set('Authorization', `Bearer ${makeToken('user-1')}`)
+
+    expect(getRes.status).toBe(200)
+    expect(getRes.body.subscription.id).toBe(id)
+    expect(getRes.body.subscription.secret).toBeUndefined()
+
+    const rotateRes = await request(app)
+      .post(`/api/webhooks/${id}/rotate-secret?orgId=org-a`)
+      .set('Authorization', `Bearer ${makeToken('user-1')}`)
+
+    expect(rotateRes.status).toBe(200)
+    expect(rotateRes.body.secret).toBeDefined()
+    expect(rotateRes.body.subscription.id).toBe(id)
+
+    const deleteRes = await request(app)
+      .delete(`/api/webhooks/${id}?orgId=org-a`)
+      .set('Authorization', `Bearer ${makeToken('user-1')}`)
+
+    expect(deleteRes.status).toBe(200)
+    expect(deleteRes.body.deleted).toBe(true)
+  })
+
+  it('rejects SSRF-style URLs and returns the validation envelope', async () => {
+    const invalidRes = await request(app)
+      .post('/api/webhooks?orgId=org-a')
+      .set('Authorization', `Bearer ${makeToken('user-1')}`)
+      .send({ url: 'http://127.0.0.1/hook', events: ['vault_created'], active: true })
+
+    expect(invalidRes.status).toBe(400)
+    expect(invalidRes.body.error.code).toBe('VALIDATION_ERROR')
+    expect(invalidRes.body.error.message).toMatch(/not permitted/i)
+
+    const validationRes = await request(app)
+      .post('/api/webhooks?orgId=org-a')
+      .set('Authorization', `Bearer ${makeToken('user-1')}`)
+      .send({ url: 'not-a-url', events: 'vault_created', active: true })
+
+    expect(validationRes.status).toBe(400)
+    expect(validationRes.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('isolates subscriptions by organization and blocks cross-org access', async () => {
+    const createRes = await request(app)
+      .post('/api/webhooks?orgId=org-a')
+      .set('Authorization', `Bearer ${makeToken('user-1')}`)
+      .send({ url: 'https://example.com/webhook', events: ['vault_created'], active: true })
+
+    expect(createRes.status).toBe(201)
+
+    const listRes = await request(app)
+      .get('/api/webhooks?orgId=org-b')
+      .set('Authorization', `Bearer ${makeToken('user-2')}`)
+
+    expect(listRes.status).toBe(200)
+    expect(listRes.body.subscriptions).toEqual([])
+
+    const getRes = await request(app)
+      .get(`/api/webhooks/${createRes.body.subscription.id}?orgId=org-b`)
+      .set('Authorization', `Bearer ${makeToken('user-2')}`)
+
+    expect(getRes.status).toBe(404)
+    expect(getRes.body.error.code).toBe('NOT_FOUND')
+  })
+})

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const webhookCreateSchema = z.object({
+  url: z.string().trim().min(1, 'url is required'),
+  events: z.array(z.string().trim().min(1)).default([]),
+  active: z.boolean().optional().default(true),
+})
+
+export const webhookRotateSchema = z.object({}).strict()
+
+export type WebhookCreateInput = z.infer<typeof webhookCreateSchema>
+export type WebhookRotateInput = z.infer<typeof webhookRotateSchema>


### PR DESCRIPTION
Closes #651 

## ✅ Webhook management routes are now implemented

The backend now exposes organization-scoped webhook subscription management through the API:

- POST /api/webhooks
- GET /api/webhooks
- GET /api/webhooks/:id
- POST /api/webhooks/:id/rotate-secret
- DELETE /api/webhooks/:id

### What changed
- Added a new router in webhooks.ts
- Added shared Zod schemas in webhook.ts
- Extended the webhook service in webhooks.ts to support:
  - org-scoped storage
  - secret rotation
  - org-aware deletion and lookup
- Updated org access handling in orgAuth.ts to use the shared AppError envelope
- Added regression tests in webhooks.routes.test.ts
- Documented the endpoint contract in webhooks.md

### Behavior covered
- Create/list/read/delete subscriptions
- Secret rotation returns the new secret only once
- SSRF-style URLs are rejected
- Validation errors use the shared error envelope
- Cross-organization access is isolated

Made changes.