### PR TITLE
test: graphql depth-limit and complexity guard

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -20,7 +20,8 @@ You must provide a valid `Authorization: Bearer <token>` header, and you must be
 ## Query Restrictions
 To prevent abusive queries:
 1. **Depth Limiting**: Queries are restricted to a maximum depth of 5. Nested queries beyond this depth will be rejected.
-2. **Read-Only**: Only queries are supported. Mutations must be performed through the REST API.
+2. **Complexity Limiting**: Queries are restricted to a maximum of 40 non-introspection field selections. Broad alias-heavy queries beyond this budget will be rejected.
+3. **Read-Only**: Only queries are supported. Mutations must be performed through the REST API.
 
 ## Example Query
 

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -7,7 +7,9 @@ import {
   GraphQLFloat,
   GraphQLInt,
   GraphQLBoolean,
+  GraphQLError,
 } from 'graphql'
+import type { ASTVisitor, ValidationContext } from 'graphql'
 import { createHandler } from 'graphql-http/lib/use/express'
 import depthLimit from 'graphql-depth-limit'
 import DataLoader from 'dataloader'
@@ -16,6 +18,77 @@ import { getVaultById, listVaults } from '../services/vaultStore.js'
 import { getAnalyticsByPeriod } from '../services/analytics.service.js'
 import { listVerifications, VerificationRecord } from '../services/verifiers.js'
 import { authenticate } from '../middleware/auth.js'
+
+const MAX_QUERY_DEPTH = 5
+const MAX_QUERY_COMPLEXITY = 40
+
+const operationDepthLimit = (maxDepth: number) => {
+  return (context: ValidationContext): ASTVisitor => {
+    let depth = 0
+    let introspectionDepth = 0
+
+    return {
+      Field: {
+        enter(node) {
+          if (node.name.value.startsWith('__') || introspectionDepth > 0) {
+            introspectionDepth += 1
+            return
+          }
+
+          depth += 1
+          if (depth > maxDepth) {
+            context.reportError(
+              new GraphQLError(`Query exceeds maximum depth of ${maxDepth}`, {
+                nodes: node,
+              }),
+            )
+            return false
+          }
+        },
+        leave(node) {
+          if (node.name.value.startsWith('__') || introspectionDepth > 0) {
+            introspectionDepth = Math.max(0, introspectionDepth - 1)
+            return
+          }
+          depth = Math.max(0, depth - 1)
+        },
+      },
+    }
+  }
+}
+
+const complexityLimit = (maxComplexity: number) => {
+  return (context: ValidationContext): ASTVisitor => {
+    let fieldCount = 0
+    let introspectionDepth = 0
+
+    return {
+      Field: {
+        enter(node) {
+          if (node.name.value.startsWith('__') || introspectionDepth > 0) {
+            introspectionDepth += 1
+            return
+          }
+
+          fieldCount += 1
+          if (fieldCount > maxComplexity) {
+            context.reportError(
+              new GraphQLError(`Query exceeds maximum complexity of ${maxComplexity}`, {
+                nodes: node,
+              }),
+            )
+            return false
+          }
+        },
+        leave(node) {
+          if (node.name.value.startsWith('__') || introspectionDepth > 0) {
+            introspectionDepth = Math.max(0, introspectionDepth - 1)
+          }
+        },
+      },
+    }
+  }
+}
 
 // --- DataLoaders ---
 // To avoid N+1 queries, we batch fetching verifications by targetId
@@ -174,6 +247,10 @@ graphqlRouter.use(
         loaders: createLoaders(),
       }
     },
-    validationRules: [depthLimit(5)], // Bound query depth to prevent abusive nested queries
+    validationRules: [
+      operationDepthLimit(MAX_QUERY_DEPTH),
+      depthLimit(MAX_QUERY_DEPTH),
+      complexityLimit(MAX_QUERY_COMPLEXITY),
+    ], // Bound query shape to prevent abusive nested or broad reads
   })
 )

