### PR TITLE
perf: DataLoader-style analytics batch resolver

### DIFF
--- a/docs/analytics-metrics.md
+++ b/docs/analytics-metrics.md
@@ -58,6 +58,26 @@ Steps:
 - Partial data: empty periods are omitted from the response. Clients may expand to full ranges as needed.
 - Storage: events are in-memory for now; replace with a database or event store in production.
 
+## Vault/Milestone Batch Resolver
+
+`src/services/analytics.service.ts` exposes request-scoped analytics loaders via
+`createAnalyticsBatchLoaders({ organizationId })`. The vault/milestone loader
+coalesces same-tick per-vault reads into one keyed SQL query and relies on a
+fresh loader instance per request, so cached analytics never cross tenant or
+request boundaries.
+
+The batch query returns one aggregate per vault id:
+
+- vault status and amount
+- milestone count
+- completed, failed, and pending milestone counts
+- total milestone amount
+- completed milestone amount
+
+Repeated vault ids are deduplicated within a request. Missing or out-of-tenant
+vault ids resolve to zero-valued aggregates for that key, preserving response
+shape without leaking whether another tenant owns the id.
+
 ## Examples
 
 Trends example bucket:

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -12,6 +12,19 @@ type AnalyticsStatsRow = {
   active_capital: number | null
 }
 
