### PR TITLE
test: organization service lifecycle and uniqueness

### DIFF
--- a/src/services/organization.test.ts
+++ b/src/services/organization.test.ts
@@ -1,0 +1,323 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { randomUUID } from 'node:crypto'
+import type { Knex } from 'knex'
+import {
+  OrganizationConflictError,
+  OrganizationService,
+  OrganizationValidationError,
+} from './organization.js'
+import { setupTestDatabase, teardownTestDatabase } from '../tests/helpers/testDatabase.js'
+import type { Organization } from '../types/enterprise.js'
+
+const describeWithDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+type OrganizationRow = Organization & {
+  id: string
+  name: string
+  slug: string
+  metadata: string | null
+  created_at: Date
+  updated_at: Date
+}
+
+type Tables = {
+  organizations: OrganizationRow[]
+  teams: Array<{ id: string; organization_id: string; name: string; slug: string }>
+  memberships: Array<{ id: string; organization_id: string; user_id: string; team_id: string | null; role: string }>
+}
+
+type Predicate<T> = (row: T) => boolean
+
+class FakeOrganizationQuery<T extends Record<string, any>> {
+  private readonly predicates: Predicate<T>[] = []
+  private insertRows: Partial<T>[] | null = null
+  private updatePatch: Partial<T> | null = null
+
+  constructor(
+    private readonly table: keyof Tables,
+    private readonly tables: Tables,
+  ) {}
+
+  insert(row: Partial<T> | Partial<T>[]) {
+    this.insertRows = Array.isArray(row) ? row : [row]
+    return this
+  }
+
+  where(criteria: Partial<T>) {
+    this.predicates.push((row) =>
+      Object.entries(criteria).every(([key, value]) => row[key] === value),
+    )
+    return this
+  }
+
+  whereNot(criteria: Partial<T>) {
+    this.predicates.push((row) =>
+      Object.entries(criteria).every(([key, value]) => row[key] !== value),
+    )
+    return this
+  }
+
+  select() {
+    return this
+  }
+
+  update(patch: Partial<T>) {
+    this.updatePatch = patch
+    return this
+  }
+
+  async returning() {
+    if (this.insertRows) {
+      return this.insertRows.map((row) => this.insertOne(row))
+    }
+
+    if (this.updatePatch) {
+      const updated: T[] = []
+      for (const row of this.rows()) {
+        if (this.matches(row)) {
+          Object.assign(row, this.updatePatch)
+          updated.push({ ...row })
+        }
+      }
+      return updated
+    }
+
+    throw new Error('returning called without insert or update')
+  }
+
+  async first() {
+    return this.execute()[0] ?? null
+  }
+
+  async delete() {
+    const before = this.rows().length
+    const deleted = this.rows().filter((row) => this.matches(row))
+    const kept = this.rows().filter((row) => !this.matches(row))
+    this.setRows(kept)
+
+    if (this.table === 'organizations') {
+      const deletedIds = new Set(deleted.map((row) => row.id))
+      this.tables.teams = this.tables.teams.filter((team) => !deletedIds.has(team.organization_id))
+      this.tables.memberships = this.tables.memberships.filter(
+        (membership) => !deletedIds.has(membership.organization_id),
+      )
+    }
+
+    return before - kept.length
+  }
+
+  then<TResult1 = T[], TResult2 = never>(
+    onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(this.execute()).then(onfulfilled, onrejected)
+  }
+
+  private insertOne(row: Partial<T>) {
+    const now = new Date()
+    const inserted = {
+      id: randomUUID(),
+      created_at: now,
+      updated_at: now,
+      ...row,
+    } as T
+
+    this.rows().push(inserted)
+    return { ...inserted }
+  }
+
+  private execute() {
+    return this.rows().filter((row) => this.matches(row)).map((row) => ({ ...row }))
+  }
+
+  private matches(row: T) {
+    return this.predicates.every((predicate) => predicate(row))
+  }
+
+  private rows(): T[] {
+    return this.tables[this.table] as T[]
+  }
+
+  private setRows(rows: T[]) {
+    ;(this.tables[this.table] as T[]) = rows
+  }
+}
+
+function createFakeDb(tables: Tables) {
+  return ((table: keyof Tables) => new FakeOrganizationQuery(table, tables)) as unknown as Knex
+}
+
+function createHarness() {
+  const tables: Tables = {
+    organizations: [],
+    teams: [],
+    memberships: [],
+  }
+
+  return {
+    service: new OrganizationService(createFakeDb(tables)),
+    tables,
+  }
+}
+
+async function expectConflict(promise: Promise<unknown>, field: 'name' | 'slug') {
+  await expect(promise).rejects.toBeInstanceOf(OrganizationConflictError)
+  await expect(promise).rejects.toHaveProperty('field', field)
+}
+
+describe('OrganizationService lifecycle and uniqueness guards', () => {
+  let service: OrganizationService
+  let tables: Tables
+
+  beforeEach(() => {
+    const harness = createHarness()
+    service = harness.service
+    tables = harness.tables
+  })
+
+  test('creates, reads, and lists organizations with normalized input', async () => {
+    const created = await service.createOrganization({
+      name: '  Acme Grants  ',
+      slug: 'acme-grants',
+      metadata: { tier: 'pro' },
+    })
+
+    expect(created.id).toBeTruthy()
+    expect(created.name).toBe('Acme Grants')
+    expect(created.slug).toBe('acme-grants')
+    expect(created.metadata).toBe(JSON.stringify({ tier: 'pro' }))
+    expect(await service.getOrganizationById(created.id)).toMatchObject({ id: created.id })
+    expect(await service.getOrganizationBySlug('acme-grants')).toMatchObject({ id: created.id })
+    expect(await service.listOrganizations()).toHaveLength(1)
+  })
+
+  test('rejects duplicate organization names and slugs before insert', async () => {
+    await service.createOrganization({ name: 'Acme', slug: 'acme' })
+
+    await expectConflict(
+      service.createOrganization({ name: 'Acme', slug: 'acme-labs' }),
+      'name',
+    )
+    await expectConflict(
+      service.createOrganization({ name: 'Acme Labs', slug: 'acme' }),
+      'slug',
+    )
+
+    expect(tables.organizations).toHaveLength(1)
+  })
+
+  test('renames organizations while blocking name and slug collisions', async () => {
+    const alpha = await service.createOrganization({ name: 'Alpha', slug: 'alpha' })
+    const beta = await service.createOrganization({ name: 'Beta', slug: 'beta' })
+
+    const renamed = await service.renameOrganization(alpha.id, 'Alpha Prime', 'alpha-prime')
+    expect(renamed).toMatchObject({ id: alpha.id, name: 'Alpha Prime', slug: 'alpha-prime' })
+
+    await expectConflict(service.renameOrganization(alpha.id, beta.name, 'alpha-next'), 'name')
+    await expectConflict(service.renameOrganization(alpha.id, 'Alpha Next', beta.slug), 'slug')
+    expect(await service.getOrganizationById(alpha.id)).toMatchObject({
+      name: 'Alpha Prime',
+      slug: 'alpha-prime',
+    })
+  })
+
+  test('updates metadata and returns null for missing organizations', async () => {
+    const org = await service.createOrganization({ name: 'Acme', slug: 'acme' })
+
+    const updated = await service.updateOrganization(org.id, { metadata: { region: 'latam' } })
+    expect(updated?.metadata).toBe(JSON.stringify({ region: 'latam' }))
+    expect(await service.updateOrganization(randomUUID(), { name: 'Ghost' })).toBeNull()
+  })
+
+  test('rejects invalid create, read, and update input', async () => {
+    await expect(service.createOrganization({ name: '', slug: 'empty-name' }))
+      .rejects.toBeInstanceOf(OrganizationValidationError)
+    await expect(service.createOrganization({ name: 'Bad Slug', slug: 'Bad Slug' }))
+      .rejects.toBeInstanceOf(OrganizationValidationError)
+    await expect(service.getOrganizationById('   '))
+      .rejects.toBeInstanceOf(OrganizationValidationError)
+
+    const org = await service.createOrganization({ name: 'Acme', slug: 'acme' })
+    await expect(service.updateOrganization(org.id, {}))
+      .rejects.toBeInstanceOf(OrganizationValidationError)
+  })
+
+  test('deletes organizations and cascades local related rows', async () => {
+    const org = await service.createOrganization({ name: 'Acme', slug: 'acme' })
+    const other = await service.createOrganization({ name: 'Other', slug: 'other' })
+    tables.teams.push(
+      { id: 'team-1', organization_id: org.id, name: 'Ops', slug: 'ops' },
+      { id: 'team-2', organization_id: other.id, name: 'Ops', slug: 'ops' },
+    )
+    tables.memberships.push(
+      { id: 'member-1', organization_id: org.id, user_id: 'alice', team_id: null, role: 'admin' },
+      { id: 'member-2', organization_id: other.id, user_id: 'bob', team_id: null, role: 'member' },
+    )
+
+    expect(await service.deleteOrganization(org.id)).toBe(true)
+    expect(await service.getOrganizationById(org.id)).toBeNull()
+    expect(tables.teams.map((team) => team.id)).toEqual(['team-2'])
+    expect(tables.memberships.map((membership) => membership.id)).toEqual(['member-2'])
+    expect(await service.deleteOrganization(org.id)).toBe(false)
+  })
+})
+
+describeWithDatabase('OrganizationService lifecycle and uniqueness guards (test DB harness)', () => {
+  let db: Knex
+  let service: OrganizationService
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+    service = new OrganizationService(db)
+  })
+
+  beforeEach(async () => {
+    await db('memberships').delete()
+    await db('teams').delete()
+    await db('organizations').delete()
+  })
+
+  afterAll(async () => {
+    if (db) {
+      await db('memberships').delete()
+      await db('teams').delete()
+      await db('organizations').delete()
+      await teardownTestDatabase(db)
+    }
+  })
+
+  test('enforces name and slug uniqueness through service guards', async () => {
+    await service.createOrganization({ name: 'Acme', slug: 'acme' })
+
+    await expectConflict(
+      service.createOrganization({ name: 'Acme', slug: 'acme-foundation' }),
+      'name',
+    )
+    await expectConflict(
+      service.createOrganization({ name: 'Acme Foundation', slug: 'acme' }),
+      'slug',
+    )
+
+    expect(await db('organizations')).toHaveLength(1)
+  })
+
+  test('hard delete uses database cascade for teams and memberships', async () => {
+    const org = await service.createOrganization({ name: 'Cascade Org', slug: 'cascade-org' })
+    await db('teams').insert({
+      organization_id: org.id,
+      name: 'Operations',
+      slug: 'operations',
+    })
+    await db('memberships').insert({
+      organization_id: org.id,
+      user_id: 'cascade-user',
+      role: 'admin',
+    })
+
+    expect(await service.deleteOrganization(org.id)).toBe(true)
+
+    expect(await db('organizations').where({ id: org.id })).toHaveLength(0)
+    expect(await db('teams').where({ organization_id: org.id })).toHaveLength(0)
+    expect(await db('memberships').where({ organization_id: org.id })).toHaveLength(0)
+  })
+})