--- a/src/tests/graphql.complexity.test.ts
+++ b/src/tests/graphql.complexity.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import express from 'express'
+import request from 'supertest'
+
+mock.module('../services/vaultStore.js', () => ({
+  listVaults: mock(async () => [
+    {
+      id: 'vault-1',
+      amount: '1000',
+      status: 'active',
+      milestones: [
+        {
+          id: 'milestone-1',
+          vaultId: 'vault-1',
+          title: 'First Milestone',
+          amount: '500',
+        },
+      ],
+    },
+  ]),
+  getVaultById: mock(async () => ({
+    id: 'vault-1',
+    amount: '1000',
+    status: 'active',
+    milestones: [
+      {
+        id: 'milestone-1',
+        vaultId: 'vault-1',
+        title: 'First Milestone',
+        amount: '500',
+      },
+    ],
+  })),
+}))
+
+mock.module('../services/analytics.service.js', () => ({
+  getAnalyticsByPeriod: mock(async () => ({
+    totalVaults: 1,
+    successRate: 1,
+  })),
+}))
+
+mock.module('../services/verifiers.js', () => ({
+  listVerifications: mock(async () => [
+    {
+      id: 'val-1',
+      targetId: 'milestone-1',
+      verifierUserId: 'user-1',
+      result: 'approved',
+    },
+  ]),
+}))
+
+mock.module('../middleware/auth.js', () => ({
+  authenticate: mock((req: any, res: any, next: any) => {
+    if (!req.header('authorization')) {
+      res.status(401).json({ error: 'Missing or malformed Authorization header' })
+      return
+    }
+    req.user = { userId: 'test-user', role: 'member' }
+    next()
+  }),
+}))
+
+mock.module('../middleware/orgAuth.js', () => ({
+  requireOrgRole: mock(() => (req: any, _res: any, next: any) => {
+    req.orgId = req.params.orgId
+    next()
+  }),
+}))
+
+describe('GraphQL depth and complexity limits', () => {
+  let app: express.Application
+
+  beforeEach(async () => {
+    const { graphqlRouter } = await import('../routes/graphql.js')
+    app = express()
+    app.use(express.json())
+    app.use('/api/organizations/:orgId/graphql', graphqlRouter)
+  })
+
+  const postGraphQL = (query: string) =>
+    request(app)
+      .post('/api/organizations/org-1/graphql')
+      .set('Authorization', 'Bearer test-token')
+      .send({ query })
+
+  it('allows a normal query within limits', async () => {
+    const response = await postGraphQL(`
+      query {
+        vaults {
+          id
+          amount
+        }
+      }
+    `)
+
+    expect(response.status).toBe(200)
+    expect(response.body.errors).toBeUndefined()
+    expect(response.body.data.vaults).toEqual([{ id: 'vault-1', amount: '1000' }])
+  })
+
+  it('rejects queries exceeding the depth limit', async () => {
+    const response = await postGraphQL(`
+      query {
+        vaults {
+          analytics {
+            totalVaults {
+              too {
+                deep {
+                  here
+                }
+              }
+            }
+          }
+        }
+      }
+    `)
+
+    expect(response.status).toBe(200)
+    expect(JSON.stringify(response.body.errors)).toContain('Query exceeds maximum depth of 5')
+  })
+
+  it('allows a broad query at the complexity boundary', async () => {
+    const selections = Array.from({ length: 13 }, (_, index) => `v${index}: vaults { id amount }`).join('\n')
+    const response = await postGraphQL(`query { ${selections} }`)
+
+    expect(response.status).toBe(200)
+    expect(response.body.errors).toBeUndefined()
+    expect(response.body.data.v0).toEqual([{ id: 'vault-1', amount: '1000' }])
+    expect(response.body.data.v12).toEqual([{ id: 'vault-1', amount: '1000' }])
+  })
+
+  it('rejects alias-heavy queries exceeding the complexity budget', async () => {
+    const selections = Array.from({ length: 14 }, (_, index) => `v${index}: vaults { id amount }`).join('\n')
+    const response = await postGraphQL(`query { ${selections} }`)
+
+    expect(response.status).toBe(200)
+    expect(JSON.stringify(response.body.errors)).toContain('Query exceeds maximum complexity of 40')
+  })
+
+  it('allows basic introspection fields', async () => {
+    const response = await postGraphQL('{ __typename }')
+
+    expect(response.status).toBe(200)
+    expect(response.body.errors).toBeUndefined()
+    expect(response.body.data.__typename).toBe('Query')
+  })
+})


### PR DESCRIPTION
Fixes #737

## Summary
- Add a syntax-level GraphQL depth validation rule so deeply nested ASTs are rejected even before scalar-field validation shortcuts.
- Add a 40-field non-introspection complexity budget to block broad alias-heavy reads.
- Add Bun endpoint coverage for normal, over-depth, boundary-complexity, over-complexity, and basic introspection queries.
- Document the complexity limit in docs/graphql.md.

## Tests
- C:\Users\jhona\.bun\bin\bun.exe test src/tests/graphql.complexity.test.ts
- git diff --check

Note: a narrow tsc invocation that imports src/routes/graphql.ts still reaches existing unrelated repo-wide TypeScript errors in src/config/env.ts, src/db/database.ts, and src/services/verifiers.ts.