### PR TITLE
feat: validate webhook event filters

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -14,13 +14,27 @@ Subscribers are stored in-memory (same pattern as API keys). Each subscriber has
 - `events` – event types to subscribe to (empty = wildcard)
 - `active` – delivery flag
 
+### Event Filters
+
+Subscribers may pass an `events` array to receive only selected vault lifecycle events.
+The current supported event types are:
+
+- `vault_created`
+- `vault_completed`
+- `vault_failed`
+- `vault_cancelled`
+
+An empty `events` array means wildcard delivery for all supported event types. Unknown
+event names are rejected before the subscriber is stored, so invalid filters cannot
+silently create a subscriber that never receives events.
+
 ### SSRF Protection
 
 `isUrlAllowed()` blocks loopback, link-local, and RFC-1918 addresses. If `WEBHOOK_ALLOWED_HOSTS` is set, the target hostname must also match.
 
 ## Delivery
 
-`dispatchWebhookEvent()` sends a payload to all eligible active subscribers. Each delivery is retried with exponential backoff (max 3 attempts).
+`dispatchWebhookEvent()` sends a payload to all eligible active subscribers. Each delivery is retried with exponential backoff (max 3 attempts). Subscribers whose `events` list does not include the payload event type are filtered out before signing or HTTP delivery.
 
 ### Headers
 
@@ -133,7 +147,7 @@ All subscriber queries are scoped by `organization_id`. When dispatching events,
 
 ### `addSubscriber(organizationId, url, secret, events)`
 
-Creates a new webhook subscriber. The URL is validated against the SSRF allowlist (`isUrlAllowed`). Returns the created subscriber.
+Creates a new webhook subscriber. The URL is validated against the SSRF allowlist (`isUrlAllowed`), and event filters are validated against the supported vault lifecycle event list. Duplicate event names are deduplicated before storage. Returns the created subscriber.
 
 ### `removeSubscriber(id)`
 
@@ -145,7 +159,7 @@ Returns all active subscribers for an organization.
 
 ### `dispatchWebhookEvent(payload)`
 
-Delivers an event to all eligible active subscribers for the organization specified in `payload.organizationId`. Uses exponential-backoff retry (max 3 attempts). Failures are collected per-subscriber.
+Delivers an event to all eligible active subscribers for the organization specified in `payload.organizationId`. Uses exponential-backoff retry (max 3 attempts). Failures are collected per-subscriber. Subscribers with a non-empty `events` list only receive matching event types; subscribers with an empty list receive all supported event types.
 
 ---
 

