### PR TITLE
test: add chaos test suite for HorizonListener synchronization and fa…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,14 @@
         "bcryptjs": "^3.0.3",
         "cors": "^2.8.6",
         "csv-stringify": "^6.6.0",
+        "dataloader": "^2.2.2",
         "date-fns": "^4.1.0",
         "debug": "^4.4.3",
         "express": "^4.21.0",
         "express-rate-limit": "^8.2.1",
+        "graphql": "^16.8.1",
+        "graphql-depth-limit": "^1.1.0",
+        "graphql-http": "^1.22.0",
         "helmet": "^7.2.0",
         "jsonwebtoken": "^9.0.3",
         "pg": "^8.20.0",
@@ -36,6 +40,7 @@
         "@types/cors": "^2.8.19",
         "@types/debug": "^4.1.13",
         "@types/express": "^4.17.21",
+        "@types/graphql-depth-limit": "^1.1.4",
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.9.0",
@@ -5350,6 +5355,30 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/graphql-depth-limit": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@types/graphql-depth-limit/-/graphql-depth-limit-1.1.6.tgz",
+      "integrity": "sha512-WU4bjoKOzJ8CQE32Pbyq+YshTMcLJf2aJuvVtSLv1BQPwDUGa38m2Vr8GGxf0GZ0luCQcfxlhZeHKu6nmTBvrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graphql": "^14.5.3"
+      }
+    },
+    "node_modules/@types/graphql-depth-limit/node_modules/graphql": {
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+      "deprecated": "No longer supported; please update to a newer version. Details: https://github.com/graphql/graphql-js#version-support",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iterall": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 6.x"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -6097,6 +6126,15 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -7080,6 +7118,12 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
       "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==",
+      "license": "MIT"
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -8587,6 +8631,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-depth-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+      "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
+    "node_modules/graphql-http": {
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.4.tgz",
+      "integrity": "sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA==",
+      "license": "MIT",
+      "workspaces": [
+        "implementations/**/*"
+      ],
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -9102,6 +9185,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",

--- a/src/tests/horizonListener.chaos.test.ts
+++ b/src/tests/horizonListener.chaos.test.ts
@@ -1,0 +1,372 @@
+import { jest } from '@jest/globals'
+import { HorizonListener } from '../services/horizonListener.js'
+import { CheckpointStore } from '../services/checkpointStore.js'
+import { HorizonListenerConfig } from '../config/horizonListener.js'
+import { HorizonEvent } from '../services/eventParser.js'
+import { createRawHorizonEvent } from './fixtures/horizonEvents.js'
+import { HorizonCheckpoint } from '../types/horizonSync.js'
+
+const CONTRACT_ID = 'CTEST123'
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000'
+
+function makeVaultCreatedEvent(
+  ledger: number,
+  txHash: string,
+  eventIndex: number,
+  overrides: Partial<HorizonEvent> = {},
+): HorizonEvent {
+  return createRawHorizonEvent(
+    'vault_created',
+    {
+      vaultId: VALID_UUID,
+      creator: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      amount: '1000.0000000',
+      startTimestamp: new Date('2024-01-01T00:00:00Z'),
+      endTimestamp: new Date('2024-12-31T23:59:59Z'),
+      successDestination: 'GSUCCESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      failureDestination: 'GFAILUREXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    },
+    {
+      ledger,
+      contractId: CONTRACT_ID,
+      txHash,
+      id: `${txHash}-${eventIndex}`,
+      pagingToken: `${ledger}-${eventIndex}`,
+      ...overrides,
+    },
+  )
+}
+
+function makeCheckpoint(lastLedger: number, pagingToken: string): HorizonCheckpoint {
+  return {
+    id: 1,
+    contractAddress: CONTRACT_ID,
+    lastLedger,
+    lastPagingToken: pagingToken,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+  }
+}
+
+function createMockDb(): any {
+  return {} as any
+}
+
+function createMockEventProcessor(success = true): any {
+  return {
+    processEvent: jest.fn<any>().mockResolvedValue(
+      success
+        ? { success: true, eventId: 'test-event' }
+        : { success: false, eventId: 'test-event', error: 'Intentional failure' },
+    ),
+  }
+}
+
+function createMockCheckpointStore(): any {
+  return {
+    getCheckpoint: jest.fn<any>().mockResolvedValue(null),
+    upsertCheckpoint: jest.fn<any>().mockResolvedValue(undefined),
+  }
+}
+
+const baseConfig: HorizonListenerConfig = {
+  horizonUrl: 'https://horizon-testnet.stellar.org',
+  contractAddresses: [CONTRACT_ID],
+  startLedger: 1000,
+  retryMaxAttempts: 3,
+  retryBackoffMs: 100,
+  shutdownTimeoutMs: 30000,
+  lagThreshold: 30,
+}
+
+// ── Contract verified by these tests ───────────────────────────────────────
+//
+// HorizonListener.handleEvent() provides at-least-once delivery with no
+// duplicate side-effects when paired with EventProcessor idempotency.
+// Specifically:
+//
+//  1. Every event accepted by handleEvent() is forwarded to
+//     EventProcessor.processEvent(), even if the ledger duplicates a
+//     previously-seen event.  Deduplication happens inside EventProcessor
+//     via the processed_events idempotency table, not in the listener.
+//
+//  2. After a successful processEvent() the listener persists a per-contract
+//     checkpoint (contract_id, last_ledger, paging_token) via
+//     CheckpointStore.upsertCheckpoint().  There is no monotonicity check on
+//     the checkpoint write — out-of-order delivery can move the cursor
+//     backward.
+//
+//  3. On (re)start, loadEffectiveStartLedger() queries each contract's
+//     checkpoint and returns the MINIMUM lastLedger across all configured
+//     contracts.  This guarantees that a contract lagging behind its peers
+//     receives all its missed events.  If a checkpoint was moved backward
+//     (see #2), the listener will resume from the lower ledger and
+//     re-deliver events; idempotency absorbs the duplicates.
+//
+//  4. Events from non-configured contracts, parse failures, and processing
+//     failures do not advance the checkpoint.
+
+describe('HorizonListener — chaos tests (resume / dedupe / reorder)', () => {
+  let mockDb: any
+  let mockEventProcessor: any
+  let mockCheckpointStore: any
+  let config: HorizonListenerConfig
+
+  beforeEach(() => {
+    mockDb = createMockDb()
+    mockEventProcessor = createMockEventProcessor(true)
+    mockCheckpointStore = createMockCheckpointStore()
+    config = { ...baseConfig }
+  })
+
+  // ── Resume after mid-stream error ─────────────────────────────────────
+
+  describe('resume from persisted cursor after interruption', () => {
+    it('persists checkpoint for every successfully processed event', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      await listener.handleEvent(makeVaultCreatedEvent(1001, 'tx1', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1002, 'tx2', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1003, 'tx3', 0))
+
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenCalledTimes(3)
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenNthCalledWith(1, CONTRACT_ID, 1001, '1001-0')
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenNthCalledWith(2, CONTRACT_ID, 1002, '1002-0')
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenNthCalledWith(3, CONTRACT_ID, 1003, '1003-0')
+    })
+
+    it('loads effective start ledger from persisted checkpoint, not startLedger', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      await listener.handleEvent(makeVaultCreatedEvent(1001, 'tx1', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1002, 'tx2', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1003, 'tx3', 0))
+
+      mockCheckpointStore.getCheckpoint.mockResolvedValue(makeCheckpoint(1003, '1003-0'))
+
+      const newListener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+      const startLedger = await newListener.loadEffectiveStartLedger()
+
+      expect(startLedger).toBe(1003)
+    })
+
+    it('falls back to startLedger when no checkpoint exists', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+      const startLedger = await listener.loadEffectiveStartLedger()
+
+      expect(startLedger).toBe(1000)
+    })
+
+    it('recovers from checkpoint write failure without crashing', async () => {
+      mockCheckpointStore.upsertCheckpoint.mockRejectedValue(new Error('DB write failed'))
+
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      await expect(
+        listener.handleEvent(makeVaultCreatedEvent(1001, 'tx1', 0)),
+      ).resolves.toBeUndefined()
+
+      expect(mockEventProcessor.processEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses minimum checkpoint across multiple contracts', async () => {
+      const multiConfig: HorizonListenerConfig = {
+        ...config,
+        contractAddresses: ['CA', 'CB', 'CC'],
+      }
+      const store = createMockCheckpointStore()
+      store.getCheckpoint.mockImplementation(async (addr: string) => {
+        const map: Record<string, number> = { CA: 1050, CB: 1020, CC: 1100 }
+        return makeCheckpoint(map[addr] ?? 1000, `${map[addr] ?? 1000}-0`)
+      })
+
+      const listener = new HorizonListener(multiConfig, mockEventProcessor, mockDb, store)
+      const startLedger = await listener.loadEffectiveStartLedger()
+
+      expect(startLedger).toBe(1020)
+    })
+  })
+
+  // ── Duplicate ledger replay ───────────────────────────────────────────
+
+  describe('duplicate ledger replay deduplication', () => {
+    it('forwards duplicate events to EventProcessor (idempotency lives there)', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+      const event = makeVaultCreatedEvent(1005, 'tx1', 0)
+
+      await listener.handleEvent(event)
+      await listener.handleEvent(event)
+
+      expect(mockEventProcessor.processEvent).toHaveBeenCalledTimes(2)
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenCalledTimes(2)
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenNthCalledWith(1, CONTRACT_ID, 1005, '1005-0')
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenNthCalledWith(2, CONTRACT_ID, 1005, '1005-0')
+    })
+
+    it('same ledger, different events (different txHashes) are both processed', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      await listener.handleEvent(makeVaultCreatedEvent(1005, 'tx1', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1005, 'tx2', 0))
+
+      expect(mockEventProcessor.processEvent).toHaveBeenCalledTimes(2)
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  // ── Out-of-order / backward ledger delivery ───────────────────────────
+
+  describe('out-of-order ledger handling', () => {
+    it('processes events regardless of ledger arrival order', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      await listener.handleEvent(makeVaultCreatedEvent(1005, 'tx1', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1003, 'tx2', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1007, 'tx3', 0))
+
+      expect(mockEventProcessor.processEvent).toHaveBeenCalledTimes(3)
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenCalledTimes(3)
+    })
+
+    it('checkpoint reflects each event ledger even when moving backward', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      await listener.handleEvent(makeVaultCreatedEvent(1005, 'tx1', 0))
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenLastCalledWith(CONTRACT_ID, 1005, '1005-0')
+
+      await listener.handleEvent(makeVaultCreatedEvent(1003, 'tx2', 0))
+      expect(mockCheckpointStore.upsertCheckpoint).toHaveBeenLastCalledWith(CONTRACT_ID, 1003, '1003-0')
+    })
+
+    it('restart from backward checkpoint re-delivers ledgers idempotency absorbs', async () => {
+      const store = createMockCheckpointStore()
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, store)
+
+      await listener.handleEvent(makeVaultCreatedEvent(1005, 'tx1', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1003, 'tx2', 0))
+
+      store.getCheckpoint.mockResolvedValue(makeCheckpoint(1003, '1003-0'))
+
+      const restarted = new HorizonListener(config, mockEventProcessor, mockDb, store)
+      const resumedFrom = await restarted.loadEffectiveStartLedger()
+
+      expect(resumedFrom).toBe(1003)
+    })
+
+    it('monotonic delivery advances cursor strictly', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      await listener.handleEvent(makeVaultCreatedEvent(1001, 'tx1', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1002, 'tx2', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1003, 'tx3', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1004, 'tx4', 0))
+      await listener.handleEvent(makeVaultCreatedEvent(1005, 'tx5', 0))
+
+      const calls = mockCheckpointStore.upsertCheckpoint.mock.calls as [string, number, string][]
+      for (let i = 1; i < calls.length; i++) {
+        expect(calls[i][1]).toBeGreaterThan(calls[i - 1][1])
+      }
+    })
+  })
+
+  // ── Event filtering ───────────────────────────────────────────────────
+
+  describe('event filtering and edge cases', () => {
+    it('ignores events from non-configured contracts', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      const event = makeVaultCreatedEvent(1005, 'tx1', 0, {
+        contractId: 'UNKNOWN_CONTRACT',
+      })
+
+      await listener.handleEvent(event)
+
+      expect(mockEventProcessor.processEvent).not.toHaveBeenCalled()
+      expect(mockCheckpointStore.upsertCheckpoint).not.toHaveBeenCalled()
+    })
+
+    it('handles parse failures gracefully — no checkpoint written', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      const event = createRawHorizonEvent(
+        'vault_created',
+        { invalid: true },
+        {
+          ledger: 1005,
+          contractId: CONTRACT_ID,
+          txHash: 'tx1',
+          id: 'tx1-0',
+          pagingToken: '1005-0',
+        },
+      )
+
+      await listener.handleEvent(event)
+
+      expect(mockEventProcessor.processEvent).not.toHaveBeenCalled()
+      expect(mockCheckpointStore.upsertCheckpoint).not.toHaveBeenCalled()
+    })
+
+    it('does not persist checkpoint when processing fails', async () => {
+      const failingProcessor = createMockEventProcessor(false)
+      const listener = new HorizonListener(config, failingProcessor, mockDb, mockCheckpointStore)
+
+      await listener.handleEvent(makeVaultCreatedEvent(1005, 'tx1', 0))
+
+      expect(failingProcessor.processEvent).toHaveBeenCalledTimes(1)
+      expect(mockCheckpointStore.upsertCheckpoint).not.toHaveBeenCalled()
+    })
+
+    it('skips event processing during shutdown', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      const startPromise = listener.start()
+      await new Promise(resolve => setTimeout(resolve, 50))
+      await listener.stop()
+
+      await listener.handleEvent(makeVaultCreatedEvent(1005, 'tx1', 0))
+
+      expect(mockEventProcessor.processEvent).not.toHaveBeenCalled()
+      expect(mockCheckpointStore.upsertCheckpoint).not.toHaveBeenCalled()
+
+      await startPromise
+    })
+
+    it('tracks inFlightEvents correctly', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+
+      let resolveProcessor!: () => void
+      const processorPromise = new Promise<void>(resolve => { resolveProcessor = resolve })
+      mockEventProcessor.processEvent.mockImplementation(() => processorPromise.then(() => ({ success: true, eventId: 'test-event' })))
+
+      const handlePromise = listener.handleEvent(makeVaultCreatedEvent(1005, 'tx1', 0))
+
+      // Give the microtask queue a tick so handleEvent increments inFlightEvents
+      await new Promise(resolve => setImmediate(resolve))
+
+      expect((listener as any).inFlightEvents).toBe(1)
+
+      resolveProcessor()
+      await handlePromise
+
+      expect((listener as any).inFlightEvents).toBe(0)
+    })
+  })
+
+  // ── Idempotency boundary / EventProcessor contract ────────────────────
+
+  describe('contract: EventProcessor receives correct parsed events', () => {
+    it('passes the parsed event to EventProcessor.processEvent', async () => {
+      const listener = new HorizonListener(config, mockEventProcessor, mockDb, mockCheckpointStore)
+      const rawEvent = makeVaultCreatedEvent(1005, 'tx1', 0)
+
+      await listener.handleEvent(rawEvent)
+
+      const [parsedEvent] = mockEventProcessor.processEvent.mock.calls[0]
+      expect(parsedEvent).toMatchObject({
+        transactionHash: 'tx1',
+        ledgerNumber: 1005,
+        eventType: 'vault_created',
+      })
+    })
+  })
+})


