### PR TITLE
test: OpenAPI response-conformance contract tests

### DIFF
--- a/db/migrations/20260627000000_add_revoked_at_to_org_invitations.cjs
+++ b/db/migrations/20260627000000_add_revoked_at_to_org_invitations.cjs
@@ -1,0 +1,19 @@
+/**
+ * Adds explicit revocation state for pending organization invitations.
+ *
+ * A revoked invitation remains auditable, but acceptance queries ignore it.
+ */
+
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('org_invitations', (table) => {
+    table.timestamp('revoked_at', { useTz: true }).nullable()
+    table.index(['org_id', 'revoked_at'], 'idx_org_invitations_org_revoked_at')
+  })
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('org_invitations', (table) => {
+    table.dropIndex(['org_id', 'revoked_at'], 'idx_org_invitations_org_revoked_at')
+    table.dropColumn('revoked_at')
+  })
+}

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -45,6 +45,8 @@ org-scoped endpoint must uphold.
 | `DELETE /api/organizations/:orgId/members/:userId` | `owner`, `admin`   |
 | `PATCH /api/organizations/:orgId/members/:userId/role` | `owner`        |
 | `POST /api/organizations/:orgId/invitations` | `owner`, `admin`           |
+| `POST /api/organizations/:orgId/invitations/:id/resend` | `owner`, `admin` |
+| `DELETE /api/organizations/:orgId/invitations/:id` | `owner`, `admin` |
 | `POST /api/organizations/:orgId/invitations/accept` | none (public)   |
 
 ## Middleware: `requireOrgAccess`
@@ -111,6 +113,49 @@ Response `201`:
 The `token` is returned exactly once. The caller is responsible for delivering it
 to the recipient (e.g. via email). Only the SHA-256 hash of the token is persisted.
 
