### PR TITLE
security: add CSRF protection for cookie auth

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -134,6 +134,23 @@ Request headers such as `x-user-role`, `x-requested-role`, or any other role-bea
 
 The only trusted source of role information is `req.user.role`, which is set only after cryptographic JWT verification.
 
+### CSRF Protection for Cookie Auth
+
+State-changing requests (`POST`, `PUT`, `PATCH`, `DELETE`) that carry cookies and do not use `Authorization: Bearer ...` or `x-api-key` must pass CSRF validation before route handlers run.
+
+Accepted CSRF proofs:
+
+- Double-submit token: `csrf_token` cookie matches the `x-csrf-token` header.
+- Same-origin browser request: `Origin` or `Referer` matches the request host/protocol.
+
+Bearer-token and API-key requests are exempt because browsers do not attach those credentials automatically cross-site. Cookie-authenticated requests that fail CSRF validation return:
+
+```json
+{
+  "error": "CSRF validation failed."
+}
+```
+
 ### Authentication Before Authorization
 
 The middleware chain enforces **authentication before authorization**:

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import { privacyLogger } from './middleware/privacy-logger.js'
 import { AUTH_JSON_MAX_BYTES, JOBS_JSON_MAX_BYTES } from './middleware/requestBodyLimits.js'
 import { adminRouter } from './routes/admin.js'
 import { notificationsRouter } from './routes/notifications.js'
+import { authenticate, csrfProtection } from './middleware/auth.js'
 
 export const app = express()
 
@@ -141,7 +142,7 @@ const corsOptions: cors.CorsOptions = {
     }
   },
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'idempotency-key'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'idempotency-key', 'x-csrf-token'],
   credentials: true,
 }
 
@@ -151,6 +152,7 @@ app.use(cors(corsOptions))
 app.use('/api/auth', express.json({ limit: AUTH_JSON_MAX_BYTES }))
 app.use('/api/jobs/enqueue', express.json({ limit: JOBS_JSON_MAX_BYTES }))
 app.use(express.json())