--- a/src/services/organization.ts
+++ b/src/services/organization.ts
@@ -1,25 +1,197 @@
 import db from '../db/index.js'
+import type { Knex } from 'knex'
 import type { Organization, CreateOrganizationInput } from '../types/enterprise.js'
 
-export const createOrganization = async (input: CreateOrganizationInput): Promise<Organization> => {
-  const [org] = await db('organizations')
-    .insert({
-      name: input.name,
-      slug: input.slug,
-      metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+export interface UpdateOrganizationInput {
+  name?: string
+  slug?: string
+  metadata?: Record<string, unknown> | null
+}
+
+export class OrganizationValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'OrganizationValidationError'
+  }
+}
+
+export class OrganizationConflictError extends Error {
+  constructor(readonly field: 'name' | 'slug') {
+    super(`Organization ${field} already exists.`)
+    this.name = 'OrganizationConflictError'
+  }
+}
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+function requireNonBlank(value: string | undefined, field: string): string {
+  if (typeof value !== 'string') {
+    throw new OrganizationValidationError(`Organization ${field} is required.`)
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw new OrganizationValidationError(`Organization ${field} cannot be blank.`)
+  }
+
+  if (trimmed.length > 255) {
+    throw new OrganizationValidationError(`Organization ${field} must be 255 characters or less.`)
+  }
+
+  return trimmed
+}
+
+function normalizeSlug(slug: string | undefined): string {
+  const normalized = requireNonBlank(slug, 'slug')
+  if (!SLUG_PATTERN.test(normalized)) {
+    throw new OrganizationValidationError(
+      'Organization slug must use lowercase letters, numbers, and single hyphens.',
+    )
+  }
+
+  return normalized
+}
+
+function serializeMetadata(metadata: Record<string, unknown> | null | undefined): string | null {
+  return metadata ? JSON.stringify(metadata) : null
+}
+
+export class OrganizationService {
+  constructor(private readonly database: Knex = db) {}
+
+  async createOrganization(input: CreateOrganizationInput): Promise<Organization> {
+    const name = requireNonBlank(input.name, 'name')
+    const slug = normalizeSlug(input.slug)
+
+    await this.assertUniqueNameAndSlug(name, slug)
+
+    const [org] = await this.database('organizations')
+      .insert({
+        name,
+        slug,
+        metadata: serializeMetadata(input.metadata),
+      })
+      .returning('*')
+    return org
+  }
+
+  async getOrganizationById(id: string): Promise<Organization | null> {
+    const organizationId = requireNonBlank(id, 'id')
+    return this.database('organizations').where({ id: organizationId }).first()
+  }
+
+  async getOrganizationBySlug(slug: string): Promise<Organization | null> {
+    return this.database('organizations').where({ slug: normalizeSlug(slug) }).first()
+  }
+
+  async listOrganizations(): Promise<Organization[]> {
+    return this.database('organizations').select('*')
+  }
+
+  async updateOrganization(
+    id: string,
+    input: UpdateOrganizationInput,
+  ): Promise<Organization | null> {
+    const organizationId = requireNonBlank(id, 'id')
+    const existing = await this.getOrganizationById(organizationId)
+    if (!existing) {
+      return null
+    }
+
+    const updates: Record<string, unknown> = {}
+    const nextName = input.name === undefined ? existing.name : requireNonBlank(input.name, 'name')
+    const nextSlug = input.slug === undefined ? existing.slug : normalizeSlug(input.slug)
+
+    if (input.name !== undefined) {
+      updates.name = nextName
+    }
+    if (input.slug !== undefined) {
+      updates.slug = nextSlug
+    }
+    if (input.metadata !== undefined) {
+      updates.metadata = serializeMetadata(input.metadata)
+    }
+    if (Object.keys(updates).length === 0) {
+      throw new OrganizationValidationError('At least one organization field must be provided.')
+    }
+
+    await this.assertUniqueNameAndSlug(nextName, nextSlug, organizationId)
+
+    updates.updated_at = new Date()
+    const [updated] = await this.database('organizations')
+      .where({ id: organizationId })
+      .update(updates)
+      .returning('*')
+
+    return updated ?? null
+  }
+
+  async renameOrganization(
+    id: string,
+    name: string,
+    slug?: string,
+  ): Promise<Organization | null> {
+    return this.updateOrganization(id, {
+      name,
+      ...(slug === undefined ? {} : { slug }),
     })
-    .returning('*')
-  return org
+  }
+
+  async deleteOrganization(id: string): Promise<boolean> {
+    const organizationId = requireNonBlank(id, 'id')
+    const deleted = await this.database('organizations').where({ id: organizationId }).delete()
+    return deleted > 0
+  }
+
+  private async assertUniqueNameAndSlug(
+    name: string,
+    slug: string,
+    excludeId?: string,
+  ): Promise<void> {
+    const byName = this.database('organizations').where({ name })
+    if (excludeId) {
+      byName.whereNot({ id: excludeId })
+    }
+    if (await byName.first()) {
+      throw new OrganizationConflictError('name')
+    }
+
+    const bySlug = this.database('organizations').where({ slug })
+    if (excludeId) {
+      bySlug.whereNot({ id: excludeId })
+    }
+    if (await bySlug.first()) {
+      throw new OrganizationConflictError('slug')
+    }
+  }
 }
 
-export const getOrganizationById = async (id: string): Promise<Organization | null> => {
-  return db('organizations').where({ id }).first()
-}
+const organizationService = new OrganizationService()
 
-export const getOrganizationBySlug = async (slug: string): Promise<Organization | null> => {
-  return db('organizations').where({ slug }).first()
-}
+export const createOrganization = async (input: CreateOrganizationInput): Promise<Organization> =>
+  organizationService.createOrganization(input)
 
-export const listOrganizations = async (): Promise<Organization[]> => {
-  return db('organizations').select('*')
-}
+export const getOrganizationById = async (id: string): Promise<Organization | null> =>
+  organizationService.getOrganizationById(id)
+
+export const getOrganizationBySlug = async (slug: string): Promise<Organization | null> =>
+  organizationService.getOrganizationBySlug(slug)
+
+export const listOrganizations = async (): Promise<Organization[]> =>
+  organizationService.listOrganizations()
+
+export const updateOrganization = async (
+  id: string,
+  input: UpdateOrganizationInput,
+): Promise<Organization | null> =>
+  organizationService.updateOrganization(id, input)
+
+export const renameOrganization = async (
+  id: string,
+  name: string,
+  slug?: string,
+): Promise<Organization | null> =>
+  organizationService.renameOrganization(id, name, slug)
+
+export const deleteOrganization = async (id: string): Promise<boolean> =>
+  organizationService.deleteOrganization(id)


### PR DESCRIPTION
## Summary
- Add `src/services/organization.test.ts` covering organization creation, reads, listing, uniqueness conflicts, rename collisions, invalid input, and deletion behavior.
- Introduce an injectable `OrganizationService` so the lifecycle contract can be exercised without the global database connection.
- Add service-level validation for org name/slug input, duplicate name/slug guards, update/rename helpers, and hard-delete support while preserving the existing exported function API.
- Include a `DATABASE_URL`-gated test DB harness section for real Postgres uniqueness/cascade checks.

Fixes #731

## Validation
- `C:\Users\jhona\.bun\bin\bun.exe test src\services\organization.test.ts` (6 passed, DB harness skipped locally because `DATABASE_URL` is not configured)
- `git diff --check`
- `npx tsc --noEmit --pretty false` filtered for `src/services/organization.ts` and `src/services/organization.test.ts` produced no touched-file errors; full TypeScript remains blocked by existing unrelated baseline errors elsewhere

Payout address: 0x06f44f4839fd5df4f4670036d028b29dec939363