### PR TITLE
security: add privacy logger allowlist guard

### DIFF
--- a/docs/privacy-logging.md
+++ b/docs/privacy-logging.md
@@ -15,6 +15,17 @@ Every log line has exactly these top-level keys — no more, no less.
 
 ## Redaction Policy
 
+### Allowlist Mode for Structured Request Logs
+
+The HTTP privacy logger runs body, query, and header payloads in **allowlist mode** before writing the structured JSON line. In this mode:
+
+- Keys in `SENSITIVE_KEYS` are always redacted, even if they also appear in the allowlist.
+- Keys not present in `SAFE_LOG_KEYS` are redacted by default.
+- Operational fields such as `requestId`, `route`, `method`, `url`, `status`, `durationMs`, pagination fields, and safe request headers remain available for debugging.
+- Nested objects are processed recursively only through allowlisted parent keys; unknown nested fields are redacted fail-closed.
+
+This means newly added fields such as webhook signing secrets, API-key material, WebAuthn challenges, or JWT payload fragments do not need to be known ahead of time to be protected in request logs.
+
 ### Export Queue DLQ and Metrics Events
 Export job failure records and export queue structured events pass through the shared privacy sanitizer before they are persisted or emitted.
 The sanitizer replaces `userId`, `targetUserId`, Stellar account addresses, emails, `creator`, `successDestination`, and `failureDestination` with deterministic 8-character SHA-256 tokens.
@@ -200,6 +211,12 @@ Update the snapshot after changing the set:
 npx jest src/tests/privacy-logger.redaction.test.ts --updateSnapshot
 ```
 
+## Adding New Safe Log Fields
+
+Only add a key to `SAFE_LOG_KEYS` when the value is operationally useful and guaranteed not to contain user content, credentials, PII, raw wallet addresses, JWT claims, webhook secrets, API-key material, or WebAuthn challenge data.
+
+After adding a safe key, add or update an allowlist-mode test in `src/tests/privacy-logger.allowlist.test.ts`.
+
 ## Testing
 
 ```bash
@@ -211,6 +228,7 @@ npx jest src/tests/privacy-logger.redaction.test.ts --updateSnapshot
 
 npm test -- src/tests/privacy-logger.test.ts
 npm test -- src/tests/exportQueue.pii.test.ts
