### PR TITLE
Harden S3 evidence object-key validation

### DIFF
--- a/docs/evidence-storage.md
+++ b/docs/evidence-storage.md
@@ -21,11 +21,19 @@ This service stores signed object-storage references for verification evidence w
 - `POST /api/verifications` now accepts `evidenceHash` and `evidenceReferenceUrl`.
 - `evidenceHash` must be a non-empty alphanumeric-hyphen-underscore string between 32 and 128 characters.
 - `evidenceReferenceUrl` must be an HTTP/HTTPS signed object-storage URL.
+- Object-storage paths are rejected when they contain leading empty segments, `.` or `..` path traversal segments, backslashes, null bytes, or line breaks. Percent-encoded variants such as `%2e%2e` and `%00` are decoded before validation.
+- Signed URL response content-type overrides, when present, must use the storage allowlist. Unsafe browser-executable types such as `text/html` and JavaScript content types are rejected.
 - URL expiry is validated by parsing one of:
   - `X-Amz-Expires` with `X-Amz-Date`
   - `Expires`
   - `expires`
 - Expired URLs are rejected.
+
+## Export object keys
+
+S3 export uploads use tenant-scoped keys in the form `exports/<requesting-user-id>/<job-id>/<filename>`.
+Each path segment is validated before upload or pre-signing so a caller cannot overwrite a sibling tenant's object with `../`, leading slash, absolute filesystem path, encoded traversal, or null-byte input.
+Export uploads also enforce a content-type allowlist for CSV, JSON, NDJSON, gzip, PDF/image/text evidence-style objects. HTML, opaque binary, and executable/script MIME types are intentionally excluded.
 
 ## Persistence
 

--- a/src/services/evidence.ts
+++ b/src/services/evidence.ts
@@ -1,4 +1,9 @@
 import { prisma } from '../lib/prisma.js'