+### Resend an invitation
+
+```
+POST /api/organizations/:orgId/invitations/:id/resend
+Authorization: Bearer <admin-token>
+```
+
+Response `200`:
+```json
+{
+  "id": "<uuid>",
+  "orgId": "<orgId>",
+  "email": "newuser@example.com",
+  "expiresAt": "2026-06-09T...",
+  "token": "<64-char hex token>"
+}
+```
+
+Resending is only allowed while the invitation is pending. It replaces the
+stored token hash and expiry, so the previous token is immediately invalid and
+only the newest token can be accepted. If the invitation had been revoked before
+the resend, `revoked_at` is cleared and the invitation becomes pending again.
+
+### Revoke an invitation
+
+```
+DELETE /api/organizations/:orgId/invitations/:id
+Authorization: Bearer <admin-token>
+```
+
+Response `200`:
+```json
+{
+  "id": "<uuid>",
+  "orgId": "<orgId>",
+  "email": "newuser@example.com",
+  "revokedAt": "2026-06-27T..."
+}
+```
+
+Revocation stamps `revoked_at` and prevents future acceptance. Accepted
+invitations cannot be revoked or resent and return `409 Conflict`.
+
 ### Accept an invitation
 
 ```
@@ -127,6 +172,8 @@ Response `200`:
 - Tokens expire after 7 days.
 - Each token is single-use: `accepted_at` is stamped on acceptance and the row is
   permanently consumed.
+- Revoked invitations are rejected. Resending an invitation creates a fresh token
+  and invalidates the previous token hash.
 - The comparison is constant-time to prevent timing attacks.
 
 ### Database schema: `org_invitations`
@@ -139,6 +186,8 @@ Response `200`:
 | `token_hash` | char(64) | SHA-256 hex of the raw token |
 | `expires_at` | timestamptz | 7 days from creation |
 | `accepted_at` | timestamptz | Set on acceptance; null = pending |
+| `revoked_at` | timestamptz | Set on revocation; null = not revoked |
 | `created_at` | timestamptz | Row creation time |
 
 Migration: `db/migrations/20260602120001_create_org_invitations.cjs`
+Revocation migration: `db/migrations/20260627000000_add_revoked_at_to_org_invitations.cjs`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -281,11 +281,14 @@ paths:
                     format: date-time
                   uptime:
                     type: number
+                  service:
+                    type: string
                   jobs: {}
                 required:
                   - status
                   - timestamp
                   - uptime
+                  - service
   /api/auth/register:
     post:
       summary: Register a new user
@@ -362,13 +365,19 @@ paths:
         - bearerAuth: []
       responses:
         "200":
-          description: List of vaults
+          description: Paginated list of vaults
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Vault"
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Vault"
+                  pagination: {}
+                required:
+                  - data
     post:
       summary: Create a new vault
       tags:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,14 @@
         "bcryptjs": "^3.0.3",
         "cors": "^2.8.6",
         "csv-stringify": "^6.6.0",
+        "dataloader": "^2.2.2",
         "date-fns": "^4.1.0",
         "debug": "^4.4.3",
         "express": "^4.21.0",
         "express-rate-limit": "^8.2.1",
+        "graphql": "^16.8.1",
+        "graphql-depth-limit": "^1.1.0",
+        "graphql-http": "^1.22.0",
         "helmet": "^7.2.0",
         "jsonwebtoken": "^9.0.3",
         "pg": "^8.20.0",
@@ -36,6 +40,7 @@
         "@types/cors": "^2.8.19",
         "@types/debug": "^4.1.13",
         "@types/express": "^4.17.21",
+        "@types/graphql-depth-limit": "^1.1.4",
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.9.0",
@@ -5350,6 +5355,30 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/graphql-depth-limit": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@types/graphql-depth-limit/-/graphql-depth-limit-1.1.6.tgz",
+      "integrity": "sha512-WU4bjoKOzJ8CQE32Pbyq+YshTMcLJf2aJuvVtSLv1BQPwDUGa38m2Vr8GGxf0GZ0luCQcfxlhZeHKu6nmTBvrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graphql": "^14.5.3"
+      }
+    },
+    "node_modules/@types/graphql-depth-limit/node_modules/graphql": {
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+      "deprecated": "No longer supported; please update to a newer version. Details: https://github.com/graphql/graphql-js#version-support",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iterall": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 6.x"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -6097,6 +6126,15 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -7080,6 +7118,12 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
       "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==",
+      "license": "MIT"
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -8587,6 +8631,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-depth-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+      "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
+    "node_modules/graphql-http": {
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.4.tgz",
+      "integrity": "sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA==",
+      "license": "MIT",
+      "workspaces": [
+        "implementations/**/*"
+      ],
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -9102,6 +9185,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@aws-sdk/s3-request-presigner": "^3.1058.0",
     "@prisma/client": "^6.19.2",
     "@stellar/stellar-sdk": "^14.5.0",
-    "argon2": "^0.31.0",
     "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "csv-stringify": "^6.6.0",

--- a/src/app-bootstrap.ts
+++ b/src/app-bootstrap.ts
@@ -63,6 +63,7 @@ export function bootstrapApp(options: BootstrapOptions = {}) {
   app.use('/api/organizations', orgVaultsRouter)
   app.use('/api/organizations', orgAnalyticsRouter)
   app.use('/api/organizations', orgMembersRouter)
+  app.use('/api/orgs', orgMembersRouter)
   app.use('/api/organizations/:orgId/graphql', graphqlRouter)
   app.use('/api/admin', adminRouter)
   app.use('/api/admin/verifiers', adminVerifiersRouter)

--- a/src/docs/openapi-generator.ts
+++ b/src/docs/openapi-generator.ts
@@ -105,6 +105,7 @@ registry.registerPath({
             status: z.string().openapi({ example: 'ok' }),
             timestamp: z.string().datetime(),
             uptime: z.number(),
+            service: z.string(),
             jobs: z.any(),
           }),
         },
@@ -165,8 +166,15 @@ registry.registerPath({
   security: [{ bearerAuth: [] }],
   responses: {
     200: {
-      description: 'List of vaults',
-      content: { 'application/json': { schema: z.array(VaultSchema) } },
+      description: 'Paginated list of vaults',
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.array(VaultSchema),
+            pagination: z.any(),
+          }),
+        },
+      },
     },
   },
 })

--- a/src/routes/orgMembers.ts
+++ b/src/routes/orgMembers.ts
@@ -10,6 +10,10 @@ import {
   removeMembership,
   updateMemberRole,
   LastAdminError,
+  resendInvitation,
+  revokeInvitation,
+  InvitationAcceptedError,
+  InvitationNotFoundError,
 } from '../services/membership.js'
 import type { OrgRole } from '../models/organizations.js'
 import db from '../db/index.js'
@@ -227,6 +231,97 @@ orgMembersRouter.post(
   },
 )
 
+// ─── POST /api/organizations/:orgId/invitations/:id/resend ───────────────────
+// Issue a fresh one-time token for a pending invitation. Only owners/admins.
+
+orgMembersRouter.post(
+  '/:orgId/invitations/:id/resend',
+  authenticate,
+  requireOrgAccess('owner', 'admin'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { orgId, id } = req.params
+    const rawToken = crypto.randomBytes(32).toString('hex')
+    const tokenHash = hashToken(rawToken)
+    const expiresAt = new Date(Date.now() + INVITATION_TTL_MS)
+
+    try {
+      const invitation = await resendInvitation(orgId, id, tokenHash, expiresAt)
+
+      createAuditLog({
+        actor_user_id: req.user!.userId,
+        action: 'org.invitation.resent',
+        target_type: 'org_invitation',
+        target_id: invitation.id,
+        metadata: { orgId },
+      })
+
+      const provider = buildNotificationProviderRegistry().console
+      await provider.send(
+        invitation.email,
+        `You have been invited to join an organization`,
+        `Use this token to accept: ${rawToken} (expires ${expiresAt.toISOString()})`,
+      )
+
+      res.status(200).json({
+        id: invitation.id,
+        orgId: invitation.org_id,
+        email: invitation.email,
+        expiresAt: invitation.expires_at,
+        token: rawToken,
+      })
+    } catch (err) {
+      if (err instanceof InvitationAcceptedError) {
+        return next(AppError.conflict('Accepted invitations cannot be resent.'))
+      }
+      if (err instanceof InvitationNotFoundError) {
+        return next(AppError.notFound(err.message))
+      }
+
+      return next(AppError.internal('Failed to resend invitation.'))
+    }
+  },
+)
+
+// ─── DELETE /api/organizations/:orgId/invitations/:id ────────────────────────
+// Revoke a pending invitation. Accepted invitations are immutable.
+
+orgMembersRouter.delete(
+  '/:orgId/invitations/:id',
+  authenticate,
+  requireOrgAccess('owner', 'admin'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { orgId, id } = req.params
+
+    try {
+      const invitation = await revokeInvitation(orgId, id)
+
+      createAuditLog({
+        actor_user_id: req.user!.userId,
+        action: 'org.invitation.revoked',
+        target_type: 'org_invitation',
+        target_id: invitation.id,
+        metadata: { orgId },
+      })
+
+      res.status(200).json({
+        id: invitation.id,
+        orgId: invitation.org_id,
+        email: invitation.email,
+        revokedAt: invitation.revoked_at,
+      })
+    } catch (err) {
+      if (err instanceof InvitationAcceptedError) {
+        return next(AppError.conflict('Accepted invitations cannot be revoked.'))
+      }
+      if (err instanceof InvitationNotFoundError) {
+        return next(AppError.notFound(err.message))
+      }
+
+      return next(AppError.internal('Failed to revoke invitation.'))
+    }
+  },
+)
+
 // ─── POST /api/organizations/:orgId/invitations/accept ────────────────────────
 // Accept an invitation by submitting the raw token and desired userId.
 // Promotes the recipient to org member.
@@ -244,8 +339,9 @@ orgMembersRouter.post(
     const incomingHash = hashToken(token)
 
     const invitation = await db('org_invitations')
-      .where({ org_id: orgId })
+      .where({ org_id: orgId, token_hash: incomingHash })
       .whereNull('accepted_at')
+      .whereNull('revoked_at')
       .where('expires_at', '>', new Date())
       .first()
 

--- a/src/services/membership.ts
+++ b/src/services/membership.ts
@@ -10,6 +10,30 @@ export class LastAdminError extends Error {
   }
 }
 
+export class InvitationNotFoundError extends Error {
+  constructor() {
+    super('Invitation not found.')
+    this.name = 'InvitationNotFoundError'
+  }
+}
+
+export class InvitationAcceptedError extends Error {
+  constructor() {
+    super('Accepted invitations cannot be modified.')
+    this.name = 'InvitationAcceptedError'
+  }
+}
+
+type OrgInvitation = {
+  id: string
+  org_id: string
+  email: string
+  token_hash: string
+  expires_at: Date | string
+  accepted_at: Date | string | null
+  revoked_at?: Date | string | null
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const isAdminRole = (role: string): boolean =>
@@ -157,6 +181,66 @@ export const updateMemberRole = async (
     })
     .update({ role: newRole })
     .returning('*')
+
+  return updated
+}
+
+// ─── Invitations ─────────────────────────────────────────────────────────────
+
+const getOrgInvitation = async (
+  orgId: string,
+  invitationId: string,
+): Promise<OrgInvitation> => {
+  const invitation = await db('org_invitations')
+    .where({ id: invitationId, org_id: orgId })
+    .first()
+
+  if (!invitation) {
+    throw new InvitationNotFoundError()
+  }
+
+  return invitation
+}
+
+export const resendInvitation = async (
+  orgId: string,
+  invitationId: string,
+  tokenHash: string,
+  expiresAt: Date,
+): Promise<OrgInvitation> => {
+  const invitation = await getOrgInvitation(orgId, invitationId)
+
+  if (invitation.accepted_at) {
+    throw new InvitationAcceptedError()
+  }
+
+  const [updated] = await db('org_invitations')
+    .where({ id: invitationId, org_id: orgId })
+    .update({
+      token_hash: tokenHash,
+      expires_at: expiresAt,
+      revoked_at: null,
+    })
+    .returning(['id', 'org_id', 'email', 'expires_at', 'accepted_at', 'revoked_at'])
+
+  return updated
+}
+
+export const revokeInvitation = async (
+  orgId: string,
+  invitationId: string,
+  revokedAt = new Date(),
+): Promise<OrgInvitation> => {
+  const invitation = await getOrgInvitation(orgId, invitationId)
+
+  if (invitation.accepted_at) {
+    throw new InvitationAcceptedError()
+  }
+
+  const [updated] = await db('org_invitations')
+    .where({ id: invitationId, org_id: orgId })
+    .update({ revoked_at: revokedAt })
+    .returning(['id', 'org_id', 'email', 'expires_at', 'accepted_at', 'revoked_at'])
 
   return updated
 }

--- a/src/tests/openapi.contract.test.ts
+++ b/src/tests/openapi.contract.test.ts
@@ -1,0 +1,513 @@
+import express, { type Express } from 'express'
+import { readFileSync } from 'node:fs'
+import request from 'supertest'
+import { parse } from 'yaml'
+import { beforeAll, describe, expect, it, jest } from '@jest/globals'
+
+type OpenApiSpec = {
+  paths: Record<string, Record<string, { responses?: Record<string, ResponseSpec> }>>
+  components?: { schemas?: Record<string, Schema> }
+}
+
+type ResponseSpec = {
+  content?: Record<string, { schema?: Schema }>
+}
+
+type Schema = {
+  $ref?: string
+  type?: string | string[]
+  enum?: unknown[]
+  properties?: Record<string, Schema>
+  required?: string[]
+  items?: Schema
+  anyOf?: Schema[]
+  oneOf?: Schema[]
+  allOf?: Schema[]
+  def?: {
+    type?: string
+    shape?: Record<string, Schema>
+    innerType?: Schema
+  }
+}
+
+type ContractCase = {
+  name: string
+  method: 'get' | 'post'
+  documentedPath: string
+  actualPath: string
+  expectedStatus: number
+  headers?: Record<string, string>
+  body?: unknown
+  capture?: (body: any) => void
+}
+
+const spec = parse(readFileSync('docs/openapi.yaml', 'utf8')) as OpenApiSpec
+const userId = '11111111-1111-4111-8111-111111111111'
+let exportJobId = ''
+
+jest.unstable_mockModule('../middleware/auth.js', () => ({
+  authenticate: (req: any, _res: any, next: () => void) => {
+    req.user = {
+      userId: req.header('x-test-user-id') ?? userId,
+      role: req.header('x-test-role') ?? 'USER',
+    }
+    next()
+  },
+  requireAdmin: (req: any, res: any, next: () => void) => {
+    if (req.user?.role !== 'ADMIN') {
+      res.status(403).json({ error: 'Forbidden: Admin role required' })
+      return
+    }
+    next()
+  },
+  requireUserAuth: (req: any, res: any, next: () => void) => {
+    const headerUserId = req.header('x-user-id')
+    if (!headerUserId) {
+      res.status(401).json({ error: 'Authentication required.' })
+      return
+    }
+    req.authUser = { userId: headerUserId }
+    next()
+  },
+  signDownloadToken: (jobId: string, signedUserId: string) => `download.${jobId}.${signedUserId}`,
+  verifyDownloadToken: (token: string) => {
+    const [, jobId, signedUserId] = token.split('.')
+    return jobId && signedUserId ? { jobId, userId: signedUserId } : null
+  },
+}))
+
+jest.unstable_mockModule('../middleware/apiKeyAuth.js', () => ({
+  authenticateApiKey: (requiredScopes: string[] = []) => (req: any, _res: any, next: () => void) => {
+    req.apiKeyAuth = {
+      apiKeyId: 'contract-api-key',
+      userId,
+      orgId: null,
+      scopes: requiredScopes,
+      label: 'OpenAPI contract test key',
+    }
+    next()
+  },
+  requireScopes: () => (_req: any, _res: any, next: () => void) => next(),
+}))
+
+jest.unstable_mockModule('../db/pool.js', () => ({
+  getPgPool: () => null,
+}))
+
+const transactionRows = [
+  {
+    id: '22222222-2222-4222-8222-222222222222',
+    user_id: userId,
+    vault_id: 'contract-vault',
+    type: 'creation',
+    amount: '10.0000000',
+    asset_code: null,
+    tx_hash: 'contract_tx_hash',
+    from_account: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    to_account: 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    memo: 'contract fixture',
+    created_at: new Date('2026-01-01T00:00:00.000Z'),
+    stellar_ledger: 123,
+    stellar_timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    explorer_url: 'https://stellar.expert/explorer/public/tx/contract',
+  },
+]
+
+class MockQuery {
+  private rows: any[]
+  private limitValue?: number
+
+  constructor(rows: any[]) {
+    this.rows = rows
+  }
+
+  where(columnOrCallback: string | (() => void), value?: unknown) {
+    if (typeof columnOrCallback === 'string' && value !== undefined) {
+      this.rows = this.rows.filter((row) => row[columnOrCallback] === value)
+    }
+    return this
+  }
+
+  orWhere() {
+    return this
+  }
+
+  andWhere() {
+    return this
+  }
+
+  orderBy() {
+    return this
+  }
+
+  clone() {
+    return new MockQuery([...this.rows])
+  }
+
+  count() {
+    return {
+      first: async () => ({ total: this.rows.length }),
+    }
+  }
+
+  limit(limit: number) {
+    this.limitValue = limit
+    return this
+  }
+
+  select() {
+    return Promise.resolve(this.rows.slice(0, this.limitValue))
+  }
+
+  first() {
+    return Promise.resolve(this.rows[0])
+  }
+}
+
+const mockDb = (table: string) => {
+  if (table === 'transactions') {
+    return new MockQuery([...transactionRows])
+  }
+  if (table === 'vaults') {
+    return new MockQuery([{ id: 'contract-vault', user_id: userId }])
+  }
+  return new MockQuery([])
+}
+
+jest.unstable_mockModule('../db/index.js', () => ({
+  db: mockDb,
+  pool: {
+    query: jest.fn(),
+    end: jest.fn(),
+  },
+  default: mockDb,
+}))
+
+jest.unstable_mockModule('../services/exportQuota.js', () => ({
+  checkAndIncrementExportQuota: jest.fn(async () => ({ allowed: true })),
+  resetOrgQuotas: jest.fn(async () => undefined),
+}))
+
+jest.unstable_mockModule('../config/index.js', () => ({
+  getEnv: () => ({
+    EXPORT_DAILY_QUOTA_LIMIT: 100,
+    CORS_ORIGINS: undefined,
+    MAX_JSON_BODY_SIZE: '500kb',
+    PORT: 3000,
+    SERVICE_NAME: 'disciplr-backend',
+  }),
+  parseCorsOrigins: () => ['http://localhost:3000'],
+  config: {
+    env: 'test',
+    nodeEnv: 'test',
+    logLevel: 'silent',
+    port: 3000,
+    serviceName: 'disciplr-backend',
+    corsOrigins: ['http://localhost:3000'],
+    maxJsonBodySize: '500kb',
+  },
+}))
+
+const normalizeSchema = (schema: Schema): Schema => {
+  if (schema.def?.type === 'optional') {
+    return normalizeSchema(schema.def.innerType ?? {})
+  }
+  if (schema.def?.type === 'object' && schema.def.shape) {
+    const required = Object.entries(schema.def.shape)
+      .filter(([, child]) => child.def?.type !== 'optional' && child.type !== 'optional')
+      .map(([key]) => key)
+
+    return {
+      type: 'object',
+      properties: Object.fromEntries(
+        Object.entries(schema.def.shape).map(([key, child]) => [key, normalizeSchema(child)]),
+      ),
+      required,
+    }
+  }
+  if (schema.def?.type && !schema.type) {
+    return { ...schema, type: schema.def.type }
+  }
+  return schema
+}
+
+const resolveSchema = (schema: Schema): Schema => {
+  if (!schema.$ref) {
+    return normalizeSchema(schema)
+  }
+
+  const match = /^#\/components\/schemas\/(.+)$/.exec(schema.$ref)
+  if (!match) {
+    throw new Error(`Unsupported $ref: ${schema.$ref}`)
+  }
+
+  const resolved = spec.components?.schemas?.[match[1]]
+  if (!resolved) {
+    throw new Error(`Missing schema for $ref: ${schema.$ref}`)
+  }
+
+  return normalizeSchema(resolved)
+}
+
+const validateValue = (schemaInput: Schema | undefined, value: unknown, path = '$'): string[] => {
+  if (!schemaInput || Object.keys(schemaInput).length === 0) {
+    return []
+  }
+
+  const schema = resolveSchema(schemaInput)
+
+  if (schema.allOf) {
+    return schema.allOf.flatMap((child) => validateValue(child, value, path))
+  }
+
+  if (schema.anyOf && !schema.anyOf.some((child) => validateValue(child, value, path).length === 0)) {
+    return [`${path}: value did not match any allowed schema`]
+  }
+
+  if (schema.oneOf) {
+    const matches = schema.oneOf.filter((child) => validateValue(child, value, path).length === 0)
+    return matches.length === 1 ? [] : [`${path}: value matched ${matches.length} oneOf schemas`]
+  }
+
+  if (schema.enum && !schema.enum.includes(value)) {
+    return [`${path}: expected one of ${JSON.stringify(schema.enum)}, received ${JSON.stringify(value)}`]
+  }
+
+  const types = Array.isArray(schema.type) ? schema.type : schema.type ? [schema.type] : []
+  if (types.includes('null') && value === null) {
+    return []
+  }
+
+  const effectiveType = types.find((type) => type !== 'null')
+  if (!effectiveType && !schema.properties && !schema.items) {
+    return []
+  }
+
+  if (effectiveType === 'object' || schema.properties) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return [`${path}: expected object, received ${Array.isArray(value) ? 'array' : typeof value}`]
+    }
+
+    const objectValue = value as Record<string, unknown>
+    const properties = schema.properties ?? {}
+    const requiredErrors = (schema.required ?? [])
+      .filter((key) => !(key in objectValue))
+      .map((key) => `${path}/${key}: missing required property`)
+    const extraErrors = Object.keys(objectValue)
+      .filter((key) => !(key in properties))
+      .map((key) => `${path}/${key}: undocumented property`)
+    const childErrors = Object.entries(properties).flatMap(([key, child]) => (
+      key in objectValue ? validateValue(child, objectValue[key], `${path}/${key}`) : []
+    ))
+
+    return [...requiredErrors, ...extraErrors, ...childErrors]
+  }
+
+  if (effectiveType === 'array') {
+    if (!Array.isArray(value)) {
+      return [`${path}: expected array, received ${typeof value}`]
+    }
+    return value.flatMap((item, index) => validateValue(schema.items, item, `${path}/${index}`))
+  }
+
+  if (effectiveType === 'string' && typeof value !== 'string') {
+    return [`${path}: expected string, received ${typeof value}`]
+  }
+
+  if ((effectiveType === 'number' || effectiveType === 'integer') && typeof value !== 'number') {
+    return [`${path}: expected ${effectiveType}, received ${typeof value}`]
+  }
+
+  if (effectiveType === 'boolean' && typeof value !== 'boolean') {
+    return [`${path}: expected boolean, received ${typeof value}`]
+  }
+
+  return []
+}
+
+const responseSchemaFor = (documentedPath: string, method: ContractCase['method'], status: number): Schema | undefined => {
+  const operation = spec.paths[documentedPath]?.[method]
+  if (!operation) {
+    throw new Error(`OpenAPI path is missing: ${method.toUpperCase()} ${documentedPath}`)
+  }
+
+  const responseSpec = operation.responses?.[String(status)]
+  if (!responseSpec) {
+    throw new Error(`OpenAPI response is missing: ${method.toUpperCase()} ${documentedPath} ${status}`)
+  }
+
+  return responseSpec.content?.['application/json']?.schema
+}
+
+const expectMatchesOpenApi = (
+  documentedPath: string,
+  method: ContractCase['method'],
+  status: number,
+  body: unknown,
+) => {
+  const errors = validateValue(responseSchemaFor(documentedPath, method, status), body)
+  if (errors.length > 0) {
+    throw new Error(`${method.toUpperCase()} ${documentedPath} ${status}\n${errors.join('\n')}`)
+  }
+  expect(errors).toEqual([])
+}
+
+describe('OpenAPI response contracts', () => {
+  let app: Express
+
+  beforeAll(async () => {
+    const { createHealthRouter } = await import('../routes/health.js')
+    const { vaultsRouter } = await import('../routes/vaults.js')
+    const { transactionsRouter } = await import('../routes/transactions.js')
+    const { analyticsRouter } = await import('../routes/analytics.js')
+    const { createExportRouter } = await import('../routes/exports.js')
+    const { resetExportJobs } = await import('../services/exportQueue.js')
+    const { resetOrgQuotas } = await import('../services/exportQuota.js')
+    const { notFound } = await import('../middleware/notFound.js')
+    const { errorHandler } = await import('../middleware/errorHandler.js')
+
+    await resetExportJobs()
+    await resetOrgQuotas()
+
+    const jobSystem = {
+      enqueue: jest.fn(),
+      getMetrics: () => ({
+        running: true,
+        queueDepth: 0,
+        delayedJobs: 0,
+        activeJobs: 0,
+        totals: { enqueued: 0, executions: 0, completed: 0, failed: 0, retried: 0 },
+      }),
+    }
+
+    app = express()
+    app.use(express.json())
+    app.use('/api/health', createHealthRouter(jobSystem as never))
+    app.use('/api/vaults', vaultsRouter)
+    app.use('/api/transactions', transactionsRouter)
+    app.use('/api/analytics', analyticsRouter)
+    app.use('/api/exports', createExportRouter(jobSystem as never))
+    app.use(notFound)
+    app.use(errorHandler)
+  })
+
+  const cases: ContractCase[] = [
+    {
+      name: 'health',
+      method: 'get',
+      documentedPath: '/api/health',
+      actualPath: '/api/health',
+      expectedStatus: 200,
+    },
+    {
+      name: 'vaults',
+      method: 'get',
+      documentedPath: '/api/vaults',
+      actualPath: '/api/vaults',
+      expectedStatus: 200,
+    },
+    {
+      name: 'transactions with cursor pagination',
+      method: 'get',
+      documentedPath: '/api/transactions',
+      actualPath: '/api/transactions?limit=1',
+      expectedStatus: 200,
+      headers: { 'x-user-id': userId },
+    },
+    {
+      name: 'vault analytics',
+      method: 'get',
+      documentedPath: '/api/analytics/vaults',
+      actualPath: '/api/analytics/vaults',
+      expectedStatus: 200,
+    },
+    {
+      name: 'milestone trends',
+      method: 'get',
+      documentedPath: '/api/analytics/milestones/trends',
+      actualPath: '/api/analytics/milestones/trends?from=2026-01-01T00:00:00.000Z&to=2026-01-02T00:00:00.000Z',
+      expectedStatus: 200,
+    },
+    {
+      name: 'behavior analytics',
+      method: 'get',
+      documentedPath: '/api/analytics/behavior',
+      actualPath: `/api/analytics/behavior?userId=${userId}`,
+      expectedStatus: 200,
+    },
+    {
+      name: 'export request',
+      method: 'post',
+      documentedPath: '/api/exports/me',
+      actualPath: '/api/exports/me?format=json&scope=all',
+      expectedStatus: 202,
+      capture: (body) => {
+        exportJobId = body.jobId
+      },
+    },
+    {
+      name: 'export status',
+      method: 'get',
+      documentedPath: '/api/exports/status/{jobId}',
+      actualPath: '/api/exports/status/__JOB_ID__',
+      expectedStatus: 200,
+    },
+  ]
+
+  it.each(cases)('matches the documented $name response', async (contractCase) => {
+    const actualPath = contractCase.actualPath.replace('__JOB_ID__', exportJobId)
+    let call = request(app)[contractCase.method](actualPath)
+
+    for (const [name, value] of Object.entries(contractCase.headers ?? {})) {
+      call = call.set(name, value)
+    }
+
+    if (contractCase.body) {
+      call = call.send(contractCase.body)
+    }
+
+    const response = await call
+    const documentedResponses = spec.paths[contractCase.documentedPath]?.[contractCase.method]?.responses ?? {}
+
+    if (!Object.keys(documentedResponses).includes(String(response.status))) {
+      throw new Error(
+        `${contractCase.method.toUpperCase()} ${contractCase.documentedPath} returned undocumented status ${response.status}`,
+      )
+    }
+    expect(response.status).toBe(contractCase.expectedStatus)
+
+    contractCase.capture?.(response.body)
+    expectMatchesOpenApi(
+      contractCase.documentedPath,
+      contractCase.method,
+      response.status,
+      response.body,
+    )
+  })
+
+  it('validates shared ErrorEnvelope responses', async () => {
+    const response = await request(app).get('/api/not-documented').set('x-request-id', 'contract-request')
+
+    expect(response.status).toBe(404)
+    const errors = validateValue({ $ref: '#/components/schemas/ErrorEnvelope' }, response.body)
+    if (errors.length > 0) {
+      throw new Error(errors.join('\n'))
+    }
+    expect(errors).toEqual([])
+  })
+
+  it('reports missing and extra fields with JSON paths', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        requiredName: { type: 'string' },
+      },
+      required: ['requiredName'],
+    }
+
+    expect(validateValue(schema, { extraName: true })).toEqual([
+      '$/requiredName: missing required property',
+      '$/extraName: undocumented property',
+    ])
+  })
+})

--- a/src/tests/orgInvitations.lifecycle.test.ts
+++ b/src/tests/orgInvitations.lifecycle.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import request from 'supertest'
+import express, { type Request, type Response, type NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
+import crypto from 'crypto'
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production'
+const sendMock = jest.fn().mockResolvedValue(undefined)
+const auditMock = jest.fn().mockResolvedValue(undefined)
+
+type InvitationRow = {
+  id: string
+  org_id: string
+  email: string
+  token_hash: string
+  expires_at: Date
+  accepted_at: Date | null
+  revoked_at: Date | null
+  created_at: Date
+}
+
+type Condition =
+  | { type: 'match'; values: Record<string, unknown> }
+  | { type: 'null'; key: string }
+  | { type: 'gt'; key: string; value: unknown }
+
+const dbMock: any = jest.fn()
+dbMock._tables = {
+  org_invitations: [] as InvitationRow[],
+  memberships: [] as any[],
+}
+dbMock._failFirst = false
+dbMock._failUpdate = false
+
+function matches(row: Record<string, any>, conditions: Condition[]) {
+  return conditions.every((condition) => {
+    if (condition.type === 'match') {
+      return Object.entries(condition.values).every(([key, value]) => row[key] === value)
+    }
+    if (condition.type === 'null') {
+      return row[condition.key] === null || typeof row[condition.key] === 'undefined'
+    }
+    return new Date(row[condition.key]).getTime() > new Date(condition.value as any).getTime()
+  })
+}
+
+dbMock.mockImplementation((table: keyof typeof dbMock._tables) => {
+  const conditions: Condition[] = []
+  let updatedRows: any[] = []
+  let insertedRows: any[] = []
+
+  const qb: any = {
+    insert: jest.fn().mockImplementation((row: any) => {
+      const inserted = {
+        ...row,
+        id: row.id ?? crypto.randomUUID(),
+        accepted_at: row.accepted_at ?? null,
+        revoked_at: row.revoked_at ?? null,
+        created_at: row.created_at ?? new Date(),
+      }
+      dbMock._tables[table].push(inserted)
+      insertedRows = [inserted]
+      return qb
+    }),
+    returning: jest.fn().mockImplementation(() => {
+      return Promise.resolve(updatedRows.length > 0 ? updatedRows : insertedRows)
+    }),
+    where: jest.fn().mockImplementation((keyOrValues: any, operator?: string, value?: unknown) => {
+      if (typeof keyOrValues === 'string' && operator === '>') {
+        conditions.push({ type: 'gt', key: keyOrValues, value })
+      } else {
+        conditions.push({ type: 'match', values: keyOrValues })
+      }
+      return qb
+    }),
+    whereNull: jest.fn().mockImplementation((key: string) => {
+      conditions.push({ type: 'null', key })
+      return qb
+    }),
+    first: jest.fn().mockImplementation(() => {
+      if (dbMock._failFirst) {
+        return Promise.reject(new Error('database unavailable'))
+      }
+      return Promise.resolve(dbMock._tables[table].find((row: any) => matches(row, conditions)) ?? null)
+    }),
+    update: jest.fn().mockImplementation((patch: Record<string, unknown>) => {
+      if (dbMock._failUpdate) {
+        throw new Error('database unavailable')
+      }
+      updatedRows = []
+      for (const row of dbMock._tables[table]) {
+        if (matches(row, conditions)) {
+          Object.assign(row, patch)
+          updatedRows.push(row)
+        }
+      }
+      return qb
+    }),
+  }
+
+  return qb
+})
+
+jest.unstable_mockModule('../db/index.js', async () => ({ default: dbMock }))
+jest.unstable_mockModule('../lib/audit-logs.js', async () => ({ createAuditLog: auditMock }))
+jest.unstable_mockModule('../services/notifications/factory.js', async () => ({
+  buildNotificationProviderRegistry: jest.fn(() => ({
+    console: { send: sendMock },
+  })),
+}))
+
+function mockAuthenticate(req: Request, res: Response, next: NextFunction): void {
+  const authHeader = req.headers.authorization
+  if (!authHeader?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Unauthorized' })
+    return
+  }
+
+  req.user = jwt.verify(authHeader.slice(7), JWT_SECRET) as any
+  next()
+}
+
+jest.unstable_mockModule('../middleware/auth.js', async () => ({ authenticate: mockAuthenticate }))
+jest.unstable_mockModule('../middleware/orgAuth.js', async () => ({
+  requireOrgAccess: (...roles: string[]) =>
+    (req: Request, res: Response, next: NextFunction) => {
+      if (!roles.includes((req.user as any)?.role)) {
+        res.status(403).json({ error: `Forbidden: requires role ${roles.join(' or ')}` })
+        return
+      }
+      next()
+    },
+}))
+
+const { orgMembersRouter } = await import('../routes/orgMembers.js')
+const { errorHandler } = await import('../middleware/errorHandler.js')
+
+const app = express()
+app.use(express.json())
+app.use('/api/orgs', orgMembersRouter)
+app.use(errorHandler)
+
+function makeToken(userId = 'admin-1', role = 'admin') {
+  return jwt.sign({ userId, role, sub: userId }, JWT_SECRET)
+}
+
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex')
+}
+
+function seedInvitation(overrides: Partial<InvitationRow> = {}) {
+  const rawToken = overrides.token_hash ? undefined : crypto.randomBytes(32).toString('hex')
+  const row: InvitationRow = {
+    id: 'inv-1',
+    org_id: 'org-abc',
+    email: 'invitee@example.com',
+    token_hash: overrides.token_hash ?? hashToken(rawToken!),
+    expires_at: new Date(Date.now() + 86_400_000),
+    accepted_at: null,
+    revoked_at: null,
+    created_at: new Date(),
+    ...overrides,
+  }
+  dbMock._tables.org_invitations.push(row)
+  return { row, rawToken }
+}
+
+beforeEach(() => {
+  dbMock._tables.org_invitations = []
+  dbMock._tables.memberships = []
+  dbMock._failFirst = false
+  dbMock._failUpdate = false
+  sendMock.mockClear()
+  auditMock.mockClear()
+})
+
+describe('organization invitation lifecycle', () => {
+  it('resends with a fresh token and invalidates the previous token', async () => {
+    const { rawToken: oldToken } = seedInvitation()
+
+    const resend = await request(app)
+      .post('/api/orgs/org-abc/invitations/inv-1/resend')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send()
+
+    expect(resend.status).toBe(200)
+    expect(resend.body.token).toHaveLength(64)
+    expect(resend.body.token).not.toBe(oldToken)
+    expect(dbMock._tables.org_invitations[0].token_hash).toBe(hashToken(resend.body.token))
+    expect(sendMock).toHaveBeenCalledTimes(1)
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({ action: 'org.invitation.resent' }))
+
+    const oldAccept = await request(app)
+      .post('/api/orgs/org-abc/invitations/accept')
+      .send({ token: oldToken, userId: 'user-2' })
+
+    expect(oldAccept.status).toBe(400)
+
+    const newAccept = await request(app)
+      .post('/api/orgs/org-abc/invitations/accept')
+      .send({ token: resend.body.token, userId: 'user-2' })
+
+    expect(newAccept.status).toBe(200)
+    expect(newAccept.body).toMatchObject({ orgId: 'org-abc', userId: 'user-2', role: 'member' })
+  })
+
+  it('revokes a pending invitation and blocks acceptance', async () => {
+    const { rawToken } = seedInvitation()
+
+    const revoke = await request(app)
+      .delete('/api/orgs/org-abc/invitations/inv-1')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send()
+
+    expect(revoke.status).toBe(200)
+    expect(revoke.body.revokedAt).toBeTruthy()
+    expect(dbMock._tables.org_invitations[0].revoked_at).toBeInstanceOf(Date)
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({ action: 'org.invitation.revoked' }))
+
+    const accept = await request(app)
+      .post('/api/orgs/org-abc/invitations/accept')
+      .send({ token: rawToken, userId: 'user-2' })
+
+    expect(accept.status).toBe(400)
+  })
+
+  it('returns 409 when revoking an accepted invitation', async () => {
+    seedInvitation({ accepted_at: new Date() })
+
+    const res = await request(app)
+      .delete('/api/orgs/org-abc/invitations/inv-1')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send()
+
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 409 when resending an accepted invitation', async () => {
+    seedInvitation({ accepted_at: new Date() })
+
+    const res = await request(app)
+      .post('/api/orgs/org-abc/invitations/inv-1/resend')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send()
+
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 404 when resending a missing invitation', async () => {
+    const res = await request(app)
+      .post('/api/orgs/org-abc/invitations/missing/resend')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send()
+
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 404 when revoking a missing invitation', async () => {
+    const res = await request(app)
+      .delete('/api/orgs/org-abc/invitations/missing')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send()
+
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 500 when resend persistence fails unexpectedly', async () => {
+    seedInvitation()
+    dbMock._failUpdate = true
+
+    const res = await request(app)
+      .post('/api/orgs/org-abc/invitations/inv-1/resend')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send()
+
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 500 when revoke persistence fails unexpectedly', async () => {
+    seedInvitation()
+    dbMock._failUpdate = true
+
+    const res = await request(app)
+      .delete('/api/orgs/org-abc/invitations/inv-1')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send()
+
+    expect(res.status).toBe(500)
+  })
+
+  it('enforces org-admin RBAC on resend and revoke', async () => {
+    seedInvitation()
+
+    const resend = await request(app)
+      .post('/api/orgs/org-abc/invitations/inv-1/resend')
+      .set('Authorization', `Bearer ${makeToken('member-1', 'member')}`)
+      .send()
+
+    const revoke = await request(app)
+      .delete('/api/orgs/org-abc/invitations/inv-1')
+      .set('Authorization', `Bearer ${makeToken('member-1', 'member')}`)
+      .send()
+
+    expect(resend.status).toBe(403)
+    expect(revoke.status).toBe(403)
+  })
+})

--- a/src/tests/orgInvitations.test.ts
+++ b/src/tests/orgInvitations.test.ts
@@ -46,6 +46,10 @@ jest.unstable_mockModule('../services/membership.js', async () => ({
   createMembership: jest.fn().mockResolvedValue({ role: 'member' }),
   removeMembership: jest.fn(),
   updateMemberRole: jest.fn(),
+  resendInvitation: jest.fn(),
+  revokeInvitation: jest.fn(),
+  InvitationNotFoundError: class InvitationNotFoundError extends Error {},
+  InvitationAcceptedError: class InvitationAcceptedError extends Error {},
   LastAdminError: class LastAdminError extends Error {},
 }))
 
@@ -185,7 +189,7 @@ describe('POST /api/organizations/:orgId/invitations/accept', () => {
       .post('/api/organizations/org-abc/invitations/accept')
       .send({ token: 'deadbeef'.repeat(8), userId: 'user-2' })
     expect(res.status).toBe(400)
-    expect(res.body.error).toMatch(/invalid or expired/i)
+    expect(res.body.error.message).toMatch(/invalid or expired/i)
   })
 
   it('returns 400 when token hash does not match', async () => {


### PR DESCRIPTION
Closes #672

---

## Summary
- add OpenAPI response contract tests for representative health, vaults, transactions, analytics, and exports routes
- validate live response bodies against documented schemas, including strict missing/extra field checks
- validate shared ErrorEnvelope shape and sync documented health/vault list response shapes with live routes

## Tests
- npm test -- src/tests/openapi.contract.test.ts --runInBand

Note: bun test src/tests/openapi.contract.test.ts could not be run locally because bun is not installed in this environment.