+app.use(csrfProtection)
 
 app.use((_req, res, next) => {
   res.setHeader('X-Timezone', 'UTC')
@@ -162,7 +164,6 @@ app.use(privacyLogger)
 // Core routes mounted here for test compatibility
 app.use('/api/admin', adminRouter)
 import { metricsRouter } from './routes/metrics.js';
-import { authenticate } from './middleware/auth.js'
 import { requireAdmin } from './middleware/rbac.js'
 import { metricsRateLimiter } from './middleware/rateLimiter.js'
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -13,6 +13,103 @@ export type Role = 'user' | 'verifier' | 'admin'
 export type JwtPayload = JWTPayload & { jti?: string }
 
 const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production'
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+const CSRF_COOKIE_NAME = 'csrf_token'
+const CSRF_HEADER_NAME = 'x-csrf-token'
+
+function parseCookieHeader(cookieHeader: string | undefined): Map<string, string> {
+    const cookies = new Map<string, string>()
+    if (!cookieHeader) return cookies
+
+    for (const part of cookieHeader.split(';')) {
+        const separatorIndex = part.indexOf('=')
+        if (separatorIndex === -1) continue
+        const name = part.slice(0, separatorIndex).trim()
+        const value = part.slice(separatorIndex + 1).trim()
+        if (name) cookies.set(name, value)
+    }
+
+    return cookies
+}
+
+function timingSafeStringEqual(left: string, right: string): boolean {
+    const leftBuffer = Buffer.from(left)
+    const rightBuffer = Buffer.from(right)
+    const maxLength = Math.max(leftBuffer.length, rightBuffer.length, 1)
+    const paddedLeft = Buffer.alloc(maxLength)
+    const paddedRight = Buffer.alloc(maxLength)
+
+    leftBuffer.copy(paddedLeft)
+    rightBuffer.copy(paddedRight)
+
+    return crypto.timingSafeEqual(paddedLeft, paddedRight) && leftBuffer.length === rightBuffer.length
+}
+
+function hasBearerAuth(req: Request): boolean {
+    return req.header('authorization')?.startsWith('Bearer ') ?? false
+}
+
+function hasApiKeyAuth(req: Request): boolean {
+    return Boolean(req.header('x-api-key'))
+}
+
+function normalizeOrigin(value: string | undefined): string | null {
+    if (!value) return null
+    try {
+        const url = new URL(value)
+        return `${url.protocol}//${url.host}`.toLowerCase()
+    } catch {
+        return null
+    }
+}
+
+function getRequestOrigin(req: Request): string | null {
+    const forwardedHost = req.header('x-forwarded-host')?.split(',')[0]?.trim()
+    const host = forwardedHost || req.header('host')
+    if (!host) return null
+
+    const forwardedProto = req.header('x-forwarded-proto')?.split(',')[0]?.trim()
+    const protocol = forwardedProto || req.protocol || (req.secure ? 'https' : 'http')
+    return `${protocol}://${host}`.toLowerCase()
+}
+
+function isSameOrigin(req: Request): boolean {
+    const suppliedOrigin = normalizeOrigin(req.header('origin') || req.header('referer'))
+    const requestOrigin = getRequestOrigin(req)
+    return Boolean(suppliedOrigin && requestOrigin && suppliedOrigin === requestOrigin)
+}
+
+function hasValidDoubleSubmitToken(req: Request): boolean {
+    const cookies = parseCookieHeader(req.header('cookie'))
+    const cookieToken = cookies.get(CSRF_COOKIE_NAME)
+    const headerToken = req.header(CSRF_HEADER_NAME)
+
+    return Boolean(cookieToken && headerToken && timingSafeStringEqual(cookieToken, headerToken))
+}
+
+export function csrfProtection(req: Request, res: Response, next: NextFunction): void {
+    if (!MUTATING_METHODS.has(req.method.toUpperCase())) {
+        next()
+        return
+    }
+
+    if (hasBearerAuth(req) || hasApiKeyAuth(req)) {
+        next()
+        return
+    }
+
+    if (!req.header('cookie')) {
+        next()
+        return
+    }
+
+    if (hasValidDoubleSubmitToken(req) || isSameOrigin(req)) {
+        next()
+        return
+    }
+
+    res.status(403).json({ error: 'CSRF validation failed.' })
+}
 
 export async function authenticate(req: Request, res: Response, next: NextFunction): Promise<void> {
      const authHeader = req.headers.authorization

--- a/src/tests/csrf.test.ts
+++ b/src/tests/csrf.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test'
+import express from 'express'
+import request from 'supertest'
+import { csrfProtection } from '../middleware/auth.js'
+
+function buildApp() {
+  const app = express()
+  app.use(csrfProtection)
+  app.all('/mutate', (_req, res) => {
+    res.status(200).json({ ok: true })
+  })
+  return app
+}
+
+describe('CSRF protection for cookie-authenticated mutations', () => {
+  it('rejects cookie-authenticated mutating requests without CSRF proof', async () => {
+    const response = await request(buildApp())
+      .post('/mutate')
+      .set('Cookie', 'session=s1')
+
+    expect(response.status).toBe(403)
+    expect(response.body).toEqual({ error: 'CSRF validation failed.' })
+  })
+
+  it('accepts a valid double-submit CSRF token', async () => {
+    const response = await request(buildApp())
+      .post('/mutate')
+      .set('Cookie', 'session=s1; csrf_token=token-123')
+      .set('x-csrf-token', 'token-123')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({ ok: true })
+  })
+
+  it('accepts same-origin cookie-authenticated mutations', async () => {
+    const response = await request(buildApp())
+      .patch('/mutate')
+      .set('Host', 'api.example.test')
+      .set('Origin', 'http://api.example.test')
+      .set('Cookie', 'session=s1')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({ ok: true })
+  })
+
+  it('blocks cross-origin cookie-authenticated mutations', async () => {
+    const response = await request(buildApp())
+      .delete('/mutate')
+      .set('Host', 'api.example.test')
+      .set('Origin', 'https://evil.example.test')
+      .set('Cookie', 'session=s1')
+
+    expect(response.status).toBe(403)
+    expect(response.body).toEqual({ error: 'CSRF validation failed.' })
+  })
+
+  it('exempts bearer-authenticated requests from CSRF checks', async () => {
+    const response = await request(buildApp())
+      .post('/mutate')
+      .set('Origin', 'https://evil.example.test')
+      .set('Cookie', 'session=s1')
+      .set('Authorization', 'Bearer token')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({ ok: true })
+  })
+
+  it('exempts API-key authenticated requests from CSRF checks', async () => {
+    const response = await request(buildApp())
+      .post('/mutate')
+      .set('Origin', 'https://evil.example.test')
+      .set('Cookie', 'session=s1')
+      .set('x-api-key', 'dsk_test.secret')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({ ok: true })
+  })
+
+  it('does not enforce CSRF on safe methods', async () => {
+    const response = await request(buildApp())
+      .get('/mutate')
+      .set('Cookie', 'session=s1')
+
+    expect(response.status).toBe(200)
+    expect(response.body).toEqual({ ok: true })
+  })
+})


### PR DESCRIPTION
Fixes #750

## Summary
- add CSRF middleware for mutating cookie-authenticated requests
- exempt bearer-token and API-key requests from CSRF checks
- accept double-submit protection (`csrf_token` cookie + `x-csrf-token` header) or same-origin `Origin`/`Referer`
- wire the middleware into `src/app.ts` and allow `x-csrf-token` through CORS
- document the cookie-auth CSRF policy and add focused Bun tests

## Validation
- `C:\Users\jhona\.bun\bin\bun.exe test src/tests/csrf.test.ts`
- `git diff --check`

## Local note
- A targeted `tsc` run through `src/app.ts` still reaches existing baseline TypeScript errors from `origin/main` in env/jobs/auth-utils/apiKeys/notifications, so validation is the required Bun CSRF test plus diff check.

## Reward
GrantFox / Stellar Wave issue #750. Payment wallet: 0x06f44f4839fd5df4f4670036d028b29dec939363