### PR TITLE
test: WebAuthn counter rollback

### DIFF
--- a/db/migrations/20260627010000_add_webauthn_signature_counter.cjs
+++ b/db/migrations/20260627010000_add_webauthn_signature_counter.cjs
@@ -1,0 +1,13 @@
+exports.up = async function up(knex) {
+  return knex.raw(`
+    ALTER TABLE "webauthn_credentials"
+      ADD COLUMN IF NOT EXISTS "sign_count" INTEGER NOT NULL DEFAULT 0;
+  `)
+}
+
+exports.down = async function down(knex) {
+  return knex.raw(`
+    ALTER TABLE "webauthn_credentials"
+      DROP COLUMN IF EXISTS "sign_count";
+  `)
+}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -190,17 +190,65 @@ export class AuthService {
         return { userId: entry.userId, sessionId }
     }
 
-    static async registerWebAuthnCredential(userId: string, credentialId: string, publicKey: string) {
-        await getPrisma().$executeRaw`
-            INSERT INTO "webauthn_credentials" ("user_id", "credential_id", "public_key")
-            VALUES (${userId}, ${credentialId}, ${publicKey})
-            ON CONFLICT ("credential_id") DO UPDATE SET
-                "public_key" = EXCLUDED."public_key",
-                "updated_at" = CURRENT_TIMESTAMP,
-                "last_used_at" = CURRENT_TIMESTAMP
+    static async registerWebAuthnCredential(userId: string, credentialId: string, publicKey: string, signCount = 0) {
+        if (!Number.isSafeInteger(signCount) || signCount < 0) {
+            throw new Error('WebAuthn signature counter must be a non-negative integer')
+        }
+
+        const existing = await getPrisma().$queryRaw<Array<{ credential_id: string }>>`
+            SELECT "credential_id"
+            FROM "webauthn_credentials"
+            WHERE "credential_id" = ${credentialId}
+            LIMIT 1
         `
 
-        return { userId, credentialId, publicKey }
+        if (existing.length > 0) {
+            throw new Error('WebAuthn credential already registered')
+        }
+
+        await getPrisma().$executeRaw`
+            INSERT INTO "webauthn_credentials" ("user_id", "credential_id", "public_key", "sign_count")
+            VALUES (${userId}, ${credentialId}, ${publicKey}, ${signCount})
+        `
+
+        return { userId, credentialId, publicKey, signCount }
+    }
+
+    static async verifyWebAuthnAssertionCounter(credentialId: string, signCount: number) {
+        const [credential] = await getPrisma().$queryRaw<Array<{
+            user_id: string
+            credential_id: string
+            sign_count: number
+        }>>`
+            SELECT "user_id", "credential_id", "sign_count"
+            FROM "webauthn_credentials"
+            WHERE "credential_id" = ${credentialId}
+            LIMIT 1
+        `
+
+        if (!credential) {
+            throw new Error('WebAuthn credential not found')
+        }
+
+        const storedSignCount = Number(credential.sign_count)
+        if (!Number.isSafeInteger(signCount) || signCount <= storedSignCount) {
+            throw new Error('WebAuthn signature counter rollback detected')
+        }
+
+        await getPrisma().$executeRaw`
+            UPDATE "webauthn_credentials"
+            SET "sign_count" = ${signCount},
+                "last_used_at" = CURRENT_TIMESTAMP,
+                "updated_at" = CURRENT_TIMESTAMP
+            WHERE "credential_id" = ${credentialId}
+        `
+
+        return {
+            userId: credential.user_id,
+            credentialId: credential.credential_id,
+            previousSignCount: storedSignCount,
+            signCount,
+        }
     }
 }
 

--- a/src/tests/webauthn.counter.test.ts
+++ b/src/tests/webauthn.counter.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+type CredentialRow = {
+  user_id: string
+  credential_id: string
+  public_key: string
+  sign_count: number
+}
+
+const credentials = new Map<string, CredentialRow>()
+
+const prisma = {
+  async $queryRaw(strings: TemplateStringsArray, ...values: unknown[]) {
+    const sql = strings.join('?')
+    if (sql.includes('FROM "webauthn_credentials"')) {
+      const credentialId = String(values[0])
+      const row = credentials.get(credentialId)
+      return row ? [{ ...row }] : []
+    }
+    throw new Error(`Unexpected query: ${sql}`)
+  },
+  async $executeRaw(strings: TemplateStringsArray, ...values: unknown[]) {
+    const sql = strings.join('?')
+    if (sql.includes('INSERT INTO "webauthn_credentials"')) {
+      const [userId, credentialId, publicKey, signCount] = values
+      const id = String(credentialId)
+      if (credentials.has(id)) {
+        throw new Error('duplicate key value violates unique constraint "webauthn_credentials_credential_id_key"')
+      }
+      credentials.set(id, {
+        user_id: String(userId),
+        credential_id: id,
+        public_key: String(publicKey),
+        sign_count: Number(signCount),
+      })
+      return 1
+    }
+
+    if (sql.includes('UPDATE "webauthn_credentials"')) {
+      const [signCount, credentialId] = values
+      const id = String(credentialId)
+      const existing = credentials.get(id)
+      if (!existing) return 0
+      credentials.set(id, { ...existing, sign_count: Number(signCount) })
+      return 1
+    }
+
+    throw new Error(`Unexpected execute: ${sql}`)
+  },
+}
+
+mock.module('../lib/prismaScope.js', () => ({
+  getPrisma: () => prisma,
+}))
+
+const { AuthService } = await import('../services/auth.service.js')
+
+describe('WebAuthn credential counter and uniqueness checks', () => {
+  beforeEach(() => {
+    credentials.clear()
+  })
+
+  it('rejects duplicate credential registration instead of silently updating it', async () => {
+    await AuthService.registerWebAuthnCredential('user-a', 'credential-1', 'public-key-a', 0)
+
+    await expect(
+      AuthService.registerWebAuthnCredential('user-b', 'credential-1', 'public-key-b', 0),
+    ).rejects.toThrow('WebAuthn credential already registered')
+
+    expect(credentials.get('credential-1')).toMatchObject({
+      user_id: 'user-a',
+      public_key: 'public-key-a',
+      sign_count: 0,
+    })
+  })
+
+  it('accepts a monotonically increasing assertion counter and persists it', async () => {
+    await AuthService.registerWebAuthnCredential('user-a', 'credential-2', 'public-key-a', 7)
+
+    const result = await AuthService.verifyWebAuthnAssertionCounter('credential-2', 8)
+
+    expect(result).toEqual({
+      userId: 'user-a',
+      credentialId: 'credential-2',
+      previousSignCount: 7,
+      signCount: 8,
+    })
+    expect(credentials.get('credential-2')?.sign_count).toBe(8)
+  })
+
+  it('rejects equal and lower counters as cloned-authenticator rollback attempts', async () => {
+    await AuthService.registerWebAuthnCredential('user-a', 'credential-3', 'public-key-a', 10)
+
+    await expect(AuthService.verifyWebAuthnAssertionCounter('credential-3', 10))
+      .rejects.toThrow('WebAuthn signature counter rollback detected')
+    await expect(AuthService.verifyWebAuthnAssertionCounter('credential-3', 9))
+      .rejects.toThrow('WebAuthn signature counter rollback detected')
+
+    expect(credentials.get('credential-3')?.sign_count).toBe(10)
+  })
+
+  it('rejects unsafe or missing counters without mutating stored state', async () => {
+    await AuthService.registerWebAuthnCredential('user-a', 'credential-4', 'public-key-a', 3)
+
+    await expect(AuthService.verifyWebAuthnAssertionCounter('credential-4', Number.NaN))
+      .rejects.toThrow('WebAuthn signature counter rollback detected')
+    await expect(AuthService.verifyWebAuthnAssertionCounter('credential-4', 3.5))
+      .rejects.toThrow('WebAuthn signature counter rollback detected')
+    await expect(AuthService.verifyWebAuthnAssertionCounter('missing-credential', 1))
+      .rejects.toThrow('WebAuthn credential not found')
+
+    expect(credentials.get('credential-4')?.sign_count).toBe(3)
+  })
+
+  it('rejects invalid initial registration counters', async () => {
+    await expect(AuthService.registerWebAuthnCredential('user-a', 'credential-5', 'public-key-a', -1))
+      .rejects.toThrow('WebAuthn signature counter must be a non-negative integer')
+    await expect(AuthService.registerWebAuthnCredential('user-a', 'credential-5', 'public-key-a', 1.5))
+      .rejects.toThrow('WebAuthn signature counter must be a non-negative integer')
+
+    expect(credentials.has('credential-5')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Add a `sign_count` column for WebAuthn credentials.
- Reject duplicate credential registration instead of silently upserting over an existing credential ID.
- Add `verifyWebAuthnAssertionCounter()` to reject equal/lower assertion counters and persist monotonic increases.
- Add Bun coverage for duplicate registration, increasing counters, equal/lower rollback rejection, unsafe counters, missing credentials, and invalid initial counters.

## Validation
- `C:\Users\jhona\.bun\bin\bun.exe test src\tests\webauthn.counter.test.ts` (5 pass, 14 assertions)
- `git diff --check`

Attempted targeted TypeScript check:
- `node_modules\.bin\tsc.cmd --noEmit --pretty false --skipLibCheck --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --esModuleInterop src\services\auth.service.ts src\tests\webauthn.counter.test.ts`
- Still blocked by existing baseline errors in `src/config/env.ts`, `src/lib/auth-utils.ts`, and missing `bun:test` type declarations.

Payout address (USDT ERC-20): `0x06f44f4839fd5df4f4670036d028b29dec939363`

Fixes #740