--- a/src/services/webhooks.ts
+++ b/src/services/webhooks.ts
@@ -54,6 +54,20 @@ export const VAULT_LIFECYCLE_EVENTS = new Set([
 
 const repo = new WebhookSubscriberRepository(db)
 
+export const validateSubscriberEvents = (events: string[]): string[] => {
+  if (!Array.isArray(events)) {
+    throw new Error('Webhook events must be an array')
+  }
+
+  const uniqueEvents = Array.from(new Set(events))
+  const unsupported = uniqueEvents.filter((event) => !VAULT_LIFECYCLE_EVENTS.has(event))
+  if (unsupported.length > 0) {
+    throw new Error(`Unsupported webhook event type(s): ${unsupported.join(', ')}`)
+  }
+
+  return uniqueEvents
+}
+
 /**
  * Returns true when a URL is safe to deliver to.
  *
@@ -147,7 +161,7 @@ export const addSubscriber = async (
     throw new Error(`Webhook URL not permitted: ${url}`)
   }
 
-  return repo.create({ organizationId, url, secret, events })
+  return repo.create({ organizationId, url, secret, events: validateSubscriberEvents(events) })
 }
 
 export const removeSubscriber = async (id: string): Promise<boolean> => repo.remove(id)

--- a/src/tests/webhooks.eventFilters.test.ts
+++ b/src/tests/webhooks.eventFilters.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import type { WebhookSubscriber } from '../services/webhooks.js'
+
+const subscribers: WebhookSubscriber[] = []
+
+mock.module('../repositories/webhookSubscriberRepository.js', () => ({
+  WebhookSubscriberRepository: class {
+    async findByOrg(organizationId: string) {
+      return subscribers.filter((subscriber) =>
+        subscriber.organizationId === organizationId && subscriber.active
+      )
+    }
+
+    async findByEvent(organizationId: string, eventType: string) {
+      return subscribers.filter((subscriber) =>
+        subscriber.organizationId === organizationId &&
+        subscriber.active &&
+        (subscriber.events.length === 0 || subscriber.events.includes(eventType))
+      )
+    }
+
+    async create(data: {
+      organizationId: string
+      url: string
+      secret: string
+      events: string[]
+    }) {
+      const subscriber: WebhookSubscriber = {
+        id: randomUUID(),
+        organizationId: data.organizationId,
+        url: data.url,
+        secret: data.secret,
+        events: [...data.events],
+        active: true,
+        createdAt: new Date('2030-01-01T00:00:00.000Z').toISOString(),
+      }
+      subscribers.push(subscriber)
+      return subscriber
+    }
+
+    async remove(id: string) {
+      const index = subscribers.findIndex((subscriber) => subscriber.id === id)
+      if (index === -1) return false
+      subscribers.splice(index, 1)
+      return true
+    }
+  },
+}))
+
+const {
+  addSubscriber,
+  dispatchWebhookEvent,
+  validateSubscriberEvents,
+} = await import('../services/webhooks.js')
+
+const organizationId = 'org-webhook-filters'
+
+function makePayload(eventType: string) {
+  return {
+    eventId: `tx-${eventType}:0`,
+    eventType,
+    timestamp: new Date('2030-01-01T00:00:00.000Z').toISOString(),
+    data: { vaultId: 'vault-1' },
+    organizationId,
+  }
+}
+
+describe('webhook event filters', () => {
+  beforeEach(() => {
+    subscribers.length = 0
+    global.fetch = mock(async () => ({ status: 200 }) as Response)
+  })
+
+  test('empty filter subscribes to all known event types for backward compatibility', async () => {
+    await addSubscriber(organizationId, 'https://hooks.example.com/all', 'secret', [])
+
+    const results = await dispatchWebhookEvent(makePayload('vault_failed'))
+
+    expect(results).toHaveLength(1)
+    expect(results[0].success).toBe(true)
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('single event filter only delivers matching events', async () => {
+    await addSubscriber(
+      organizationId,
+      'https://hooks.example.com/completed',
+      'secret',
+      ['vault_completed'],
+    )
+
+    const matching = await dispatchWebhookEvent(makePayload('vault_completed'))
+    const nonMatching = await dispatchWebhookEvent(makePayload('vault_created'))
+
+    expect(matching).toHaveLength(1)
+    expect(nonMatching).toHaveLength(0)
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('unknown event types are rejected before subscriber storage', async () => {
+    await expect(
+      addSubscriber(
+        organizationId,
+        'https://hooks.example.com/bad',
+        'secret',
+        ['vault_created', 'vault_staked'],
+      ),
+    ).rejects.toThrow(/Unsupported webhook event type\(s\): vault_staked/)
+
+    expect(subscribers).toHaveLength(0)
+  })
+
+  test('non-matching events short-circuit before signing or HTTP delivery', async () => {
+    await addSubscriber(
+      organizationId,
+      'https://hooks.example.com/failed-only',
+      'secret',
+      ['vault_failed'],
+    )
+
+    const results = await dispatchWebhookEvent(makePayload('vault_cancelled'))
+
+    expect(results).toEqual([])
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  test('validation deduplicates event filters before persistence', async () => {
+    expect(validateSubscriberEvents(['vault_created', 'vault_created', 'vault_failed']))
+      .toEqual(['vault_created', 'vault_failed'])
+
+    const subscriber = await addSubscriber(
+      organizationId,
+      'https://hooks.example.com/dedupe',
+      'secret',
+      ['vault_created', 'vault_created'],
+    )
+    expect(subscriber.events).toEqual(['vault_created'])
+  })
+})


### PR DESCRIPTION
## Summary
- validate webhook subscriber event filters against the supported vault lifecycle event set
- keep empty `events` as wildcard delivery for backward compatibility
- deduplicate event filters before persistence
- add Bun coverage for wildcard, single-event match, unknown event rejection, no-match short-circuit before HTTP delivery, and dedupe
- document event filters and delivery filtering in `docs/webhooks.md`

## Tests
- `C:\Users\jhona\.bun\bin\bun.exe test src\tests\webhooks.eventFilters.test.ts` (5 pass)
- `node --experimental-vm-modules node_modules\jest\bin\jest.js --runTestsByPath .\src\tests\webhooks.test.ts --runInBand` (30 pass)
- `git diff --check`
- `npx tsc --noEmit --pretty false | Select-String "webhooks|webhookSubscriberRepository"` (no touched-file-specific output; full repo still has existing unrelated baseline type errors)

Closes #724