### PR TITLE
test: step-up action binding

### DIFF
--- a/src/middleware/stepUp.ts
+++ b/src/middleware/stepUp.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from 'express'
 import { AuthService } from '../services/auth.service.js'
 
-export const requireStepUp = (maxAgeSeconds = 300) => {
+export const requireStepUp = (maxAgeSeconds = 300, action?: string) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     const userId = (req as any).user?.userId ?? (req as any).authUser?.userId
     const sessionId =
@@ -17,7 +17,10 @@ export const requireStepUp = (maxAgeSeconds = 300) => {
       })
     }
 
-    const verifiedSession = await AuthService.validateStepUpSession(sessionId, maxAgeSeconds)
+    const verifiedSession = await AuthService.validateStepUpSession(sessionId, maxAgeSeconds, {
+      userId,
+      action,
+    })
     if (!verifiedSession || verifiedSession.userId !== userId) {
       return res.status(401).json({
         error: 'Step-up authentication required',

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -283,7 +283,7 @@ adminRouter.post('/horizon/listener/reset-cursor', async (req: Request, res: Res
  * Force-logout a user (Admin only) - Preserve Issue #46 logic
  * Force-logout a user (Admin only) - Issue #46 logic preserved
  */
-adminRouter.post('/users/:userId/revoke-sessions', requireStepUp(), async (req: Request, res: Response) => {
+adminRouter.post('/users/:userId/revoke-sessions', requireStepUp(300, 'admin.users.revoke_sessions'), async (req: Request, res: Response) => {
   const { userId } = req.params
   
   if (!userId) {
@@ -373,7 +373,7 @@ adminRouter.get('/audit-logs/:id', async (req, res) => {
   }
 })
 
-adminRouter.post('/overrides/vaults/:id/cancel', requireStepUp(), async (req, res) => {
+adminRouter.post('/overrides/vaults/:id/cancel', requireStepUp(300, 'admin.overrides.vault.cancel'), async (req, res) => {
   const { id } = req.params
   const { reason, reasonCode, idempotencyKey, details } = req.body ?? {}
 

--- a/src/routes/apiKeys.ts
+++ b/src/routes/apiKeys.ts
@@ -95,7 +95,7 @@ apiKeysRouter.post('/:id/rotate', apiKeyRateLimiter, async (req, res) => {
   })
 })
 
-apiKeysRouter.post('/:id/revoke', requireStepUp(), async (req, res) => {
+apiKeysRouter.post('/:id/revoke', requireStepUp(300, 'api_keys.revoke'), async (req, res) => {
   const userId = req.authUser!.userId
   const record = await revokeApiKey(req.params.id, userId)
 

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -164,17 +164,23 @@ authRouter.post('/webauthn/challenge', authenticate, async (req, res, next) => {
     return next(AppError.unauthorized('Unauthorized'))
   }
 
-  const challenge = await AuthService.issueStepUpChallenge(req.user.userId)
+  const action = typeof req.body?.action === 'string' ? req.body.action : undefined
+  const challenge = await AuthService.issueStepUpChallenge(req.user.userId, action)
   res.status(200).json(challenge)
 })
 
 authRouter.post('/webauthn/assert', authenticate, async (req, res, next) => {
-  const { nonce, credentialId, publicKey } = req.body as { nonce?: string; credentialId?: string; publicKey?: string }
+  const { nonce, credentialId, publicKey, action } = req.body as {
+    nonce?: string
+    credentialId?: string
+    publicKey?: string
+    action?: string
+  }
   if (!req.user?.userId || !nonce || !credentialId || !publicKey) {
     return next(AppError.badRequest('Missing WebAuthn assertion data'))
   }
 
-  const recorded = await AuthService.recordStepUpAssertion(nonce, req.user.userId)
+  const recorded = await AuthService.recordStepUpAssertion(nonce, req.user.userId, action)
   if (!recorded) {
     return next(AppError.unauthorized('Invalid or expired step-up assertion'))
   }
@@ -183,7 +189,7 @@ authRouter.post('/webauthn/assert', authenticate, async (req, res, next) => {
   res.status(200).json({ success: true })
 })
 
-authRouter.post('/users/:id/role', requireJson, authenticate, requireStepUp(), async (req, res, next) => {
+authRouter.post('/users/:id/role', requireJson, authenticate, requireStepUp(300, 'auth.users.role.update'), async (req, res, next) => {
   if (!req.user) {
     return next(AppError.unauthorized('Unauthorized'))
   }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -6,7 +6,12 @@ import { randomUUID } from 'node:crypto'
 import { recordSession, revokeAllUserSessions } from './session.js'
 
 const STEP_UP_TTL_SECONDS = 5 * 60
-const STEP_UP_NONCES = new Map<string, { userId: string; expiresAt: number; used: boolean }>()
+const STEP_UP_NONCES = new Map<string, { userId: string; action?: string; expiresAt: number; used: boolean }>()
+
+const normalizeStepUpAction = (action?: string | null): string | undefined => {
+    const normalized = action?.trim()
+    return normalized ? normalized : undefined
+}
 
 export class AuthService {
     static async register(input: RegisterInput) {
@@ -149,22 +154,31 @@ export class AuthService {
         await revokeAllUserSessions(userId)
     }
 
-    static async issueStepUpChallenge(userId: string) {
+    static async issueStepUpChallenge(userId: string, action?: string) {
         const nonce = randomUUID()
         const expiresAt = Date.now() + STEP_UP_TTL_SECONDS * 1000
-        STEP_UP_NONCES.set(nonce, { userId, expiresAt, used: false })
+        const normalizedAction = normalizeStepUpAction(action)
+        STEP_UP_NONCES.set(nonce, { userId, action: normalizedAction, expiresAt, used: false })
 
         return {
             nonce,
             expiresAt,
             ttlSeconds: STEP_UP_TTL_SECONDS,
             challenge: 'webauthn-step-up',
+            action: normalizedAction,
         }
     }
 
-    static async recordStepUpAssertion(nonce: string, userId: string) {
+    static async recordStepUpAssertion(nonce: string, userId: string, action?: string) {
         const entry = STEP_UP_NONCES.get(nonce)
-        if (!entry || entry.used || entry.expiresAt < Date.now() || entry.userId !== userId) {
+        const expectedAction = normalizeStepUpAction(action)
+        if (
+            !entry
+            || entry.used
+            || entry.expiresAt < Date.now()
+            || entry.userId !== userId
+            || ((entry.action || expectedAction) && entry.action !== expectedAction)
+        ) {
             return false
         }
 
@@ -173,9 +187,22 @@ export class AuthService {
         return true
     }
 
-    static async validateStepUpSession(sessionId: string, maxAgeSeconds = STEP_UP_TTL_SECONDS) {
+    static async validateStepUpSession(
+        sessionId: string,
+        maxAgeSeconds = STEP_UP_TTL_SECONDS,
+        expected?: string | { userId?: string; action?: string },
+    ) {
         const entry = STEP_UP_NONCES.get(sessionId)
         if (!entry || entry.used || entry.expiresAt < Date.now()) {
+            return null
+        }
+
+        const expectedUserId = typeof expected === 'object' ? expected.userId : undefined
+        const expectedAction = normalizeStepUpAction(typeof expected === 'string' ? expected : expected?.action)
+        if (expectedUserId && entry.userId !== expectedUserId) {
+            return null
+        }
+        if ((entry.action || expectedAction) && entry.action !== expectedAction) {
             return null
         }
 
@@ -187,7 +214,11 @@ export class AuthService {
 
         entry.used = true
         STEP_UP_NONCES.delete(sessionId)
-        return { userId: entry.userId, sessionId }
+        return { userId: entry.userId, sessionId, action: entry.action }
+    }
+
+    static clearStepUpSessionsForTesting() {
+        STEP_UP_NONCES.clear()
     }
 
     static async registerWebAuthnCredential(userId: string, credentialId: string, publicKey: string) {

--- a/src/tests/auth.stepup.test.ts
+++ b/src/tests/auth.stepup.test.ts
@@ -1,13 +1,16 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals'
 import { AuthService } from '../services/auth.service.js'
 
 describe('AuthService step-up challenge flow', () => {
   beforeEach(() => {
+    AuthService.clearStepUpSessionsForTesting()
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2026-06-26T00:00:00.000Z'))
   })
 
   afterEach(() => {
     jest.useRealTimers()
+    AuthService.clearStepUpSessionsForTesting()
   })
 
   it('issues a challenge, consumes it once, and rejects replays', async () => {

--- a/src/tests/stepUp.binding.test.ts
+++ b/src/tests/stepUp.binding.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import express, { type NextFunction, type Request, type Response } from 'express'
+import request from 'supertest'
+import { requireStepUp } from '../middleware/stepUp.js'
+import { AuthService } from '../services/auth.service.js'
+import { UserRole } from '../types/user.js'
+
+const START_TIME = new Date('2026-06-27T00:00:00.000Z').getTime()
+const realDateNow = Date.now
+
+function setNow(ms: number) {
+  Date.now = () => ms
+}
+
+function buildProtectedApp(userId: string, action: string) {
+  const app = express()
+  app.use(express.json())
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    req.user = { userId, role: UserRole.ADMIN }
+    next()
+  })
+  app.post('/dangerous-action', requireStepUp(300, action), (_req, res) => {
+    res.status(200).json({ ok: true, action })
+  })
+  return app
+}
+
+describe('step-up token binding and replay window', () => {
+  beforeEach(() => {
+    setNow(START_TIME)
+    AuthService.clearStepUpSessionsForTesting()
+  })
+
+  afterEach(() => {
+    Date.now = realDateNow
+    AuthService.clearStepUpSessionsForTesting()
+  })
+
+  it('accepts a token bound to the same user and action, then rejects replay', async () => {
+    const app = buildProtectedApp('user-a', 'admin.users.delete')
+    const challenge = await AuthService.issueStepUpChallenge('user-a', 'admin.users.delete')
+
+    await request(app)
+      .post('/dangerous-action')
+      .set('x-step-up-session-id', challenge.nonce)
+      .expect(200)
+
+    const replay = await request(app)
+      .post('/dangerous-action')
+      .set('x-step-up-session-id', challenge.nonce)
+      .expect(401)
+
+    expect(replay.body.stepUpRequired).toBe(true)
+  })
+
+  it('does not let user B replay user A step-up token', async () => {
+    const userAToken = await AuthService.issueStepUpChallenge('user-a', 'admin.users.delete')
+    const userBApp = buildProtectedApp('user-b', 'admin.users.delete')
+
+    await request(userBApp)
+      .post('/dangerous-action')
+      .set('x-step-up-session-id', userAToken.nonce)
+      .expect(401)
+
+    const userAApp = buildProtectedApp('user-a', 'admin.users.delete')
+    await request(userAApp)
+      .post('/dangerous-action')
+      .set('x-step-up-session-id', userAToken.nonce)
+      .expect(200)
+  })
+
+  it('does not let an action X token authorize action Y', async () => {
+    const challenge = await AuthService.issueStepUpChallenge('user-a', 'api_keys.revoke')
+    const actionYApp = buildProtectedApp('user-a', 'admin.users.delete')
+
+    await request(actionYApp)
+      .post('/dangerous-action')
+      .set('x-step-up-session-id', challenge.nonce)
+      .expect(401)
+
+    const actionXApp = buildProtectedApp('user-a', 'api_keys.revoke')
+    await request(actionXApp)
+      .post('/dangerous-action')
+      .set('x-step-up-session-id', challenge.nonce)
+      .expect(200)
+  })
+
+  it('rejects replay just after expiry while accepting a fresh boundary token', async () => {
+    const app = buildProtectedApp('user-a', 'admin.users.delete')
+    const fresh = await AuthService.issueStepUpChallenge('user-a', 'admin.users.delete')
+    setNow(fresh.expiresAt - 1)
+
+    await request(app)
+      .post('/dangerous-action')
+      .set('x-step-up-session-id', fresh.nonce)
+      .expect(200)
+
+    setNow(START_TIME)
+    const expired = await AuthService.issueStepUpChallenge('user-a', 'admin.users.delete')
+    setNow(expired.expiresAt + 1)
+
+    const response = await request(app)
+      .post('/dangerous-action')
+      .set('x-step-up-session-id', expired.nonce)
+      .expect(401)
+
+    expect(response.body.stepUpRequired).toBe(true)
+  })
+
+  it('binds WebAuthn assertion recording to the challenge action', async () => {
+    const challenge = await AuthService.issueStepUpChallenge('user-a', 'api_keys.revoke')
+
+    const wrongAction = await AuthService.recordStepUpAssertion(challenge.nonce, 'user-a', 'admin.users.delete')
+    const correctAction = await AuthService.recordStepUpAssertion(challenge.nonce, 'user-a', 'api_keys.revoke')
+
+    expect(wrongAction).toBe(false)
+    expect(correctAction).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Bind step-up challenges/sessions to an optional action as well as the user.
- Make `requireStepUp()` validate the expected user and action before consuming a session.
- Thread action through WebAuthn challenge/assert routes and mark existing destructive step-up routes with explicit action names.
- Add Bun coverage for valid use, replay rejection, cross-user replay, cross-action replay, expiry boundary, and action-bound assertion recording.
- Fix the existing Jest step-up test harness import and clear step-up state between tests.

## Validation
- `C:\Users\jhona\.bun\bin\bun.exe test src\tests\stepUp.binding.test.ts` (5 pass)
- `node --experimental-vm-modules node_modules\jest\bin\jest.js --runTestsByPath .\src\tests\auth.stepup.test.ts --runInBand` (2 pass)
- `git diff --check`

Attempted targeted TypeScript check:
- `node_modules\.bin\tsc.cmd --noEmit --pretty false --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --esModuleInterop src\services\auth.service.ts src\middleware\stepUp.ts src\routes\auth.ts src\tests\stepUp.binding.test.ts`
- Still blocked by existing baseline issues in `src/config/env.ts`, `src/lib/auth-utils.ts`, Prisma enum typing via the shared generated client, and missing `bun:test` type declarations.

Payout address (USDT ERC-20): `0x06f44f4839fd5df4f4670036d028b29dec939363`

Fixes #739