### PR DESCRIPTION
Closes #671 

## Summary

Adds deterministic chaos tests for the Horizon listener's resilience to connection interruptions, duplicate ledger replay, and out-of-order event delivery. These failure modes are the most common sources of drift in production — the listener's resume and deduplication behaviour was previously unproven.

## Changes

### `src/tests/horizonListener.chaos.test.ts` (new, 372 lines)

17 tests across 5 groups verifying the contract documented in the file header:

| Group | Tests | Verified behaviour |
|---|---|---|
| **Resume after interruption** | 5 | Checkpoints persist per event; `loadEffectiveStartLedger` returns the stored cursor, not `startLedger`; falls back to config when no checkpoint exists; survives checkpoint write failures; picks the minimum cursor across multiple contracts |
| **Duplicate ledger replay** | 2 | Duplicate events are forwarded to `EventProcessor` on every call (dedup lives in the idempotency layer, not the listener); same-ledger different-txHash events are both forwarded |
| **Out-of-order delivery** | 4 | Events process regardless of arrival order; the checkpoint reflects each event's ledger even when it moves backward; restart from a backward checkpoint re-delivers the gap (idempotency absorbs duplicates); monotonic delivery strictly advances the cursor |
| **Filtering & edge cases** | 5 | Non-configured contracts are filtered; parse failures log and skip; processing failures skip checkpoint writes; shutdown guard blocks event handling; `inFlightEvents` counter is accurate |
| **EventProcessor contract** | 1 | Parsed events carry the correct `transactionHash`, `ledgerNumber`, and `eventType` |

### Key finding

`CheckpointStore.upsertCheckpoint` does **not** enforce monotonicity — the `onConflict.merge` unconditionally overwrites the cursor. Out-of-order events can move the checkpoint backward. The tests verify this behaviour and document that the gap is absorbed by `EventProcessor`'s idempotency table on restart.

## Contract verified

```
At-least-once delivery with no duplicate side-effects.
Out-of-order delivery can move the cursor backward.
On restart, the minimum checkpoint across all contracts is chosen.
```

## Test results

```
PASS  src/tests/horizonListener.chaos.test.ts  (17 tests, all passed)
PASS  src/tests/horizonListener.test.ts         (existing tests unaffected)
```

The pre-existing `adminHorizonListener.test.ts` failure (unrelated `session.js` import) is not affected.
