### PR TITLE
test: queryParser prototype-pollution and injection guards

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -40,6 +40,36 @@ export function formatValidationError(error: ZodError) {
   return buildValidationError(flattenZodErrors(error))
 }
 
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+export function isUnsafeObjectKey(key: string): boolean {
+  return UNSAFE_OBJECT_KEYS.has(key)
+}
+
+export function sanitizeObject<T>(input: T): T {
+  if (Array.isArray(input)) {
+    return input.map((value) => sanitizeObject(value)) as T
+  }
+
+  if (input === null || typeof input !== 'object') {
+    return input
+  }
+
+  const output: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (isUnsafeObjectKey(key)) {
+      throw new Error(`Unsafe query key rejected: ${key}`)
+    }
+    output[key] = sanitizeObject(value)
+  }
+
+  return output as T
+}
+
+export function isValidField(field: string, allowedFields: readonly string[]): boolean {
+  return typeof field === 'string' && !isUnsafeObjectKey(field) && allowedFields.includes(field)
+}
+
 export const utcTimestampSchema = z
   .string({ message: 'required' })
   .refine(

--- a/src/services/queryParser.ts
+++ b/src/services/queryParser.ts
@@ -87,7 +87,7 @@ export class QueryParser {
         if (!isValidField(column, this.allowedColumns)) {
           this.logger?.warn('QueryParser: Restricted column access attempted', { column });
           this.metricsHook?.({ event: 'restricted_column_access', column });
-          continue;
+          throw new Error(`Invalid filter field: ${column}`);
         }
 
         if (typeof filterValue === 'object' && filterValue !== null) {
@@ -101,6 +101,7 @@ export class QueryParser {
             } else {
               this.logger?.warn('QueryParser: Invalid operator attempted', { column, op });
               this.metricsHook?.({ event: 'invalid_operator_attempt', column, operator: op });
+              throw new Error(`Invalid filter operator: ${op}`);
             }
           }
         } else {
@@ -135,6 +136,7 @@ export class QueryParser {
       } else {
         this.logger?.warn('QueryParser: Restricted column sort attempted', { column: col });
         this.metricsHook?.({ event: 'restricted_sort_access', column: col });
+        throw new Error(`Invalid sort field: ${col}`);
       }
     }
 

--- a/src/tests/queryParser.injection.test.ts
+++ b/src/tests/queryParser.injection.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { QueryParser } from '../services/queryParser.js'
+
+describe('QueryParser injection guards', () => {
+  let warn: ReturnType<typeof mock>
+  let metricsHook: ReturnType<typeof mock>
+  let parser: QueryParser
+
+  beforeEach(() => {
+    warn = mock(() => undefined)
+    metricsHook = mock(() => undefined)
+    parser = new QueryParser({
+      allowedColumns: ['id', 'status', 'amount', 'created_at'],
+      defaultLimit: 20,
+      maxLimit: 50,
+      logger: { warn },
+      metricsHook,
+    })
+  })
+
+  it('parses valid filters, operators, sorting, and capped pagination', () => {
+    const parsed = parser.parse({
+      filter: {
+        status: 'active',
+        amount: { gte: '10', lt: '20' },
+        id: { in: ['vault-a', 'vault-b'] },
+      },
+      sort: ['created_at:desc', 'amount'],
+      limit: '500',
+      offset: '3',
+    })
+
+    expect(parsed.conditions).toEqual([
+      { column: 'status', operator: '=', value: 'active' },
+      { column: 'amount', operator: '>=', value: '10' },
+      { column: 'amount', operator: '<', value: '20' },
+      { column: 'id', operator: 'IN', value: ['vault-a', 'vault-b'] },
+    ])
+    expect(parsed.sorts).toEqual([
+      { column: 'created_at', order: 'desc' },
+      { column: 'amount', order: 'asc' },
+    ])
+    expect(parsed.limit).toBe(50)
+    expect(parsed.offset).toBe(3)
+  })
+
+  it('rejects prototype-pollution keys before they can alter Object.prototype', () => {
+    const query: any = { filter: { status: 'active' } }
+    Object.defineProperty(query.filter, '__proto__', {
+      enumerable: true,
+      value: { polluted: true },
+    })
+
+    expect(() => parser.parse(query)).toThrow('Unsafe query key rejected: __proto__')
+    expect(({} as any).polluted).toBeUndefined()
+  })
+
+  it('rejects constructor and prototype keys at any filter depth', () => {
+    expect(() => parser.parse({ filter: { constructor: { eq: 'active' } } })).toThrow(
+      'Unsafe query key rejected: constructor',
+    )
+    expect(() => parser.parse({ filter: { status: { prototype: 'active' } } })).toThrow(
+      'Unsafe query key rejected: prototype',
+    )
+  })
+
+  it('rejects unknown filter fields', () => {
+    expect(() => parser.parse({ filter: { organization_id: 'org-b' } })).toThrow(
+      'Invalid filter field: organization_id',
+    )
+
+    expect(warn).toHaveBeenCalledWith('QueryParser: Restricted column access attempted', {
+      column: 'organization_id',
+    })
+    expect(metricsHook).toHaveBeenCalledWith({
+      event: 'restricted_column_access',
+      column: 'organization_id',
+    })
+  })
+
+  it('rejects unsupported filter operators', () => {
+    expect(() => parser.parse({ filter: { status: { $ne: 'deleted' } } })).toThrow(
+      'Invalid filter operator: $ne',
+    )
+
+    expect(warn).toHaveBeenCalledWith('QueryParser: Invalid operator attempted', {
+      column: 'status',
+      op: '$ne',
+    })
+    expect(metricsHook).toHaveBeenCalledWith({
+      event: 'invalid_operator_attempt',
+      column: 'status',
+      operator: '$ne',
+    })
+  })
+
+  it('rejects unknown sort fields', () => {
+    expect(() => parser.parse({ sort: 'organization_id:desc' })).toThrow(
+      'Invalid sort field: organization_id',
+    )
+
+    expect(warn).toHaveBeenCalledWith('QueryParser: Restricted column sort attempted', {
+      column: 'organization_id',
+    })
+    expect(metricsHook).toHaveBeenCalledWith({
+      event: 'restricted_sort_access',
+      column: 'organization_id',
+    })
+  })
+})


### PR DESCRIPTION
Fixes #735

## Summary
- Add shared query-object sanitization helpers for unsafe prototype-pollution keys.
- Reject unknown filter fields, unsupported operators, and unknown sort fields in QueryParser instead of silently dropping them.
- Add Bun coverage for valid filters plus __proto__, constructor, prototype, unknown field, bad operator, and bad sort attempts.

## Tests
- C:\Users\jhona\.bun\bin\bun.exe test src/tests/queryParser.injection.test.ts
- npx tsc --noEmit --pretty false --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --esModuleInterop src\lib\validation.ts src\services\queryParser.ts
- git diff --check