### PR TITLE
feat: add job queue depth and stuck-job sweeper

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -8,6 +8,8 @@
 - `deadline.check`
 - `oracle.call`
 - `analytics.recompute`
+- `export.generate`
+- `sessions.cleanup`
 
 ## Enqueue options
 
@@ -21,11 +23,31 @@ Options parsing behavior:
 
 ## Retry failed jobs
 
-`POST /api/admin/jobs/:id/retry` is an admin-only endpoint to retry a failed job.
+`POST /api/jobs/:id/retry` is an admin-only endpoint to retry a failed job.
 
 - Resets a job's attempts to 0 and queues it for immediate execution.
 - If the job has exhausted its `max_attempts` (i.e. is dead-lettered), the request will be refused unless `?force=true` is passed as a query parameter.
 - Emits a `job.retry` audit log upon success.
+
+## Queue depth and stuck-job sweep
+
+`GET /api/jobs/depth` returns an admin-only queue-depth report grouped by job
+type and state. The response includes queued, delayed, active, and dead-letter
+totals plus a `byType` map for every supported job type.
+
+`POST /api/jobs/sweep-stuck` reclaims active jobs whose in-memory lease has been
+held longer than `staleAfterMs`.
+
+- `staleAfterMs` is optional and defaults to 5 minutes.
+- `staleAfterMs` may be supplied in the JSON body or query string and is bounded
+  to a maximum of 24 hours.
+- Jobs with attempts remaining are moved back to the ready queue with their
+  current attempt count preserved, so the next execution consumes the next
+  attempt.
+- Jobs already at `maxAttempts` are moved to the dead-letter queue instead of
+  being retried indefinitely.
+- The sweep trigger emits a `job.sweep_stuck` audit log with scanned, reclaimed,
+  and dead-lettered counts.
 
 ## Error contract
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -518,6 +518,68 @@ paths:
                   - delayedJobs
                   - activeJobs
                   - totals
+  /api/jobs/depth:
+    get:
+      summary: Get queue depth grouped by job type and state
+      tags:
+        - Jobs
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Queue depth report
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  generatedAt:
+                    type: string
+                    format: date-time
+                  totals:
+                    type: object
+                    properties:
+                      queued:
+                        type: number
+                      delayed:
+                        type: number
+                      active:
+                        type: number
+                      deadLetter:
+                        type: number
+                    required:
+                      - queued
+                      - delayed
+                      - active
+                      - deadLetter
+                  byType:
+                    type: object
+                    additionalProperties: {}
+                required:
+                  - generatedAt
+                  - totals
+                  - byType
+  /api/jobs/sweep-stuck:
+    post:
+      summary: Sweep stuck active jobs back to ready queue or dead letter
+      tags:
+        - Jobs
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                staleAfterMs:
+                  type: integer
+                  exclusiveMinimum: 0
+      responses:
+        "202":
+          description: Stuck-job sweep completed
+        "400":
+          description: Invalid staleAfterMs
   /api/jobs/deadletters:
     get:
       summary: List dead-letter jobs

--- a/src/docs/openapi-generator.ts
+++ b/src/docs/openapi-generator.ts
@@ -301,6 +301,58 @@ registry.registerPath({
   },
 })
 