+import {
+  S3ObjectValidationError,
+  validateObjectStorageResponseContentType,
+  validateObjectStorageUrlPath,
+} from './exportS3.js'
 
 export class EvidenceReferenceValidationError extends Error {
   constructor(message: string) {
@@ -107,6 +112,16 @@ function getSignedUrlExpiry(referenceUrl: string): Date {
 
 export function validateSignedObjectStorageUrl(referenceUrl: string): Date {
   const expiry = getSignedUrlExpiry(referenceUrl)
+  try {
+    validateObjectStorageUrlPath(referenceUrl)
+    validateObjectStorageResponseContentType(referenceUrl)
+  } catch (error) {
+    if (error instanceof S3ObjectValidationError) {
+      throw new EvidenceReferenceValidationError(error.message)
+    }
+    throw error
+  }
+
   if (expiry.getTime() <= Date.now()) {
     throw new EvidenceReferenceValidationError('Signed object-storage URL has already expired')
   }

--- a/src/services/exportQueue.ts
+++ b/src/services/exportQueue.ts
@@ -6,7 +6,7 @@ import type { BackgroundJobSystem } from '../jobs/system.js'
 import { Readable, Transform } from 'node:stream'
 import { createGzip, gzipSync } from 'node:zlib'
 import { maskPii, sanitizePrivacyPayload, sanitizePrivacyString } from '../utils/privacy.js'
-import { resolveS3Config, uploadToS3 } from '../services/exportS3.js'
+import { buildExportS3Key, resolveS3Config, uploadToS3 } from '../services/exportS3.js'
 
 export type ExportFormat = 'csv' | 'json' | 'ndjson'
 export type ExportScope = 'vaults' | 'transactions' | 'analytics' | 'all'
@@ -729,7 +729,7 @@ export async function processJob(
     const s3Config = resolveS3Config()
     let s3Key: string | undefined
     if (s3Config) {
-      const key = `exports/${job.id}/${filename}`
+      const key = buildExportS3Key(job.userId, job.id, filename)
       const contentType = job.format === 'csv'
         ? 'text/csv; charset=utf-8'
         : job.format === 'json'
@@ -748,7 +748,7 @@ export async function processJob(
       attempts: nextAttempt,
       completedAt: new Date().toISOString(),
       error: undefined,
-      result: job.format === 'ndjson' ? undefined : buffer,
+      result: s3Key || job.format === 'ndjson' ? undefined : buffer,
       filename,
       s3Key,
     })

--- a/src/services/exportS3.ts
+++ b/src/services/exportS3.ts
@@ -17,6 +17,208 @@ export interface S3Config {
   signedUrlTtlSeconds: number
 }
 
+export class S3ObjectValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'S3ObjectValidationError'
+  }
+}
+
+const ALLOWED_OBJECT_STORAGE_CONTENT_TYPES = new Set([
+  'application/gzip',
+  'application/json',
+  'application/pdf',
+  'application/x-ndjson',
+  'image/jpeg',
+  'image/png',
+  'text/csv',
+  'text/plain',
+])
+
+const RESPONSE_CONTENT_TYPE_QUERY_PARAMS = [
+  'response-content-type',
+  'ResponseContentType',
+  'responseContentType',
+]
+
+function decodeObjectKey(input: string): string {
+  try {
+    return decodeURIComponent(input)
+  } catch {
+    throw new S3ObjectValidationError('S3 object key contains invalid percent-encoding')
+  }
+}
+
+function validateDecodedObjectKey(decodedKey: string): void {
+  if (decodedKey.length === 0) {
+    throw new S3ObjectValidationError('S3 object key must not be empty')
+  }
+
+  if (decodedKey.startsWith('/')) {
+    throw new S3ObjectValidationError('S3 object key must not start with a slash')
+  }
+
+  if (decodedKey.includes('\\')) {
+    throw new S3ObjectValidationError('S3 object key must not contain backslashes')
+  }
+
+  const segments = decodedKey.split('/')
+  for (const segment of segments) {
+    if (segment === '') {
+      throw new S3ObjectValidationError('S3 object key must not contain empty path segments')
+    }
+
+    if (segment === '.' || segment === '..') {
+      throw new S3ObjectValidationError('S3 object key must not contain dot path segments')
+    }
+
+    if (segment.includes('\0')) {
+      throw new S3ObjectValidationError('S3 object key segment must not contain null bytes')
+    }
+
+    if (/[\r\n]/.test(segment)) {
+      throw new S3ObjectValidationError('S3 object key segment must not contain line breaks')
+    }
+  }
+}
+
+function extractRawUrlPath(referenceUrl: string): string | undefined {
+  const schemeIndex = referenceUrl.indexOf('://')
+  if (schemeIndex === -1) return undefined
+
+  const authorityStart = schemeIndex + 3
+  const pathStart = referenceUrl.indexOf('/', authorityStart)
+  if (pathStart === -1) return ''
+
+  const pathAndLater = referenceUrl.slice(pathStart)
+  const pathEnd = pathAndLater.search(/[?#]/)
+  return pathEnd === -1 ? pathAndLater : pathAndLater.slice(0, pathEnd)
+}
+
+function contentDispositionFilename(key: string): string {
+  const finalSegment = key.split('/').pop() ?? 'download'
+  return finalSegment.replace(/["\\]/g, '_')
+}
+
+export function validateS3ObjectKey(key: string): string {
+  if (typeof key !== 'string') {
+    throw new S3ObjectValidationError('S3 object key must be a string')
+  }
+
+  const normalizedKey = key.trim()
+  if (normalizedKey.length === 0) {
+    throw new S3ObjectValidationError('S3 object key must not be empty')
+  }
+
+  if (normalizedKey.startsWith('/')) {
+    throw new S3ObjectValidationError('S3 object key must not start with a slash')
+  }
+
+  if (/^[A-Za-z]:[\\/]/.test(normalizedKey)) {
+    throw new S3ObjectValidationError('S3 object key must not be an absolute filesystem path')
+  }
+
+  validateDecodedObjectKey(decodeObjectKey(normalizedKey))
+  return normalizedKey
+}
+
+export function sanitizeS3KeySegment(segment: string, label = 'S3 object key segment'): string {
+  if (typeof segment !== 'string') {
+    throw new S3ObjectValidationError(`${label} must be a string`)
+  }
+
+  const normalizedSegment = segment.trim()
+  if (normalizedSegment.length === 0) {
+    throw new S3ObjectValidationError(`${label} must not be empty`)
+  }
+
+  const decodedSegment = decodeObjectKey(normalizedSegment)
+  if (
+    decodedSegment === '.'
+    || decodedSegment === '..'
+    || decodedSegment.includes('/')
+    || decodedSegment.includes('\\')
+    || decodedSegment.includes('\0')
+    || /[\r\n]/.test(decodedSegment)
+  ) {
+    throw new S3ObjectValidationError(`${label} contains an unsafe path segment`)
+  }
+
+  return normalizedSegment
+}
+
+export function buildExportS3Key(userId: string, jobId: string, filename: string): string {
+  return validateS3ObjectKey([
+    'exports',
+    sanitizeS3KeySegment(userId, 'export owner id'),
+    sanitizeS3KeySegment(jobId, 'export job id'),
+    sanitizeS3KeySegment(filename, 'export filename'),
+  ].join('/'))
+}
+
+export function assertAllowedS3ContentType(contentType: string): string {
+  if (typeof contentType !== 'string') {
+    throw new S3ObjectValidationError('S3 object content type must be a string')
+  }
+
+  const normalizedContentType = contentType.trim()
+  if (normalizedContentType.length === 0) {
+    throw new S3ObjectValidationError('S3 object content type must not be empty')
+  }
+
+  if (/[\0\r\n]/.test(normalizedContentType)) {
+    throw new S3ObjectValidationError('S3 object content type contains unsafe control characters')
+  }
+
+  const baseContentType = normalizedContentType.split(';', 1)[0].trim().toLowerCase()
+  if (!ALLOWED_OBJECT_STORAGE_CONTENT_TYPES.has(baseContentType)) {
+    throw new S3ObjectValidationError(`S3 object content type is not allowed: ${baseContentType}`)
+  }
+
+  return normalizedContentType
+}
+
+export function validateObjectStorageUrlPath(referenceUrl: string): void {
+  let url: URL
+  try {
+    url = new URL(referenceUrl)
+  } catch {
+    throw new S3ObjectValidationError('Object-storage URL must be a valid URL')
+  }
+
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new S3ObjectValidationError('Object-storage URL must use http or https')
+  }
+
+  const rawPath = extractRawUrlPath(referenceUrl) ?? url.pathname
+  if (rawPath === '' || rawPath === '/') {
+    throw new S3ObjectValidationError('Object-storage URL path must include an object key')
+  }
+
+  if (rawPath.startsWith('//')) {
+    throw new S3ObjectValidationError('Object-storage URL path must not start with an empty segment')
+  }
+
+  validateS3ObjectKey(rawPath.startsWith('/') ? rawPath.slice(1) : rawPath)
+}
+
+export function validateObjectStorageResponseContentType(referenceUrl: string): void {
+  let url: URL
+  try {
+    url = new URL(referenceUrl)
+  } catch {
+    throw new S3ObjectValidationError('Object-storage URL must be a valid URL')
+  }
+
+  const responseContentType = RESPONSE_CONTENT_TYPE_QUERY_PARAMS
+    .map((param) => url.searchParams.get(param))
+    .find((value): value is string => typeof value === 'string' && value.trim() !== '')
+
+  if (responseContentType) {
+    assertAllowedS3ContentType(responseContentType)
+  }
+}
+
 /** Resolve S3 config from environment.  Returns undefined when not configured. */
 export function resolveS3Config(env: NodeJS.ProcessEnv = process.env): S3Config | undefined {
   const bucket = env.EXPORT_S3_BUCKET
@@ -55,15 +257,17 @@ export function resetPresigner(): void {
  * Uses @aws-sdk/lib-storage for multipart-safe, streaming uploads.
  */
 export async function uploadToS3(config: S3Config, key: string, data: Buffer | Readable, contentType: string): Promise<void> {
+  const safeKey = validateS3ObjectKey(key)
+  const safeContentType = assertAllowedS3ContentType(contentType)
   const client = _clientFactory(config.region)
   const upload = new Upload({
     client,
     params: {
       Bucket: config.bucket,
-      Key: key,
+      Key: safeKey,
       Body: data instanceof Buffer ? Readable.from(data) : data,
-      ContentType: contentType,
-      ContentDisposition: `attachment; filename="${key.split('/').pop()}"`,
+      ContentType: safeContentType,
+      ContentDisposition: `attachment; filename="${contentDispositionFilename(safeKey)}"`,
     },
   })
   await upload.done()
@@ -73,8 +277,9 @@ export async function uploadToS3(config: S3Config, key: string, data: Buffer | R
  * Return a pre-signed GET URL valid for `ttlSeconds`.
  */
 export async function getExportSignedUrl(config: S3Config, key: string): Promise<string> {
+  const safeKey = validateS3ObjectKey(key)
   const client = _clientFactory(config.region)
-  return _presigner(client, new GetObjectCommand({ Bucket: config.bucket, Key: key }), {
+  return _presigner(client, new GetObjectCommand({ Bucket: config.bucket, Key: safeKey }), {
     expiresIn: config.signedUrlTtlSeconds,
   })
 }

--- a/src/tests/exportQueue.s3.test.ts
+++ b/src/tests/exportQueue.s3.test.ts
@@ -159,7 +159,7 @@ describe('Export S3 integration', () => {
     const completed = await import('../services/exportQueue.js').then((m) => m.getJob(job.id))
 
     expect(completed?.status).toBe('done')
-    expect(completed?.s3Key).toMatch(/^exports\/[a-f0-9-]+\/export-.*\.csv$/)
+    expect(completed?.s3Key).toMatch(/^exports\/user-s3\/[a-f0-9-]+\/export-.*\.csv$/)
     expect(completed?.result).toBeUndefined()
     expect(completed?.filename).toContain('.csv')
 

--- a/src/tests/exportS3.traversal.test.ts
+++ b/src/tests/exportS3.traversal.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { Buffer } from 'node:buffer'
+import {
+  assertAllowedS3ContentType,
+  buildExportS3Key,
+  resetS3ClientFactory,
+  S3ObjectValidationError,
+  setS3ClientFactory,
+  uploadToS3,
+  validateObjectStorageResponseContentType,
+  validateObjectStorageUrlPath,
+  validateS3ObjectKey,
+} from '../services/exportS3.js'
+import {
+  EvidenceReferenceValidationError,
+  validateSignedObjectStorageUrl,
+} from '../services/evidence.js'
+
+describe('S3 object key traversal and content-type guards', () => {
+  afterEach(() => {
+    resetS3ClientFactory()
+  })
+
+  it('builds tenant-prefixed export keys from safe segments', () => {
+    expect(buildExportS3Key('user-123', 'job-456', 'export-2026.csv'))
+      .toBe('exports/user-123/job-456/export-2026.csv')
+  })
+
+  it('rejects object keys with traversal, absolute paths, null bytes, or empty segments', () => {
+    const invalidKeys = [
+      '/exports/user/job/export.csv',
+      'exports/user/../export.csv',
+      'exports/user/%2e%2e/export.csv',
+      'exports/user//export.csv',
+      'exports/user\\job\\export.csv',
+      'exports/user/job/export.csv\0',
+      'C:\\exports\\user\\export.csv',
+    ]
+
+    for (const key of invalidKeys) {
+      expect(() => validateS3ObjectKey(key)).toThrow(S3ObjectValidationError)
+    }
+  })
+
+  it('accepts generated export content types and rejects browser-executable types', () => {
+    expect(assertAllowedS3ContentType('text/csv; charset=utf-8')).toBe('text/csv; charset=utf-8')
+    expect(assertAllowedS3ContentType('application/json; charset=utf-8')).toBe('application/json; charset=utf-8')
+    expect(assertAllowedS3ContentType('application/x-ndjson')).toBe('application/x-ndjson')
+
+    for (const contentType of ['text/html', 'application/javascript', 'application/x-msdownload', 'application/octet-stream']) {
+      expect(() => assertAllowedS3ContentType(contentType)).toThrow(S3ObjectValidationError)
+    }
+  })
+
+  it('validates object-storage URL paths before evidence references are accepted', () => {
+    const expiry = Math.floor(Date.now() / 1000) + 3600
+    expect(() => validateObjectStorageUrlPath(`https://bucket.s3.amazonaws.com/org%2Forg-1%2Fevidence.pdf?Expires=${expiry}`))
+      .not.toThrow()
+
+    for (const url of [
+      `https://bucket.s3.amazonaws.com/evidence/../secret.pdf?Expires=${expiry}`,
+      `https://bucket.s3.amazonaws.com/evidence/%2e%2e/secret.pdf?Expires=${expiry}`,
+      `https://bucket.s3.amazonaws.com//secret.pdf?Expires=${expiry}`,
+      `https://bucket.s3.amazonaws.com/evidence/%00/secret.pdf?Expires=${expiry}`,
+    ]) {
+      expect(() => validateObjectStorageUrlPath(url)).toThrow(S3ObjectValidationError)
+    }
+  })
+
+  it('enforces signed URL response content-type overrides when present', () => {
+    const expiry = Math.floor(Date.now() / 1000) + 3600
+    expect(() => validateObjectStorageResponseContentType(
+      `https://bucket.s3.amazonaws.com/evidence.pdf?Expires=${expiry}&response-content-type=application%2Fpdf`,
+    )).not.toThrow()
+
+    expect(() => validateObjectStorageResponseContentType(
+      `https://bucket.s3.amazonaws.com/evidence.pdf?Expires=${expiry}&response-content-type=text%2Fhtml`,
+    )).toThrow(S3ObjectValidationError)
+  })
+
+  it('wraps evidence signed URL storage-key violations in evidence validation errors', () => {
+    const expiry = Math.floor(Date.now() / 1000) + 3600
+    const validUrl = `https://storage.example.test/evidence.pdf?Expires=${expiry}&signature=valid123`
+    expect(validateSignedObjectStorageUrl(validUrl).getTime()).toBeGreaterThan(Date.now())
+
+    expect(() => validateSignedObjectStorageUrl(
+      `https://storage.example.test/evidence/%2e%2e/secret.pdf?Expires=${expiry}&signature=valid123`,
+    )).toThrow(EvidenceReferenceValidationError)
+
+    expect(() => validateSignedObjectStorageUrl(
+      `https://storage.example.test/evidence.pdf?Expires=${expiry}&response-content-type=text%2Fhtml`,
+    )).toThrow(EvidenceReferenceValidationError)
+  })
+
+  it('rejects unsafe upload inputs before constructing an S3 client', async () => {
+    let clientFactoryCalled = false
+    setS3ClientFactory(() => {
+      clientFactoryCalled = true
+      throw new Error('client factory should not run for invalid input')
+    })
+
+    try {
+      await uploadToS3(
+        { bucket: 'exports', region: 'us-east-1', signedUrlTtlSeconds: 3600 },
+        'exports/user-123/job-456/export.csv',
+        Buffer.from('test', 'utf8'),
+        'text/html',
+      )
+      throw new Error('expected uploadToS3 to reject unsafe content type')
+    } catch (error) {
+      expect(error).toBeInstanceOf(S3ObjectValidationError)
+    }
+
+    expect(clientFactoryCalled).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Add S3 object-key validation for direct export uploads and signed evidence URLs, including decoded `..`, `%2e%2e`, leading/empty segments, backslashes, null bytes, line breaks, and absolute filesystem paths.
- Enforce an object-storage content-type allowlist before upload and for signed URL response content-type overrides, excluding HTML, script, executable, and opaque binary MIME types.
- Generate export keys under `exports/<requesting-user-id>/<job-id>/<filename>` and clear the local result buffer once an export is uploaded to S3.
- Document the storage contract in `docs/evidence-storage.md`.

## Validation
- `C:\Users\jhona\.bun\bin\bun.exe test src\tests\exportS3.traversal.test.ts` (7 pass, 27 assertions)
- `node --experimental-vm-modules node_modules\jest\bin\jest.js --runTestsByPath .\src\tests\exportQueue.s3.test.ts --runInBand` (7 pass)
- `git diff --check`

Additional repo-wide checks were attempted for transparency:
- `node --experimental-vm-modules node_modules\jest\bin\jest.js --runTestsByPath .\src\tests\evidence.service.test.ts .\src\tests\evidence.signedUrl.test.ts --runInBand` currently has pre-existing failures from expired/static date fixtures and an incomplete DB mock row.
- `node_modules\.bin\tsc.cmd --noEmit --pretty false` is blocked by existing baseline TypeScript errors in unrelated modules such as `src/config/env.ts`, `src/index.ts`, `src/jobs/queue.ts`, and others.

Payout address (USDT ERC-20): `0x06f44f4839fd5df4f4670036d028b29dec939363`

Closes #744