+export type VaultMilestoneAnalyticsRow = {
+  vault_id: string
+  organization_id: string | null
+  vault_status: string | null
+  vault_amount: string
+  milestone_count: number
+  completed_milestones: number
+  failed_milestones: number
+  pending_milestones: number
+  total_milestone_amount: string
+  completed_milestone_amount: string
+}
+
 export type AnalyticsSummaryRow = {
   total_vaults: number
   active_vaults: number
@@ -26,7 +39,13 @@ export type AnalyticsSummaryRow = {
 const analyticsStorage = (process.env.ANALYTICS_STORAGE ?? '').toLowerCase()
 const shouldUsePostgres = analyticsStorage === 'postgres'
 
-const getPool = (): Pool => getPgPool()
+const getPool = (): Pool => {
+  const pool = getPgPool()
+  if (!pool) {
+    throw new Error('PostgreSQL pool is not configured')
+  }
+  return pool
+}
 
 const initializePostgresSchema = async (pool: Pool): Promise<void> => {
   await pool.query(`
@@ -210,6 +229,61 @@ export async function queryVaultStatusBreakdownAllTime(): Promise<Array<{ status
     'SELECT status, COUNT(*)::text as count FROM vaults GROUP BY status',
   )
   return rows.map((r) => ({ status: r.status, count: Number(r.count) }))
+}
+
+export async function queryVaultMilestoneAnalyticsBatch(
+  vaultIds: readonly string[],
+  organizationId?: string | null,
+): Promise<VaultMilestoneAnalyticsRow[]> {
+  const uniqueVaultIds = Array.from(new Set(vaultIds.filter((id) => typeof id === 'string' && id.length > 0)))
+  if (uniqueVaultIds.length === 0) return []
+
+  const params: unknown[] = [uniqueVaultIds]
+  const organizationFilter = organizationId
+    ? 'AND v.organization_id::text = $2'
+    : ''
+
+  if (organizationId) {
+    params.push(organizationId)
+  }
+
+  const pool = getPool()
+  const { rows } = await pool.query<VaultMilestoneAnalyticsRow>(
+    `SELECT
+        v.id AS vault_id,
+        v.organization_id::text AS organization_id,
+        v.status::text AS vault_status,
+        v.amount::text AS vault_amount,
+        COUNT(m.id)::int AS milestone_count,
+        COALESCE(SUM(CASE WHEN m.status = 'completed' THEN 1 ELSE 0 END), 0)::int AS completed_milestones,
+        COALESCE(SUM(CASE WHEN m.status = 'failed' THEN 1 ELSE 0 END), 0)::int AS failed_milestones,
+        COALESCE(
+          SUM(CASE WHEN m.id IS NOT NULL AND m.status NOT IN ('completed', 'failed') THEN 1 ELSE 0 END),
+          0
+        )::int AS pending_milestones,
+        COALESCE(SUM(CAST(m.amount AS numeric)), 0)::text AS total_milestone_amount,
+        COALESCE(
+          SUM(CASE WHEN m.status = 'completed' THEN CAST(m.amount AS numeric) ELSE 0 END),
+          0
+        )::text AS completed_milestone_amount
+      FROM vaults v
+      LEFT JOIN milestones m ON m.vault_id = v.id
+      WHERE v.id = ANY($1::text[])
+      ${organizationFilter}
+      GROUP BY v.id, v.organization_id, v.status, v.amount`,
+    params,
+  )
+
+  return rows.map((row) => ({
+    ...row,
+    milestone_count: Number(row.milestone_count ?? 0),
+    completed_milestones: Number(row.completed_milestones ?? 0),
+    failed_milestones: Number(row.failed_milestones ?? 0),
+    pending_milestones: Number(row.pending_milestones ?? 0),
+    vault_amount: String(row.vault_amount ?? '0'),
+    total_milestone_amount: String(row.total_milestone_amount ?? '0'),
+    completed_milestone_amount: String(row.completed_milestone_amount ?? '0'),
+  }))
 }
 
 export async function backfillAnalyticsStorage(): Promise<void> {

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -1,13 +1,104 @@
 import { 
   queryVaultStatsByPeriod,
+  queryVaultMilestoneAnalyticsBatch,
   queryVaultStatusBreakdownAllTime,
   queryVaultStatusBreakdownByPeriod,
   readAnalyticsSummary,
   updateAnalyticsSummary as dbUpdateSummary,
-  getTimeRangeFilter
+  getTimeRangeFilter,
+  type VaultMilestoneAnalyticsRow,
 } from '../db/database.js'
+import DataLoader from 'dataloader'
 import type { VaultAnalytics, VaultAnalyticsWithPeriod } from '../types/vault.js'
 import { utcNow } from '../utils/timestamps.js'
+
+export interface VaultMilestoneAnalytics {
+  vaultId: string
+  organizationId: string | null
+  vaultStatus: string | null
+  vaultAmount: string
+  milestoneCount: number
+  completedMilestones: number
+  failedMilestones: number
+  pendingMilestones: number
+  totalMilestoneAmount: string
+  completedMilestoneAmount: string
+}
+
+export type VaultMilestoneAnalyticsBatchQuery = (
+  vaultIds: readonly string[],
+  organizationId?: string | null,
+) => Promise<VaultMilestoneAnalyticsRow[]>
+
+export interface AnalyticsBatchLoaderOptions {
+  organizationId?: string | null
+  cache?: boolean
+  queryVaultMilestoneAnalytics?: VaultMilestoneAnalyticsBatchQuery
+}
+
+export interface AnalyticsBatchLoaders {
+  organizationId: string | null
+  vaultMilestoneAnalytics: DataLoader<string, VaultMilestoneAnalytics>
+}
+
+const emptyVaultMilestoneAnalytics = (vaultId: string, organizationId: string | null): VaultMilestoneAnalytics => ({
+  vaultId,
+  organizationId,
+  vaultStatus: null,
+  vaultAmount: '0',
+  milestoneCount: 0,
+  completedMilestones: 0,
+  failedMilestones: 0,
+  pendingMilestones: 0,
+  totalMilestoneAmount: '0',
+  completedMilestoneAmount: '0',
+})
+
+const mapVaultMilestoneAnalyticsRow = (row: VaultMilestoneAnalyticsRow): VaultMilestoneAnalytics => ({
+  vaultId: row.vault_id,
+  organizationId: row.organization_id,
+  vaultStatus: row.vault_status,
+  vaultAmount: String(row.vault_amount ?? '0'),
+  milestoneCount: Number(row.milestone_count ?? 0),
+  completedMilestones: Number(row.completed_milestones ?? 0),
+  failedMilestones: Number(row.failed_milestones ?? 0),
+  pendingMilestones: Number(row.pending_milestones ?? 0),
+  totalMilestoneAmount: String(row.total_milestone_amount ?? '0'),
+  completedMilestoneAmount: String(row.completed_milestone_amount ?? '0'),
+})
+
+export function createAnalyticsBatchLoaders(options: AnalyticsBatchLoaderOptions = {}): AnalyticsBatchLoaders {
+  const organizationId = options.organizationId ?? null
+  const queryVaultMilestoneAnalytics = options.queryVaultMilestoneAnalytics ?? queryVaultMilestoneAnalyticsBatch
+
+  return {
+    organizationId,
+    vaultMilestoneAnalytics: new DataLoader<string, VaultMilestoneAnalytics>(
+      async (vaultIds) => {
+        const uniqueVaultIds = Array.from(new Set(vaultIds))
+        const rows = await queryVaultMilestoneAnalytics(uniqueVaultIds, organizationId)
+        const byVaultId = new Map(rows.map((row) => [row.vault_id, mapVaultMilestoneAnalyticsRow(row)]))
+
+        return vaultIds.map((vaultId) => (
+          byVaultId.get(vaultId) ?? emptyVaultMilestoneAnalytics(vaultId, organizationId)
+        ))
+      },
+      { cache: options.cache ?? true },
+    ),
+  }
+}
+
+export async function getVaultMilestoneAnalytics(
+  vaultIds: readonly string[],
+  loaders: AnalyticsBatchLoaders = createAnalyticsBatchLoaders(),
+): Promise<VaultMilestoneAnalytics[]> {
+  const results = await loaders.vaultMilestoneAnalytics.loadMany(vaultIds)
+
+  return results.map((result) => {
+    if (result instanceof Error) throw result
+    return result
+  })
+}
 
 export async function getOverallAnalytics(): Promise<VaultAnalytics> {
   const summary = await readAnalyticsSummary()

--- a/src/tests/performance/analyticsBatch.perf.test.ts
+++ b/src/tests/performance/analyticsBatch.perf.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  createAnalyticsBatchLoaders,
+  getVaultMilestoneAnalytics,
+  type VaultMilestoneAnalyticsBatchQuery,
+} from '../../services/analytics.service.js'
+import type { VaultMilestoneAnalyticsRow } from '../../db/database.js'
+
+const makeRow = (
+  vaultId: string,
+  organizationId: string,
+  overrides: Partial<VaultMilestoneAnalyticsRow> = {},
+): VaultMilestoneAnalyticsRow => ({
+  vault_id: vaultId,
+  organization_id: organizationId,
+  vault_status: 'active',
+  vault_amount: '1000.0000000',
+  milestone_count: 3,
+  completed_milestones: 2,
+  failed_milestones: 0,
+  pending_milestones: 1,
+  total_milestone_amount: '1000.0000000',
+  completed_milestone_amount: '700.0000000',
+  ...overrides,
+})
+
+const makeCountingQuery = (rows: VaultMilestoneAnalyticsRow[]) => {
+  const calls: Array<{ vaultIds: string[]; organizationId: string | null | undefined }> = []
+
+  const query: VaultMilestoneAnalyticsBatchQuery = async (vaultIds, organizationId) => {
+    calls.push({ vaultIds: [...vaultIds], organizationId })
+    return rows.filter((row) => (
+      vaultIds.includes(row.vault_id) &&
+      (organizationId == null || row.organization_id === organizationId)
+    ))
+  }
+
+  return { calls, query }
+}
+
+describe('analytics batch resolver', () => {
+  it('coalesces same-tick per-vault analytics reads and deduplicates repeated keys', async () => {
+    const { calls, query } = makeCountingQuery([
+      makeRow('vault-a', 'org-a'),
+      makeRow('vault-b', 'org-a', { completed_milestones: 1, pending_milestones: 2 }),
+    ])
+    const loaders = createAnalyticsBatchLoaders({ organizationId: 'org-a', queryVaultMilestoneAnalytics: query })
+
+    const [first, second, duplicate] = await Promise.all([
+      loaders.vaultMilestoneAnalytics.load('vault-a'),
+      loaders.vaultMilestoneAnalytics.load('vault-b'),
+      loaders.vaultMilestoneAnalytics.load('vault-a'),
+    ])
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.organizationId).toBe('org-a')
+    expect(calls[0]!.vaultIds.sort()).toEqual(['vault-a', 'vault-b'])
+    expect(first).toEqual(duplicate)
+    expect(second).toMatchObject({
+      vaultId: 'vault-b',
+      completedMilestones: 1,
+      pendingMilestones: 2,
+      totalMilestoneAmount: '1000.0000000',
+    })
+  })
+
+  it('reduces representative org analytics query count from one-per-vault to one batch query', async () => {
+    const vaultIds = Array.from({ length: 50 }, (_, index) => `vault-${index}`)
+    const { calls, query } = makeCountingQuery(vaultIds.map((vaultId) => makeRow(vaultId, 'org-a')))
+    const loaders = createAnalyticsBatchLoaders({ organizationId: 'org-a', queryVaultMilestoneAnalytics: query })
+
+    const results = await getVaultMilestoneAnalytics(vaultIds, loaders)
+
+    expect(results).toHaveLength(vaultIds.length)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.vaultIds).toHaveLength(vaultIds.length)
+    expect(calls.length).toBeLessThan(vaultIds.length)
+  })
+
+  it('preserves aggregate parity and returns zero aggregates for missing tenant-scoped rows', async () => {
+    const { query } = makeCountingQuery([
+      makeRow('vault-a', 'org-a', {
+        vault_status: 'completed',
+        vault_amount: '42.1250000',
+        milestone_count: 4,
+        completed_milestones: 3,
+        failed_milestones: 1,
+        pending_milestones: 0,
+        total_milestone_amount: '42.1250000',
+        completed_milestone_amount: '31.5000000',
+      }),
+    ])
+    const loaders = createAnalyticsBatchLoaders({ organizationId: 'org-a', queryVaultMilestoneAnalytics: query })
+
+    const [existing, missing] = await getVaultMilestoneAnalytics(['vault-a', 'vault-missing'], loaders)
+
+    expect(existing).toEqual({
+      vaultId: 'vault-a',
+      organizationId: 'org-a',
+      vaultStatus: 'completed',
+      vaultAmount: '42.1250000',
+      milestoneCount: 4,
+      completedMilestones: 3,
+      failedMilestones: 1,
+      pendingMilestones: 0,
+      totalMilestoneAmount: '42.1250000',
+      completedMilestoneAmount: '31.5000000',
+    })
+    expect(missing).toEqual({
+      vaultId: 'vault-missing',
+      organizationId: 'org-a',
+      vaultStatus: null,
+      vaultAmount: '0',
+      milestoneCount: 0,
+      completedMilestones: 0,
+      failedMilestones: 0,
+      pendingMilestones: 0,
+      totalMilestoneAmount: '0',
+      completedMilestoneAmount: '0',
+    })
+  })
+
+  it('does not leak cached analytics across tenant/request loader contexts', async () => {
+    const { calls, query } = makeCountingQuery([
+      makeRow('shared-vault-id', 'org-a', { vault_amount: '10.0000000' }),
+      makeRow('shared-vault-id', 'org-b', { vault_amount: '999.0000000' }),
+    ])
+    const orgALoaders = createAnalyticsBatchLoaders({ organizationId: 'org-a', queryVaultMilestoneAnalytics: query })
+    const orgBLoaders = createAnalyticsBatchLoaders({ organizationId: 'org-b', queryVaultMilestoneAnalytics: query })
+
+    const [orgAResult, orgBResult] = await Promise.all([
+      orgALoaders.vaultMilestoneAnalytics.load('shared-vault-id'),
+      orgBLoaders.vaultMilestoneAnalytics.load('shared-vault-id'),
+    ])
+
+    expect(orgAResult.vaultAmount).toBe('10.0000000')
+    expect(orgBResult.vaultAmount).toBe('999.0000000')
+    expect(calls).toHaveLength(2)
+    expect(calls.map((call) => call.organizationId).sort()).toEqual(['org-a', 'org-b'])
+  })
+})


### PR DESCRIPTION
## Summary
- Add a request-scoped DataLoader-style analytics batch context in `src/services/analytics.service.ts`.
- Add one keyed PostgreSQL batch query for vault/milestone aggregates in `src/db/database.ts`.
- Cover batching, repeated-key dedupe, query-count reduction, aggregate parity, and tenant/request cache isolation in `src/tests/performance/analyticsBatch.perf.test.ts`.
- Document the batch resolver behavior in `docs/analytics-metrics.md`.

Fixes #755

## Validation
- `C:\Users\jhona\.bun\bin\bun.exe test src\tests\performance\analyticsBatch.perf.test.ts` (4 pass)
- `git diff --check`
- Attempted targeted TypeScript check: `npx tsc --noEmit --pretty false --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --esModuleInterop --skipLibCheck src\db\database.ts src\services\analytics.service.ts`
  - Still blocked by existing baseline errors in `src/config/env.ts` (`TS1117` duplicate property and `EnvWarning.variable` shape errors); no new touched-file TypeScript errors after the local `getPool()` null guard.
- Attempted existing `bun test src\tests\analytics.storage.test.ts`; blocked by existing test setup/env initialization (`Environment not validated yet - call initEnv() first`).

## Reward / payout
- Potential reward basis: GrantFox / Stellar Wave issue #755, subject to maintainer review and campaign eligibility.
- USDT Ethereum payout address: `0x06f44f4839fd5df4f4670036d028b29dec939363`