+// GET /api/jobs/depth
+registry.registerPath({
+  method: 'get',
+  path: '/api/jobs/depth',
+  summary: 'Get queue depth grouped by job type and state',
+  tags: ['Jobs'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: 'Queue depth report',
+      content: {
+        'application/json': {
+          schema: z.object({
+            generatedAt: z.string().datetime(),
+            totals: z.object({
+              queued: z.number(),
+              delayed: z.number(),
+              active: z.number(),
+              deadLetter: z.number(),
+            }),
+            byType: z.record(z.string(), z.any()),
+          }),
+        },
+      },
+    },
+  },
+})
+
+// POST /api/jobs/sweep-stuck
+registry.registerPath({
+  method: 'post',
+  path: '/api/jobs/sweep-stuck',
+  summary: 'Sweep stuck active jobs back to ready queue or dead letter',
+  tags: ['Jobs'],
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            staleAfterMs: z.number().int().positive().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    202: { description: 'Stuck-job sweep completed' },
+    400: { description: 'Invalid staleAfterMs' },
+  },
+})
+
 // GET /api/jobs/deadletters
 registry.registerPath({
   method: 'get',

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -15,6 +15,8 @@ interface InternalQueuedJob<T extends JobType = JobType> {
   maxAttempts: number
   createdAt: number
   runAt: number
+  activeSince?: number
+  leaseId?: number
 }
 
 interface CompletedJobRecord {
@@ -78,6 +80,40 @@ export interface QueueMetrics {
   recentFailures: FailedJobRecord[]
 }
 
+export interface QueueDepthReport {
+  generatedAt: string
+  totals: {
+    queued: number
+    delayed: number
+    active: number
+    deadLetter: number
+  }
+  byType: Record<JobType, QueueTypeMetrics>
+}
+
+export interface StuckJobSweepOptions {
+  staleAfterMs?: number
+  now?: number
+}
+
+export interface StuckJobSweepRecord {
+  jobId: string
+  type: JobType
+  attempt: number
+  maxAttempts: number
+  activeForMs: number
+}
+
+export interface StuckJobSweepResult {
+  scannedActive: number
+  staleAfterMs: number
+  reclaimed: number
+  deadLettered: number
+  untouched: number
+  reclaimedJobs: StuckJobSweepRecord[]
+  deadLetteredJobs: StuckJobSweepRecord[]
+}
+
 export interface JobQueueOptions {
   concurrency?: number
   pollIntervalMs?: number
@@ -96,13 +132,12 @@ const sleep = async (ms: number): Promise<void> => {
 }
 
 const createEmptyTypeMetrics = (): Record<JobType, QueueTypeMetrics> => {
-  return {
-    'notification.send': { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
-    'deadline.check': { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
-    'oracle.call': { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
-    'analytics.recompute': { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
-    'export.generate': { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
-  }
+  return Object.fromEntries(
+    JOB_TYPES.map((type) => [
+      type,
+      { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
+    ]),
+  ) as Record<JobType, QueueTypeMetrics>
 }
 
 const getErrorMessage = (error: unknown): string => {
@@ -282,6 +317,75 @@ export class InMemoryJobQueue {
     }
   }
 
+  getDepthReport(): QueueDepthReport {
+    const metrics = this.getMetrics()
+
+    return {
+      generatedAt: new Date().toISOString(),
+      totals: {
+        queued: metrics.queueDepth,
+        delayed: metrics.delayedJobs,
+        active: metrics.activeJobs,
+        deadLetter: metrics.deadLetterJobs,
+      },
+      byType: metrics.byType,
+    }
+  }
+
+  sweepStuckJobs(options: StuckJobSweepOptions = {}): StuckJobSweepResult {
+    const staleAfterMs = asPositiveInteger(options.staleAfterMs, 5 * 60_000)
+    const now = options.now ?? Date.now()
+    const reclaimedJobs: StuckJobSweepRecord[] = []
+    const deadLetteredJobs: StuckJobSweepRecord[] = []
+    const activeEntries = [...this.activeJobs.entries()]
+
+    for (const [jobId, job] of activeEntries) {
+      const activeSince = job.activeSince ?? now
+      const activeForMs = Math.max(0, now - activeSince)
+      if (activeForMs < staleAfterMs) {
+        continue
+      }
+
+      const record: StuckJobSweepRecord = {
+        jobId,
+        type: job.type,
+        attempt: job.attempt,
+        maxAttempts: job.maxAttempts,
+        activeForMs,
+      }
+
+      this.activeJobs.delete(jobId)
+      job.activeSince = undefined
+
+      if (job.attempt >= job.maxAttempts) {
+        this.moveToDeadLetter(job, `Job lease expired after ${activeForMs}ms`)
+        deadLetteredJobs.push(record)
+        continue
+      }
+
+      job.runAt = now
+      this.pendingJobs.push(job)
+      reclaimedJobs.push(record)
+    }
+
+    if (reclaimedJobs.length > 0) {
+      this.sortPendingJobs()
+      if (this.running) {
+        void this.drain()
+      }
+    }
+
+    return {
+      scannedActive: activeEntries.length,
+      staleAfterMs,
+      reclaimed: reclaimedJobs.length,
+      deadLettered: deadLetteredJobs.length,
+      untouched: activeEntries.length - reclaimedJobs.length - deadLetteredJobs.length,
+      reclaimedJobs,
+      deadLetteredJobs,
+    }
+  }
+
   private async drain(): Promise<void> {
     if (!this.running || this.draining) {
       return
@@ -313,17 +417,27 @@ export class InMemoryJobQueue {
     }
 
     job.attempt += 1
+    job.activeSince = Date.now()
+    job.leaseId = (job.leaseId ?? 0) + 1
+    const leaseId = job.leaseId
     this.activeJobs.set(job.id, job)
     this.totals.executions += 1
-    const startedAt = Date.now()
+    const startedAt = job.activeSince
 
     try {
       await handler(job.payload, {
         jobId: job.id,
         attempt: job.attempt,
       })
+      if (!this.isActiveLease(job.id, leaseId)) {
+        return
+      }
       this.recordCompletedJob(job, Date.now() - startedAt)
     } catch (error) {
+      if (!this.isActiveLease(job.id, leaseId)) {
+        return
+      }
+
       const message = getErrorMessage(error)
 
       // If the handler marked the error as non-retryable, record failure and skip retry
@@ -338,11 +452,19 @@ export class InMemoryJobQueue {
         this.moveToDeadLetter(job, message)
       }
     } finally {
-      this.activeJobs.delete(job.id)
-      if (this.running) {
+      if (this.isActiveLease(job.id, leaseId)) {
+        this.activeJobs.delete(job.id)
+        job.activeSince = undefined
+      }
+
+      if (this.running && !this.draining) {
         void this.drain()
       }
     }
+  }
+
+  private isActiveLease(jobId: string, leaseId: number): boolean {
+    return this.activeJobs.get(jobId)?.leaseId === leaseId
   }
 
   private recordCompletedJob(job: InternalQueuedJob<JobType>, durationMs: number): void {
@@ -355,6 +477,18 @@ export class InMemoryJobQueue {
       durationMs,
     })
     this.trimHistory(this.completedJobs)
+  }
+
+  private recordFailedJob(job: InternalQueuedJob<JobType>, error: string): void {
+    this.totals.failed += 1
+    this.failedJobs.unshift({
+      jobId: job.id,
+      type: job.type,
+      failedAt: new Date().toISOString(),
+      attempts: job.attempt,
+      error,
+    })
+    this.trimHistory(this.failedJobs)
   }
 
   private moveToDeadLetter(job: InternalQueuedJob<JobType>, error: string): void {

--- a/src/jobs/system.ts
+++ b/src/jobs/system.ts
@@ -1,5 +1,12 @@
 import { createDefaultJobHandlers } from './handlers.js'
-import { InMemoryJobQueue, type QueueMetrics, type QueuedJobReceipt } from './queue.js'
+import {
+  InMemoryJobQueue,
+  type QueueDepthReport,
+  type QueueMetrics,
+  type QueuedJobReceipt,
+  type StuckJobSweepOptions,
+  type StuckJobSweepResult,
+} from './queue.js'
 import { type EnqueueOptions, type JobPayloadByType, type JobType } from './types.js'
 import { recoverPendingExportJobs } from '../services/exportQueue.js'
 import {
@@ -104,6 +111,14 @@ export class BackgroundJobSystem {
 
   getMetrics(): QueueMetrics {
     return this.queue.getMetrics()
+  }
+
+  getDepthReport(): QueueDepthReport {
+    return this.queue.getDepthReport()
+  }
+
+  sweepStuckJobs(options: StuckJobSweepOptions = {}): StuckJobSweepResult {
+    return this.queue.sweepStuckJobs(options)
   }
 
   private scheduleRecurringJobs(): void {

--- a/src/routes/jobs.ts
+++ b/src/routes/jobs.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 import { UserRole } from '../types/user.js'
 import type { BackgroundJobSystem } from '../jobs/system.js'
 import {
+  isJobType,
+  isPayloadForJobType,
   type EnqueueOptions,
   type JobPayloadByType,
   type JobType,
@@ -17,6 +19,15 @@ import { createAuditLog } from '../lib/audit-logs.js'
 import { enqueueJobSchema } from '../lib/validation.js'
 
 const jobsJson = requireJson({ maxBytes: JOBS_JSON_MAX_BYTES })
+const MAX_STALE_AFTER_MS = 86_400_000
+
+const sweepStuckJobsSchema = z.object({
+  staleAfterMs: z.coerce.number().int().positive().max(MAX_STALE_AFTER_MS).optional(),
+})
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null
+}
 
 // Helpers
 const enqueueTypedJob = (
@@ -57,6 +68,42 @@ export const createJobsRouter = (jobSystem: BackgroundJobSystem, options: JobsRo
   // GET /metrics — internal queue metrics (admin only)
   jobsRouter.get('/metrics', (_req, res) => {
     res.json(jobSystem.getMetrics())
+  })
+
+  // GET /depth — queue depth grouped by job type and state (admin only)
+  jobsRouter.get('/depth', (_req, res) => {
+    res.json(jobSystem.getDepthReport())
+  })
+
+  // POST /sweep-stuck — reclaim jobs whose active lease exceeded staleAfterMs
+  jobsRouter.post('/sweep-stuck', (req, res) => {
+    const input = sweepStuckJobsSchema.safeParse({
+      staleAfterMs: isRecord(req.body) && req.body.staleAfterMs !== undefined
+        ? req.body.staleAfterMs
+        : req.query.staleAfterMs,
+    })
+    if (!input.success) {
+      res.status(400).json({
+        error: 'Invalid staleAfterMs. It must be a positive integer no greater than 86400000.',
+      })
+      return
+    }
+
+    const result = jobSystem.sweepStuckJobs(input.data)
+    createAuditLog({
+      actor_user_id: req.user!.userId,
+      action: 'job.sweep_stuck',
+      target_type: 'job_queue',
+      target_id: 'in-memory',
+      metadata: {
+        staleAfterMs: result.staleAfterMs,
+        scannedActive: result.scannedActive,
+        reclaimed: result.reclaimed,
+        deadLettered: result.deadLettered,
+      },
+    })
+
+    res.status(202).json({ swept: true, result })
   })
 
   // GET /deadletters — inspect failed jobs that exhausted retries

--- a/src/tests/jobs.sweeper.test.ts
+++ b/src/tests/jobs.sweeper.test.ts
@@ -1,0 +1,270 @@
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { InMemoryJobQueue } from '../jobs/queue.js'
+import { JOB_TYPES, type JobPayloadByType, type JobType } from '../jobs/types.js'
+import { generateValidToken, UserRole } from './helpers/rbacTestUtils.js'
+import type { BackgroundJobSystem } from '../jobs/system.js'
+import type { QueueDepthReport, StuckJobSweepResult } from '../jobs/queue.js'
+import type { RequestHandler } from 'express'
+
+const createAuditLog = mock(() => {})
+
+mock.module('../lib/audit-logs.js', () => ({
+  createAuditLog,
+}))
+
+const { createJobsRouter } = await import('../routes/jobs.js')
+
+const noopLimiter: RequestHandler = (_req, _res, next) => next()
+const adminToken = generateValidToken({ userId: 'admin-jobs-sweeper', role: UserRole.ADMIN })
+const userToken = generateValidToken({ userId: 'user-jobs-sweeper', role: UserRole.USER })
+
+interface ActiveJobSeed<T extends JobType = JobType> {
+  id: string
+  type: T
+  payload: JobPayloadByType[T]
+  attempt: number
+  maxAttempts: number
+  createdAt: number
+  runAt: number
+  activeSince: number
+  leaseId: number
+}
+
+const seedActiveJob = (queue: InMemoryJobQueue, job: ActiveJobSeed) => {
+  const internals = queue as unknown as {
+    activeJobs: Map<string, ActiveJobSeed>
+  }
+  internals.activeJobs.set(job.id, job)
+}
+
+const emptyTypeMetrics = () => Object.fromEntries(
+  JOB_TYPES.map((type) => [
+    type,
+    { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
+  ]),
+) as QueueDepthReport['byType']
+
+const makeDepthReport = (): QueueDepthReport => ({
+  generatedAt: '2026-06-27T04:00:00.000Z',
+  totals: {
+    queued: 2,
+    delayed: 1,
+    active: 1,
+    deadLetter: 0,
+  },
+  byType: {
+    ...emptyTypeMetrics(),
+    'oracle.call': { queued: 1, delayed: 0, active: 1, completed: 0, failed: 0, deadLetter: 0 },
+    'sessions.cleanup': { queued: 0, delayed: 1, active: 0, completed: 0, failed: 0, deadLetter: 0 },
+  },
+})
+
+const makeSweepResult = (): StuckJobSweepResult => ({
+  scannedActive: 2,
+  staleAfterMs: 1_000,
+  reclaimed: 1,
+  deadLettered: 1,
+  untouched: 0,
+  reclaimedJobs: [
+    {
+      jobId: 'stale-reclaimed',
+      type: 'oracle.call',
+      attempt: 1,
+      maxAttempts: 3,
+      activeForMs: 5_000,
+    },
+  ],
+  deadLetteredJobs: [
+    {
+      jobId: 'stale-deadletter',
+      type: 'notification.send',
+      attempt: 1,
+      maxAttempts: 1,
+      activeForMs: 5_000,
+    },
+  ],
+})
+
+const makeApp = (jobSystem: Partial<BackgroundJobSystem>) => {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/jobs', createJobsRouter(jobSystem as BackgroundJobSystem, { enqueueLimiter: noopLimiter }))
+  return app
+}
+
+describe('InMemoryJobQueue depth reporting and stuck-job sweeper', () => {
+  test('depth report groups queued and delayed jobs by every supported type', () => {
+    const queue = new InMemoryJobQueue()
+    queue.registerHandler('oracle.call', async () => {})
+    queue.registerHandler('sessions.cleanup', async () => {})
+
+    queue.enqueue('oracle.call', { oracle: 'test', symbol: 'XLM' })
+    queue.enqueue('sessions.cleanup', {}, { delayMs: 60_000 })
+
+    const report = queue.getDepthReport()
+
+    expect(report.totals.queued).toBe(1)
+    expect(report.totals.delayed).toBe(1)
+    expect(report.byType['oracle.call'].queued).toBe(1)
+    expect(report.byType['sessions.cleanup'].delayed).toBe(1)
+    expect(Object.keys(report.byType).sort()).toEqual([...JOB_TYPES].sort())
+  })
+
+  test('sweeper leaves fresh active leases untouched', () => {
+    const now = Date.now()
+    const queue = new InMemoryJobQueue()
+    seedActiveJob(queue, {
+      id: 'fresh-job',
+      type: 'oracle.call',
+      payload: { oracle: 'test', symbol: 'XLM' },
+      attempt: 1,
+      maxAttempts: 3,
+      createdAt: now - 5_000,
+      runAt: now - 5_000,
+      activeSince: now - 100,
+      leaseId: 1,
+    })
+
+    const result = queue.sweepStuckJobs({ staleAfterMs: 1_000, now })
+
+    expect(result).toMatchObject({
+      scannedActive: 1,
+      reclaimed: 0,
+      deadLettered: 0,
+      untouched: 1,
+    })
+    expect(queue.getMetrics().activeJobs).toBe(1)
+  })
+
+  test('sweeper requeues stale jobs that still have attempts remaining', () => {
+    const now = Date.now()
+    const queue = new InMemoryJobQueue()
+    seedActiveJob(queue, {
+      id: 'stale-reclaimed',
+      type: 'oracle.call',
+      payload: { oracle: 'test', symbol: 'XLM' },
+      attempt: 1,
+      maxAttempts: 3,
+      createdAt: now - 10_000,
+      runAt: now - 10_000,
+      activeSince: now - 5_000,
+      leaseId: 1,
+    })
+
+    const result = queue.sweepStuckJobs({ staleAfterMs: 1_000, now })
+
+    expect(result.reclaimed).toBe(1)
+    expect(result.deadLettered).toBe(0)
+    expect(result.reclaimedJobs[0]).toMatchObject({
+      jobId: 'stale-reclaimed',
+      type: 'oracle.call',
+      attempt: 1,
+      maxAttempts: 3,
+    })
+    expect(queue.getMetrics().activeJobs).toBe(0)
+    expect(queue.getMetrics().queueDepth).toBe(1)
+  })
+
+  test('sweeper dead-letters stale jobs that exhausted max attempts', () => {
+    const now = Date.now()
+    const queue = new InMemoryJobQueue()
+    seedActiveJob(queue, {
+      id: 'stale-deadletter',
+      type: 'notification.send',
+      payload: { recipient: 'ops@example.com', subject: 'queued', body: 'stuck' },
+      attempt: 1,
+      maxAttempts: 1,
+      createdAt: now - 10_000,
+      runAt: now - 10_000,
+      activeSince: now - 5_000,
+      leaseId: 1,
+    })
+
+    const result = queue.sweepStuckJobs({ staleAfterMs: 1_000, now })
+
+    expect(result.deadLettered).toBe(1)
+    expect(result.reclaimed).toBe(0)
+    expect(queue.getMetrics().activeJobs).toBe(0)
+    expect(queue.getMetrics().deadLetterJobs).toBe(1)
+    expect(queue.getDeadLetters()[0]).toMatchObject({
+      jobId: 'stale-deadletter',
+      error: 'Job lease expired after 5000ms',
+    })
+  })
+})
+
+describe('Jobs router depth and stuck-job sweep endpoints', () => {
+  beforeEach(() => {
+    createAuditLog.mockClear()
+  })
+
+  test('returns queue depth report for admins', async () => {
+    const report = makeDepthReport()
+    const app = makeApp({
+      getDepthReport: mock(() => report),
+    })
+
+    const res = await request(app)
+      .get('/api/jobs/depth')
+      .set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(report)
+    expect(res.body.byType['sessions.cleanup'].delayed).toBe(1)
+  })
+
+  test('rejects depth report for non-admin users', async () => {
+    const app = makeApp({
+      getDepthReport: mock(() => makeDepthReport()),
+    })
+
+    const res = await request(app)
+      .get('/api/jobs/depth')
+      .set('Authorization', `Bearer ${userToken}`)
+
+    expect(res.status).toBe(403)
+  })
+
+  test('sweeps stale jobs and records an audit log', async () => {
+    const result = makeSweepResult()
+    const sweepStuckJobs = mock(() => result)
+    const app = makeApp({ sweepStuckJobs })
+
+    const res = await request(app)
+      .post('/api/jobs/sweep-stuck')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ staleAfterMs: 1_000 })
+
+    expect(res.status).toBe(202)
+    expect(res.body).toEqual({ swept: true, result })
+    expect(sweepStuckJobs).toHaveBeenCalledWith({ staleAfterMs: 1_000 })
+    expect(createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor_user_id: 'admin-jobs-sweeper',
+        action: 'job.sweep_stuck',
+        target_type: 'job_queue',
+        metadata: {
+          staleAfterMs: 1_000,
+          scannedActive: 2,
+          reclaimed: 1,
+          deadLettered: 1,
+        },
+      }),
+    )
+  })
+
+  test('rejects invalid staleAfterMs values before sweeping', async () => {
+    const sweepStuckJobs = mock(() => makeSweepResult())
+    const app = makeApp({ sweepStuckJobs })
+
+    const res = await request(app)
+      .post('/api/jobs/sweep-stuck')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ staleAfterMs: 0 })
+
+    expect(res.status).toBe(400)
+    expect(sweepStuckJobs).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Add admin-only queue depth reporting grouped by job type/state at `GET /api/jobs/depth`.
- Add `POST /api/jobs/sweep-stuck` to reclaim stale active leases, preserving attempts for retriable jobs and moving exhausted jobs to DLQ.
- Add lease ids so late handler completions from reclaimed jobs cannot double-count, and include `sessions.cleanup` in type metrics.
- Document the operation and regenerate OpenAPI docs.

Fixes #725

## Validation
- `C:\Users\jhona\.bun\bin\bun.exe test src\tests\jobs.sweeper.test.ts` (8 passed)
- `node --experimental-vm-modules node_modules\jest\bin\jest.js --runTestsByPath .\src\tests\jobs.deadletter.test.ts --runInBand` (7 passed)
- `npm run openapi:generate`
- `git diff --check`
- `npx tsc --noEmit --pretty false` filtered for `src/jobs/queue.ts`, `src/jobs/system.ts`, `src/routes/jobs.ts`, and `src/tests/jobs.sweeper.test.ts` produced no touched-file errors; full tsc still has existing unrelated OpenAPI generator typing errors in other sections

Payout address: 0x06f44f4839fd5df4f4670036d028b29dec939363