### PR TITLE
feat: add verification idempotency keys

### DIFF
--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-POST `/api/vaults` supports client-controlled idempotency via the `idempotency-key` request header. Sending the same key with an identical payload returns the original response without creating a duplicate vault. Sending the same key with a *different* payload returns a 409 to signal a conflict.
+POST `/api/vaults` and POST `/api/verifications` support client-controlled idempotency via the `idempotency-key` request header. Sending the same key with an identical payload returns the original response without creating a duplicate vault or verification decision. Sending the same key with a *different* payload returns a 409 to signal a conflict.
 
 ---
 
@@ -40,6 +40,7 @@ idempotency-key: <256 chars>             # exceeds maximum length
 | Valid key, repeated request, **same** payload | 200 | Cached response replayed; `idempotency.replayed: true` |
 | Valid key, repeated request, **different** payload | 409 | Conflict; no side effects |
 | Invalid key format | 400 | Key rejected before any business logic |
+| Valid key expires after TTL | 201 | Request may execute again after the server-side idempotency TTL elapses |
 
 ---
 
@@ -51,6 +52,16 @@ idempotency-key: <256 chars>             # exceeds maximum length
 {
   "vault": { "id": "...", "milestones": [...], ... },
   "onChain": { "payload": { "method": "create_vault", ... } },
+  "idempotency": { "key": "my-key", "replayed": false }
+}
+```
+
+For verification decisions, the same envelope is used with verification fields:
+
+```json
+{
+  "verification": { "id": "ver-1", "targetId": "milestone-1", ... },
+  "evidenceReference": { "id": "ev-1", "verificationId": "ver-1", ... },
   "idempotency": { "key": "my-key", "replayed": false }
 }
 ```
@@ -98,7 +109,7 @@ Same body as the original 201, with `idempotency.replayed` set to `true`:
 3. **On 5xx or timeout**: retry with the **same** key and **same** payload. The server will deduplicate.
 4. **On 409**: do **not** retry. A different payload was already submitted under this key. Inspect the original request and generate a new key for a new operation.
 5. **On 400 (`INVALID_IDEMPOTENCY_KEY`)**: fix the key format before retrying.
-6. **On 200 (replay)**: treat this identically to a 201. The `vault.id` in the body is the canonical resource identifier.
+6. **On 200 (replay)**: treat this identically to a 201. The `vault.id` or `verification.id` in the body is the canonical resource identifier.
 
 ---
 
@@ -120,9 +131,13 @@ Idempotency keys are scoped to the authenticated user. User A and User B can eac
 
 The value stored in the idempotency cache is always server-generated (never derived from request data). A client cannot influence the cached response content beyond choosing the idempotency key.
 
+### Concurrent same-key submissions
+
+Concurrent submissions with the same key and same payload share the same in-flight server operation. The first request performs the side effect and subsequent in-flight requests wait for that generated response instead of submitting a second verification or vault creation.
+
 ### Scope of deduplication
 
-The idempotency guarantee covers a single endpoint: `POST /api/vaults`. Other endpoints are not covered and should not be passed this header.
+The idempotency guarantee covers `POST /api/vaults` and `POST /api/verifications`. Keys are scoped by endpoint operation and authenticated user, so the same client key can be safely reused for unrelated endpoint families without collision.
 
 ---
 
@@ -132,7 +147,7 @@ The idempotency guarantee covers a single endpoint: `POST /api/vaults`. Other en
 |-----------|----------|
 | Key validation | `src/services/idempotency.ts` → `validateIdempotencyKey` |
 | Payload hashing | `src/services/idempotency.ts` → `hashRequestPayload` |
-| Store read/write | `src/services/idempotency.ts` → `getIdempotentResponse` / `saveIdempotentResponse` |
-| Route integration | `src/routes/vaults.ts` → `POST /` handler |
+| Store read/write | `src/services/idempotency.ts` → `getIdempotentResponse` / `saveIdempotentResponse` / `runIdempotentRequest` |
+| Route integration | `src/routes/vaults.ts` and `src/routes/verifications.ts` → `POST /` handlers |
 | Unit tests | `src/tests/eventIdempotency.test.ts` (describe blocks: `validateIdempotencyKey`, `hashRequestPayload`, `idempotency store`) |
-| Route-level tests | `tests/vaults.test.ts` and `src/routes/vaults.test.ts` |
+| Route-level tests | `tests/vaults.test.ts`, `src/routes/vaults.test.ts`, and `src/tests/verifications.idempotency.test.ts` |

--- a/src/lib/audit-logs.ts
+++ b/src/lib/audit-logs.ts
@@ -77,6 +77,7 @@ const sanitizeMetadata = (metadata: Record<string, unknown> = {}): AuditLogMetad
 
 export const createAuditLog = async (
   entry: Omit<AuditLog, 'id' | 'created_at'> & { organization_id?: string },
+  trx?: Knex.Transaction,
 ): Promise<AuditLog> => {
   if (!entry.actor_user_id || !entry.action || !entry.target_type || !entry.target_id) {
     throw new Error('Invalid audit log entry: missing required fields')
@@ -115,7 +116,7 @@ export const createAuditLog = async (
     insertPayload.organization_id = auditLog.organization_id
   }
 
-  const [insertedLog] = await db('audit_logs').insert(insertPayload).returning('*')
+  const [insertedLog] = await (trx ?? db)('audit_logs').insert(insertPayload).returning('*')
 
   return insertedLog
 }

--- a/src/routes/verifications.ts
+++ b/src/routes/verifications.ts
@@ -7,6 +7,12 @@ import { AppError } from '../middleware/errorHandler.js'
 import { createEvidenceReference, EvidenceReferenceValidationError } from '../services/evidence.js'
 import { db } from '../db/knex.js'
 import { retryWithBackoff } from '../utils/retry.js'
+import {
+  hashRequestPayload,
+  IdempotencyConflictError,
+  runIdempotentRequest,
+  validateIdempotencyKey,
+} from '../services/idempotency.js'
 
 export const verificationsRouter = Router()
 
@@ -49,55 +55,97 @@ verificationsRouter.post('/', authenticate, requireVerifier, async (req: Request
     return next(AppError.badRequest('evidenceReferenceUrl is required'))
   }
 
+  const clientIdempotencyKey = req.header('idempotency-key')?.trim()
+  if (clientIdempotencyKey !== undefined && !validateIdempotencyKey(clientIdempotencyKey)) {
+    return next(AppError.badRequest(
+      'Idempotency key must be 1-255 characters and contain only letters, digits, hyphens, and underscores.',
+    ))
+  }
+
   try {
     const cleanTargetId = targetId.trim()
+    const cleanEvidenceReferenceUrl = evidenceReferenceUrl.trim()
+    const requestFingerprint = {
+      targetId: cleanTargetId,
+      result,
+      disputed: !!disputed,
+      evidenceHash: cleanEvidenceHash,
+      evidenceReferenceUrl: cleanEvidenceReferenceUrl,
+    }
 
-    // Wrap recordVerification + createAuditLog in a single Knex transaction so
-    // a crash between the two writes cannot leave the verification row without
-    // an audit trail.  createEvidenceReference uses Prisma and cannot join the
-    // Knex transaction; it is idempotent (ON CONFLICT DO UPDATE) so it is safe
-    // to call after the Knex tx commits.
-    const rec = await retryWithBackoff(
-      () =>
-        db.transaction(async (trx) => {
-          const verification = await recordVerification(
-            verifierUserId,
-            cleanTargetId,
-            result,
-            !!disputed,
-            cleanEvidenceHash,
-            trx,
-          )
+    const recordDecision = async () => {
+      // Wrap recordVerification + createAuditLog in a single Knex transaction so
+      // a crash between the two writes cannot leave the verification row without
+      // an audit trail.  createEvidenceReference uses Prisma and cannot join the
+      // Knex transaction; it is idempotent (ON CONFLICT DO UPDATE) so it is safe
+      // to call after the Knex tx commits.
+      const rec = await retryWithBackoff(
+        () =>
+          db.transaction(async (trx) => {
+            const verification = await recordVerification(
+              verifierUserId,
+              cleanTargetId,
+              result,
+              !!disputed,
+              cleanEvidenceHash,
+              trx,
+            )
 
-          await createAuditLog(
-            {
-              actor_user_id: verifierUserId,
-              action: 'verification.decision.recorded',
-              target_type: 'verification',
-              target_id: cleanTargetId,
-              metadata: {
-                result,
-                disputed: !!disputed,
-                evidence_hash: cleanEvidenceHash,
+            await createAuditLog(
+              {
+                actor_user_id: verifierUserId,
+                action: 'verification.decision.recorded',
+                target_type: 'verification',
+                target_id: cleanTargetId,
+                metadata: {
+                  result,
+                  disputed: !!disputed,
+                  evidence_hash: cleanEvidenceHash,
+                },
               },
-            },
-            trx,
-          )
+              trx,
+            )
 
-          return verification
-        }),
-      undefined,
-      isSerializationError,
-    )
+            return verification
+          }),
+        undefined,
+        isSerializationError,
+      )
 
-    const evidenceReference = await createEvidenceReference(
-      rec.id,
-      evidenceHash.trim(),
-      evidenceReferenceUrl.trim(),
-    )
+      const evidenceReference = await createEvidenceReference(
+        rec.id,
+        cleanEvidenceHash,
+        cleanEvidenceReferenceUrl,
+      )
 
-    res.status(201).json({ verification: rec, evidenceReference })
+      return { verification: rec, evidenceReference }
+    }
+
+    if (clientIdempotencyKey) {
+      const scopedKey = `verification:${verifierUserId}:${clientIdempotencyKey}`
+      const hash = hashRequestPayload(requestFingerprint)
+      const { response, replayed } = await runIdempotentRequest(
+        scopedKey,
+        hash,
+        recordDecision,
+      )
+
+      res.status(replayed ? 200 : 201).json({
+        ...response,
+        idempotency: {
+          key: clientIdempotencyKey,
+          replayed,
+        },
+      })
+      return
+    }
+
+    res.status(201).json(await recordDecision())
   } catch (error: any) {
+    if (error instanceof IdempotencyConflictError || error?.name === 'IdempotencyConflictError') {
+      return next(AppError.conflict('Idempotency key has already been used with a different payload.'))
+    }
+
     if (error?.name === 'VerificationConflictError') {
       return next(AppError.conflict('conflicting verification decision already exists'))
     }

--- a/src/services/idempotency.ts
+++ b/src/services/idempotency.ts
@@ -10,15 +10,52 @@ export class IdempotencyConflictError extends Error {
 }
 
 // In-memory store for idempotent responses (replaces DB for now)
-const idempotencyStore = new Map<string, { hash: string; response: unknown }>()
+const idempotencyStore = new Map<string, { hash: string; response: unknown; expiresAt: number }>()
+const inFlightRequests = new Map<string, { hash: string; promise: Promise<unknown> }>()
+const IDEMPOTENCY_KEY_RE = /^[A-Za-z0-9_-]{1,255}$/
+const DEFAULT_IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000
 
-export function hashRequestPayload(body: unknown): string {
-  return createHash('sha256').update(JSON.stringify(body)).digest('hex')
+const resolveDefaultTtlMs = (): number => {
+  const configured = Number(process.env.IDEMPOTENCY_TTL_MS)
+  if (Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured)
+  }
+  return DEFAULT_IDEMPOTENCY_TTL_MS
 }
 
-export async function getIdempotentResponse<T>(key: string, hash: string): Promise<T | null> {
+const canonicalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item))
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonicalize(item)]),
+    )
+  }
+  return value
+}
+
+export function validateIdempotencyKey(key: string): boolean {
+  return IDEMPOTENCY_KEY_RE.test(key)
+}
+
+export function hashRequestPayload(body: unknown): string {
+  return createHash('sha256').update(JSON.stringify(canonicalize(body))).digest('hex')
+}
+
+export async function getIdempotentResponse<T>(
+  key: string,
+  hash: string,
+  now: number = Date.now(),
+): Promise<T | null> {
   const entry = idempotencyStore.get(key)
   if (!entry) return null
+  if (entry.expiresAt <= now) {
+    idempotencyStore.delete(key)
+    return null
+  }
   if (entry.hash !== hash) throw new IdempotencyConflictError()
   return entry.response as T
 }
@@ -27,13 +64,49 @@ export async function saveIdempotentResponse(
   key: string,
   hash: string,
   _id: string,
-  response: unknown
+  response: unknown,
+  ttlMs: number = resolveDefaultTtlMs(),
 ): Promise<void> {
-  idempotencyStore.set(key, { hash, response })
+  idempotencyStore.set(key, { hash, response, expiresAt: Date.now() + ttlMs })
+}
+
+export async function runIdempotentRequest<T>(
+  key: string,
+  hash: string,
+  producer: () => Promise<T>,
+): Promise<{ response: T; replayed: boolean }> {
+  const stored = await getIdempotentResponse<T>(key, hash)
+  if (stored) {
+    return { response: stored, replayed: true }
+  }
+
+  const inFlight = inFlightRequests.get(key)
+  if (inFlight) {
+    if (inFlight.hash !== hash) {
+      throw new IdempotencyConflictError()
+    }
+    return { response: await inFlight.promise as T, replayed: true }
+  }
+
+  const promise = (async () => {
+    const response = await producer()
+    await saveIdempotentResponse(key, hash, key, response)
+    return response
+  })()
+  inFlightRequests.set(key, { hash, promise })
+
+  try {
+    return { response: await promise, replayed: false }
+  } finally {
+    if (inFlightRequests.get(key)?.promise === promise) {
+      inFlightRequests.delete(key)
+    }
+  }
 }
 
 export function resetIdempotencyStore(): void {
   idempotencyStore.clear()
+  inFlightRequests.clear()
 }
 
 /**

--- a/src/tests/verifications.idempotency.test.ts
+++ b/src/tests/verifications.idempotency.test.ts
@@ -1,0 +1,237 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const mockRecordVerification = mock(async () => MOCK_REC)
+const mockCreateAuditLog = mock(async () => MOCK_AUDIT)
+const mockCreateEvidenceReference = mock(async () => MOCK_EVIDENCE)
+const mockListVerifications = mock(async () => [])
+const mockTrx = { isMockTrx: true }
+const mockDbTransaction = mock(async (cb: (trx: any) => Promise<any>) => cb(mockTrx))
+
+mock.module('../db/knex.js', () => ({
+  db: { transaction: mockDbTransaction },
+  closeDatabase: mock(() => {}),
+}))
+
+mock.module('../utils/retry.js', () => ({
+  retryWithBackoff: mock(async (op: () => Promise<any>) => op()),
+  isRetryable: mock(() => false),
+  DEFAULT_RETRY_CONFIG: {},
+  sleep: mock(async () => {}),
+  calculateJitter: mock(() => 0),
+}))
+
+mock.module('../middleware/auth.js', () => ({
+  authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = { userId: 'verifier-1', role: 'VERIFIER' } as any
+    next()
+  },
+}))
+
+mock.module('../middleware/rbac.js', () => ({
+  requireVerifier: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+  requireAdmin: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}))
+
+mock.module('../services/verifiers.js', () => ({
+  recordVerification: mockRecordVerification,
+  listVerifications: mockListVerifications,
+}))
+
+mock.module('../lib/audit-logs.js', () => ({
+  createAuditLog: mockCreateAuditLog,
+}))
+
+mock.module('../services/evidence.js', () => ({
+  createEvidenceReference: mockCreateEvidenceReference,
+  EvidenceReferenceValidationError: class EvidenceReferenceValidationError extends Error {
+    constructor(message: string) {
+      super(message)
+      this.name = 'EvidenceReferenceValidationError'
+    }
+  },
+}))
+
+const { verificationsRouter } = await import('../routes/verifications.js')
+const { resetIdempotencyStore } = await import('../services/idempotency.js')
+
+const HASH = 'a'.repeat(64)
+const REF_URL = 'https://s3.example.com/evidence.pdf?Expires=32503680000&signature=abc'
+
+const VALID_BODY = {
+  targetId: 'milestone-1',
+  result: 'approved',
+  evidenceHash: HASH,
+  evidenceReferenceUrl: REF_URL,
+}
+
+const MOCK_REC = {
+  id: 'ver-1',
+  verifierUserId: 'verifier-1',
+  targetId: 'milestone-1',
+  result: 'approved',
+  evidenceHash: HASH,
+  disputed: false,
+  timestamp: '2026-06-27T04:00:00.000Z',
+}
+
+const MOCK_REC_2 = {
+  ...MOCK_REC,
+  id: 'ver-2',
+  timestamp: '2026-06-27T04:01:00.000Z',
+}
+
+const MOCK_AUDIT = {
+  id: 'audit-1',
+  actor_user_id: 'verifier-1',
+  action: 'verification.decision.recorded',
+  target_type: 'verification',
+  target_id: 'milestone-1',
+  metadata: {},
+  created_at: '2026-06-27T04:00:00.000Z',
+}
+
+const MOCK_EVIDENCE = {
+  id: 'ev-1',
+  verificationId: 'ver-1',
+  evidenceHash: HASH,
+  referenceUrl: REF_URL,
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  createdAt: '2026-06-27T04:00:00.000Z',
+}
+
+const makeApp = () => {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/verifications', verificationsRouter)
+  app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(err.statusCode ?? err.status ?? 500).json({ error: err.message })
+  })
+  return app
+}
+
+const app = makeApp()
+
+const pause = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function setupHappyPath(record = MOCK_REC) {
+  mockRecordVerification.mockImplementation(async () => record)
+  mockCreateAuditLog.mockImplementation(async () => MOCK_AUDIT)
+  mockCreateEvidenceReference.mockImplementation(async () => MOCK_EVIDENCE)
+  mockDbTransaction.mockImplementation(async (cb: (trx: any) => Promise<any>) => cb(mockTrx))
+}
+
+describe('verifications idempotency-key support', () => {
+  beforeEach(() => {
+    resetIdempotencyStore()
+    delete process.env.IDEMPOTENCY_TTL_MS
+    mockRecordVerification.mockClear()
+    mockCreateAuditLog.mockClear()
+    mockCreateEvidenceReference.mockClear()
+    mockDbTransaction.mockClear()
+    setupHappyPath()
+  })
+
+  afterEach(() => {
+    delete process.env.IDEMPOTENCY_TTL_MS
+    resetIdempotencyStore()
+  })
+
+  test('replays an identical request without recording another verification', async () => {
+    const first = await request(app)
+      .post('/api/verifications')
+      .set('idempotency-key', 'checkin-same-key')
+      .send(VALID_BODY)
+
+    const replay = await request(app)
+      .post('/api/verifications')
+      .set('idempotency-key', 'checkin-same-key')
+      .send({ ...VALID_BODY })
+
+    expect(first.status).toBe(201)
+    expect(first.body.idempotency).toEqual({ key: 'checkin-same-key', replayed: false })
+    expect(replay.status).toBe(200)
+    expect(replay.body.verification.id).toBe('ver-1')
+    expect(replay.body.idempotency).toEqual({ key: 'checkin-same-key', replayed: true })
+    expect(mockRecordVerification).toHaveBeenCalledTimes(1)
+    expect(mockCreateEvidenceReference).toHaveBeenCalledTimes(1)
+  })
+
+  test('rejects the same key with a conflicting body before side effects', async () => {
+    await request(app)
+      .post('/api/verifications')
+      .set('idempotency-key', 'checkin-conflict-key')
+      .send(VALID_BODY)
+      .expect(201)
+
+    const conflict = await request(app)
+      .post('/api/verifications')
+      .set('idempotency-key', 'checkin-conflict-key')
+      .send({ ...VALID_BODY, result: 'rejected' })
+
+    expect(conflict.status).toBe(409)
+    expect(conflict.body.error).toMatch(/different payload/i)
+    expect(mockRecordVerification).toHaveBeenCalledTimes(1)
+  })
+
+  test('evicts expired keys so a later retry can execute again', async () => {
+    process.env.IDEMPOTENCY_TTL_MS = '1'
+
+    await request(app)
+      .post('/api/verifications')
+      .set('idempotency-key', 'checkin-ttl-key')
+      .send(VALID_BODY)
+      .expect(201)
+
+    await pause(10)
+    setupHappyPath(MOCK_REC_2)
+
+    const afterTtl = await request(app)
+      .post('/api/verifications')
+      .set('idempotency-key', 'checkin-ttl-key')
+      .send(VALID_BODY)
+
+    expect(afterTtl.status).toBe(201)
+    expect(afterTtl.body.verification.id).toBe('ver-2')
+    expect(afterTtl.body.idempotency).toEqual({ key: 'checkin-ttl-key', replayed: false })
+    expect(mockRecordVerification).toHaveBeenCalledTimes(2)
+  })
+
+  test('deduplicates concurrent same-key submissions while the first is in flight', async () => {
+    let resolveVerification: (value: typeof MOCK_REC) => void = () => {}
+    const pendingVerification = new Promise<typeof MOCK_REC>((resolve) => {
+      resolveVerification = resolve
+    })
+    mockRecordVerification.mockImplementationOnce(async () => pendingVerification)
+
+    const first = request(app)
+      .post('/api/verifications')
+      .set('idempotency-key', 'checkin-concurrent-key')
+      .send(VALID_BODY)
+    const second = request(app)
+      .post('/api/verifications')
+      .set('idempotency-key', 'checkin-concurrent-key')
+      .send(VALID_BODY)
+
+    await pause(5)
+    resolveVerification(MOCK_REC)
+
+    const [firstRes, secondRes] = await Promise.all([first, second])
+
+    expect(firstRes.status).toBe(201)
+    expect(secondRes.status).toBe(200)
+    expect(secondRes.body.idempotency).toEqual({ key: 'checkin-concurrent-key', replayed: true })
+    expect(mockRecordVerification).toHaveBeenCalledTimes(1)
+  })
+
+  test('rejects invalid idempotency-key format', async () => {
+    const res = await request(app)
+      .post('/api/verifications')
+      .set('idempotency-key', 'bad key!')
+      .send(VALID_BODY)
+
+    expect(res.status).toBe(400)
+    expect(mockRecordVerification).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Add `idempotency-key` handling to `POST /api/verifications`.
- Reuse the shared idempotency store with canonical request hashing, TTL eviction, same-key conflict detection, and in-flight dedupe for concurrent retries.
- Preserve the existing verification/audit transaction path and make `createAuditLog` accept the optional transaction it already receives.
- Document verification idempotency semantics in `docs/idempotency.md`.

Fixes #727

## Validation
- `C:\Users\jhona\.bun\bin\bun.exe test src\tests\verifications.idempotency.test.ts` (5 passed)
- `node --experimental-vm-modules node_modules\jest\bin\jest.js --runTestsByPath .\src\tests\verifications.transaction.test.ts --runInBand` (13 passed)
- `git diff --check`
- `npx tsc --noEmit --pretty false` filtered for `src/services/idempotency.ts`, `src/routes/verifications.ts`, `src/tests/verifications.idempotency.test.ts`, and `src/lib/audit-logs.ts` produced no touched-file errors; full TypeScript remains blocked by existing unrelated baseline errors elsewhere
- `C:\Users\jhona\.bun\bin\bun.exe test src\tests\eventProcessor.idempotency.test.ts` is blocked locally because Postgres is not running on `localhost:5432`

Payout address: 0x06f44f4839fd5df4f4670036d028b29dec939363