+bun test src/tests/privacy-logger.allowlist.test.ts
 ```
 
 Test coverage includes:
@@ -227,6 +245,7 @@ Test coverage includes:
 - Middleware schema (exact top-level keys)
 - `null` body and `null` query
 - Header redaction (`authorization`, `x-api-key`, `x-auth-token`, `cookie`)
+- Allowlist-mode redaction of unknown body, query, and header fields
 - Serialization-failure fallback
 - Snapshot of a representative request
 

--- a/src/middleware/privacy-logger.ts
+++ b/src/middleware/privacy-logger.ts
@@ -30,21 +30,70 @@ const SENSITIVE_KEYS = new Set([
   'failuredestination',
 ])
 
+export const SAFE_LOG_KEYS = new Set([
+  'accept',
+  'content-type',
+  'correlationid',
+  'cursor',
+  'durationms',
+  'event',
+  'host',
+  'id',
+  'ip',
+  'level',
+  'limit',
+  'method',
+  'page',
+  'pagesize',
+  'path',
+  'requestid',
+  'request_id',
+  'route',
+  'service',
+  'sortby',
+  'sortorder',
+  'status',
+  'statuscode',
+  'timestamp',
+  'type',
+  'url',
+  'user-agent',
+  'x-correlation-id',
+  'x-request-id',
+])
+
 const EMAIL_RE = /[^@\s]+@[^@\s]+\.[^@\s]+/
 const JWT_RE = /^[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+$/
+
+export interface RedactOptions {
+  allowlistMode?: boolean
+  allowedKeys?: Iterable<string>
+}
 
 /** Returns true when a field name should always be redacted. */
 export function shouldRedact(key: string): boolean {
   return SENSITIVE_KEYS.has(key.toLowerCase())
 }
 
+/** Returns true when a field name is safe to keep in allowlist-mode logs. */
+export function isSafeLogKey(key: string, allowedKeys: Iterable<string> = SAFE_LOG_KEYS): boolean {
+  const normalized = new Set(Array.from(allowedKeys, (allowedKey) => allowedKey.toLowerCase()))
+  return normalized.has(key.toLowerCase())
+}
+
 /**
  * Pure recursive redactor. Deep-copies input and replaces:
  * - values under sensitive field names, and
  * - string values matching email or JWT patterns
- * with REDACTED. Never mutates the original.
+ * with REDACTED. In allowlist mode, non-sensitive keys are only kept when they
+ * are explicitly allowlisted. Never mutates the original.
  */
-export function redact<T>(value: T, seen = new WeakSet()): T {
+export function redact<T>(value: T, options: RedactOptions = {}): T {
+  const allowedKeys = new Set(Array.from(options.allowedKeys ?? SAFE_LOG_KEYS, (key) => key.toLowerCase()))
+  return redactValue(value, options.allowlistMode === true, allowedKeys, new WeakSet())
+}
+
+function redactValue<T>(value: T, allowlistMode: boolean, allowedKeys: Set<string>, seen: WeakSet<object>): T {
   if (value === null || value === undefined) return value
 
   if (typeof value !== 'object') {
@@ -60,7 +109,7 @@ export function redact<T>(value: T, seen = new WeakSet()): T {
   seen.add(value as object)
 
   if (Array.isArray(value)) {
-    return value.map((item) => redact(item, seen)) as unknown as T
+    return value.map((item) => redactValue(item, allowlistMode, allowedKeys, seen)) as unknown as T
   }
 
   if (value instanceof Date) return value.toISOString() as unknown as T
@@ -70,7 +119,11 @@ export function redact<T>(value: T, seen = new WeakSet()): T {
   const result: Record<string, unknown> = {}
 
   for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-    result[k] = shouldRedact(k) ? REDACTED : redact(v, seen)
+    if (shouldRedact(k) || (allowlistMode && !allowedKeys.has(k.toLowerCase()))) {
+      result[k] = REDACTED
+      continue
+    }
+    result[k] = redactValue(v, allowlistMode, allowedKeys, seen)
   }
 
   return result as unknown as T
@@ -141,13 +194,13 @@ export const privacyLogger = (
           rawBody !== undefined &&
           typeof rawBody === 'object' &&
           !Array.isArray(rawBody)
-            ? redact(rawBody as Record<string, unknown>)
+            ? redact(rawBody as Record<string, unknown>, { allowlistMode: true })
             : null,
         query:
           rawQuery && Object.keys(rawQuery).length > 0
-            ? redact(rawQuery)
+            ? redact(rawQuery, { allowlistMode: true })
             : null,
-        headers: redact(req.headers as Record<string, unknown>),
+        headers: redact(req.headers as Record<string, unknown>, { allowlistMode: true }),
       }
 
       console.log(JSON.stringify(line))

--- a/src/tests/privacy-logger.allowlist.test.ts
+++ b/src/tests/privacy-logger.allowlist.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import express from 'express'
+import request from 'supertest'
+import { privacyLogger, redact, REDACTED } from '../middleware/privacy-logger.js'
+
+describe('privacy logger allowlist mode', () => {
+  const originalLog = console.log
+
+  afterEach(() => {
+    console.log = originalLog
+  })
+
+  it('redacts unknown fields by default in allowlist mode', () => {
+    const output = redact(
+      {
+        requestId: 'req-123',
+        status: 'active',
+        webhookSigningSecret: 'whsec_live_secret',
+      },
+      { allowlistMode: true },
+    )
+
+    expect(output).toEqual({
+      requestId: 'req-123',
+      status: 'active',
+      webhookSigningSecret: REDACTED,
+    })
+  })
+
+  it('keeps denylist redactions active even for allowlisted keys', () => {
+    const output = redact(
+      {
+        token: 'plain-token',
+        status: 'active',
+      },
+      {
+        allowlistMode: true,
+        allowedKeys: ['token', 'status'],
+      },
+    )
+
+    expect(output).toEqual({
+      token: REDACTED,
+      status: 'active',
+    })
+  })
+
+  it('recursively redacts nested unknown fields and nested denylisted secrets', () => {
+    const output = redact(
+      {
+        metadata: {
+          status: 'queued',
+          webauthnChallenge: 'challenge-secret',
+          nested: {
+            token: 'nested-token',
+            status: 'retrying',
+          },
+        },
+      },
+      {
+        allowlistMode: true,
+        allowedKeys: ['metadata', 'nested', 'status'],
+      },
+    )
+
+    expect(output).toEqual({
+      metadata: {
+        status: 'queued',
+        webauthnChallenge: REDACTED,
+        nested: {
+          token: REDACTED,
+          status: 'retrying',
+        },
+      },
+    })
+  })
+
+  it('logs only allowlisted request fields while preserving operational fields', async () => {
+    const lines: string[] = []
+    console.log = (line?: unknown) => {
+      lines.push(String(line))
+    }
+
+    const app = express()
+    app.use(express.json())
+    app.use(privacyLogger)
+    app.post('/hook', (_req, res) => {
+      res.status(202).json({ ok: true })
+    })
+
+    await request(app)
+      .post('/hook?requestId=req-123&webhookSecret=query-secret')
+      .set('Authorization', 'Bearer secret-token')
+      .set('User-Agent', 'allowlist-test')
+      .send({
+        requestId: 'req-123',
+        status: 'pending',
+        webhookSigningSecret: 'body-secret',
+        details: { token: 'nested-token' },
+      })
+      .expect(202)
+
+    expect(lines).toHaveLength(1)
+    const logLine = JSON.parse(lines[0])
+
+    expect(logLine.method).toBe('POST')
+    expect(logLine.url).toContain('/hook')
+    expect(logLine.status).toBe(202)
+    expect(logLine.body).toEqual({
+      requestId: 'req-123',
+      status: 'pending',
+      webhookSigningSecret: REDACTED,
+      details: REDACTED,
+    })
+    expect(logLine.query).toEqual({
+      requestId: 'req-123',
+      webhookSecret: REDACTED,
+    })
+    expect(logLine.headers.authorization).toBe(REDACTED)
+    expect(logLine.headers['user-agent']).toBe('allowlist-test')
+  })
+})


### PR DESCRIPTION
Fixes #748

## Summary
- Add allowlist-mode redaction so structured request logs fail closed on unknown body/query/header fields.
- Keep denylist and pattern redactions active, including when a key is explicitly allowlisted.
- Apply allowlist mode in the HTTP privacy logger while keeping redact() default behavior compatible for direct callers.
- Document SAFE_LOG_KEYS policy and add Bun coverage for utility and middleware behavior.

## Tests
- C:\Users\jhona\.bun\bin\bun.exe test src/tests/privacy-logger.allowlist.test.ts
- npx tsc --noEmit --pretty false --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --esModuleInterop src\middleware\privacy-logger.ts
- git diff --check