### PR TITLE
security: add SSRF guard for evidence references

### DIFF
--- a/docs/evidence-storage.md
+++ b/docs/evidence-storage.md
@@ -27,6 +27,16 @@ This service stores signed object-storage references for verification evidence w
   - `expires`
 - Expired URLs are rejected.
 
+## SSRF protection
+
+Evidence references are treated as outbound object-storage URLs and are validated before they are persisted.
+
+- Only `http` and `https` schemes are accepted.
+- `localhost`, `.localhost`, `localtest.me`, loopback, RFC1918, link-local, unique-local IPv6, and cloud metadata IPs are blocked.
+- DNS names are resolved and every returned address is checked, so DNS rebinding to a private/internal address is rejected.
+- `EVIDENCE_ALLOWED_HOSTS` can restrict evidence references to specific hosts or subdomains.
+- When `EVIDENCE_ALLOWED_HOSTS` is not set, the service falls back to `WEBHOOK_ALLOWED_HOSTS` so outbound webhook and evidence URL policy can be managed together.
+
 ## Persistence
 
 A new `evidence_references` table stores evidence metadata.

--- a/src/services/evidence.ts
+++ b/src/services/evidence.ts
@@ -1,3 +1,5 @@
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
 import { prisma } from '../lib/prisma.js'
 
 export class EvidenceReferenceValidationError extends Error {
@@ -17,6 +19,127 @@ export interface EvidenceReference {
 }
 
 const EVIDENCE_HASH_PATTERN = /^[A-Za-z0-9_-]{32,128}$/
+const METADATA_IP = '169.254.169.254'
+
+export interface DnsLookupAddress {
+  address: string
+  family: number
+}
+
+export type EvidenceDnsResolver = (
+  hostname: string,
+  options: { all: true; verbatim: true },
+) => Promise<DnsLookupAddress[]>
+
+function getEvidenceAllowedHosts(): string[] {
+  return (process.env.EVIDENCE_ALLOWED_HOSTS ?? process.env.WEBHOOK_ALLOWED_HOSTS ?? '')
+    .split(',')
+    .map((host) => host.trim().replace(/\.$/, '').toLowerCase())
+    .filter(Boolean)
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[|\]$/g, '').replace(/\.$/, '').toLowerCase()
+}
+
+function normalizeIpv4MappedAddress(address: string): string {
+  const normalized = normalizeHostname(address)
+  const dottedMatch = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i)
+  if (dottedMatch) return dottedMatch[1]
+
+  const hexMatch = normalized.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i)
+  if (!hexMatch) return normalized
+
+  const high = Number.parseInt(hexMatch[1], 16)
+  const low = Number.parseInt(hexMatch[2], 16)
+  return [
+    String((high >> 8) & 255),
+    String(high & 255),
+    String((low >> 8) & 255),
+    String(low & 255),
+  ].join('.')
+}
+
+function isBlockedIpAddress(address: string): boolean {
+  const normalized = normalizeIpv4MappedAddress(address)
+
+  if (isIP(normalized) === 4) {
+    return (
+      normalized === METADATA_IP ||
+      /^0\./.test(normalized) ||
+      /^10\./.test(normalized) ||
+      /^127\./.test(normalized) ||
+      /^169\.254\./.test(normalized) ||
+      /^172\.(1[6-9]|2[0-9]|3[01])\./.test(normalized) ||
+      /^192\.168\./.test(normalized)
+    )
+  }
+
+  if (isIP(normalized) === 6) {
+    if (normalized === '::1') return true
+    const firstGroup = Number.parseInt(normalized.split(':')[0] || '0', 16)
+    return (firstGroup & 0xfe00) === 0xfc00 || (firstGroup & 0xffc0) === 0xfe80
+  }
+
+  return false
+}
+
+function isAllowedEvidenceHost(hostname: string, allowedHosts = getEvidenceAllowedHosts()): boolean {
+  if (allowedHosts.length === 0) return true
+  return allowedHosts.some((host) => hostname === host || hostname.endsWith(`.${host}`))
+}
+
+export async function validateEvidenceReferenceUrlSafety(
+  referenceUrl: string,
+  resolver: EvidenceDnsResolver = lookup,
+): Promise<void> {
+  let url: URL
+  try {
+    url = new URL(referenceUrl)
+  } catch {
+    throw new EvidenceReferenceValidationError('evidenceReferenceUrl must be a valid URL')
+  }
+
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new EvidenceReferenceValidationError('evidenceReferenceUrl must use http or https')
+  }
+
+  const hostname = normalizeHostname(url.hostname)
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    /(?:^|\.)localtest\.me$/.test(hostname)
+  ) {
+    throw new EvidenceReferenceValidationError('evidenceReferenceUrl host is not permitted')
+  }
+
+  if (!isAllowedEvidenceHost(hostname)) {
+    throw new EvidenceReferenceValidationError('evidenceReferenceUrl host is not allowlisted')
+  }
+
+  if (isIP(hostname) !== 0) {
+    if (isBlockedIpAddress(hostname)) {
+      throw new EvidenceReferenceValidationError('evidenceReferenceUrl resolves to a private or internal address')
+    }
+    return
+  }
+
+  let resolved: DnsLookupAddress[]
+  try {
+    resolved = await resolver(hostname, { all: true, verbatim: true })
+  } catch {
+    throw new EvidenceReferenceValidationError('evidenceReferenceUrl host did not resolve')
+  }
+  if (resolved.length === 0) {
+    throw new EvidenceReferenceValidationError('evidenceReferenceUrl host did not resolve')
+  }
+
+  for (const record of resolved) {
+    if (isBlockedIpAddress(record.address)) {
+      throw new EvidenceReferenceValidationError('evidenceReferenceUrl resolves to a private or internal address')
+    }
+  }
+}
 
 function normalizeEvidenceHash(input: unknown): string {
   if (typeof input !== 'string') {
@@ -119,7 +242,9 @@ export async function createEvidenceReference(
   evidenceReferenceUrl: string,
 ): Promise<EvidenceReference> {
   const normalizedHash = normalizeEvidenceHash(evidenceHash)
-  const expiresAt = validateSignedObjectStorageUrl(evidenceReferenceUrl.trim())
+  const normalizedReferenceUrl = evidenceReferenceUrl.trim()
+  const expiresAt = validateSignedObjectStorageUrl(normalizedReferenceUrl)
+  await validateEvidenceReferenceUrlSafety(normalizedReferenceUrl)
   const now = new Date()
 
   const rows = await prisma.$queryRaw<
@@ -141,7 +266,7 @@ export async function createEvidenceReference(
     ) VALUES (
       ${verificationId},
       ${normalizedHash},
-      ${evidenceReferenceUrl.trim()},
+      ${normalizedReferenceUrl},
       ${expiresAt},
       ${now}
     )

--- a/src/tests/evidence.ssrf.test.ts
+++ b/src/tests/evidence.ssrf.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeAll, describe, expect, it, mock } from 'bun:test'
+import type { EvidenceDnsResolver } from '../services/evidence.js'
+
+mock.module('../lib/prisma.js', () => ({
+  prisma: {
+    $queryRaw: mock(async () => []),
+  },
+}))
+
+let validateEvidenceReferenceUrlSafety: typeof import('../services/evidence.js').validateEvidenceReferenceUrlSafety
+
+beforeAll(async () => {
+  ;({ validateEvidenceReferenceUrlSafety } = await import('../services/evidence.js'))
+})
+
+const publicResolver = (address = '93.184.216.34'): EvidenceDnsResolver =>
+  async () => [{ address, family: address.includes(':') ? 6 : 4 }]
+
+const futureUrl = (host: string, protocol = 'https') =>
+  `${protocol}://${host}/evidence.pdf?Expires=${Math.floor(Date.now() / 1000) + 3600}`
+
+describe('evidence SSRF guard', () => {
+  afterEach(() => {
+    delete process.env.EVIDENCE_ALLOWED_HOSTS
+    delete process.env.WEBHOOK_ALLOWED_HOSTS
+  })
+
+  it('blocks loopback, RFC1918, link-local, and metadata IP references', async () => {
+    const blocked = [
+      futureUrl('127.0.0.1'),
+      futureUrl('10.0.0.5'),
+      futureUrl('172.16.4.5'),
+      futureUrl('192.168.1.25'),
+      futureUrl('169.254.1.10'),
+      futureUrl('169.254.169.254'),
+      `${futureUrl('2852039166')}`,
+      `${futureUrl('0xa9fea9fe')}`,
+      futureUrl('[::1]'),
+      futureUrl('[::ffff:169.254.169.254]'),
+      futureUrl('[fe80::1]'),
+      futureUrl('[fc00::1]'),
+    ]
+
+    for (const url of blocked) {
+      await expect(validateEvidenceReferenceUrlSafety(url, publicResolver())).rejects.toThrow(
+        /not permitted|private or internal/,
+      )
+    }
+  })
+
+  it('blocks localhost-style rebinding hostnames before DNS lookup', async () => {
+    await expect(validateEvidenceReferenceUrlSafety(futureUrl('localhost'), publicResolver())).rejects.toThrow(
+      /not permitted/,
+    )
+    await expect(validateEvidenceReferenceUrlSafety(futureUrl('hook.localtest.me'), publicResolver())).rejects.toThrow(
+      /not permitted/,
+    )
+  })
+
+  it('re-checks every resolved DNS address to block rebinding to private IPs', async () => {
+    const rebindingResolver: EvidenceDnsResolver = async () => [
+      { address: '93.184.216.34', family: 4 },
+      { address: '10.10.10.10', family: 4 },
+    ]
+
+    await expect(
+      validateEvidenceReferenceUrlSafety(futureUrl('storage.example.com'), rebindingResolver),
+    ).rejects.toThrow(/private or internal/)
+  })
+
+  it('enforces the evidence host allowlist while allowing public resolved hosts', async () => {
+    process.env.EVIDENCE_ALLOWED_HOSTS = 'storage.example.com'
+
+    await expect(
+      validateEvidenceReferenceUrlSafety(futureUrl('tenant.storage.example.com'), publicResolver()),
+    ).resolves.toBeUndefined()
+
+    await expect(
+      validateEvidenceReferenceUrlSafety(futureUrl('attacker.example.com'), publicResolver()),
+    ).rejects.toThrow(/not allowlisted/)
+  })
+
+  it('falls back to WEBHOOK_ALLOWED_HOSTS for shared outbound URL policy', async () => {
+    process.env.WEBHOOK_ALLOWED_HOSTS = 'hooks.example.com'
+
+    await expect(
+      validateEvidenceReferenceUrlSafety(futureUrl('evidence.hooks.example.com'), publicResolver()),
+    ).resolves.toBeUndefined()
+
+    await expect(
+      validateEvidenceReferenceUrlSafety(futureUrl('storage.example.com'), publicResolver()),
+    ).rejects.toThrow(/not allowlisted/)
+  })
+
+  it('rejects non-http schemes before DNS lookup', async () => {
+    await expect(
+      validateEvidenceReferenceUrlSafety('file:///etc/passwd?Expires=32503680000', publicResolver()),
+    ).rejects.toThrow(/must use http or https/)
+  })
+})


### PR DESCRIPTION
Fixes #746

## Summary
- add evidence reference URL SSRF validation before object-storage URLs are persisted
- block localhost-style names, metadata IPs, RFC1918, loopback, link-local, and unique-local IPv6 targets
- resolve DNS and reject any private/internal address to cover DNS rebinding
- support EVIDENCE_ALLOWED_HOSTS with WEBHOOK_ALLOWED_HOSTS fallback for shared outbound URL policy
- document the evidence URL policy and add focused Bun tests

## Validation
- C:\Users\jhona\.bun\bin\bun.exe test src/tests/evidence.ssrf.test.ts
- npx tsc --noEmit --pretty false --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --esModuleInterop src\services\evidence.ts
- git diff --check

## Reward
GrantFox / Stellar Wave issue #746. Payment wallet: 0x06f44f4839fd5df4f4670036d028b29dec939363