### PR TITLE
feat: hybrid keyword+vector evidence similarity search with HNSW index

### DIFF
--- a/db/migrations/20260627120000_add_evidence_hybrid_search_indexes.cjs
+++ b/db/migrations/20260627120000_add_evidence_hybrid_search_indexes.cjs
@@ -1,0 +1,47 @@
+/**
+ * Migration: HNSW index for vectors and pg_trgm for evidence text similarity
+ */
+
+exports.up = async function (knex) {
+  // Enable pg_trgm for keyword similarity
+  await knex.raw('CREATE EXTENSION IF NOT EXISTS pg_trgm')
+
+  // Drop the old ivfflat index
+  await knex.raw('DROP INDEX IF EXISTS idx_milestone_embeddings_vector')
+
+  // Create HNSW index for better recall/latency tradeoffs
+  // Using m=16, ef_construction=64 as standard defaults for 768-dim embeddings
+  await knex.raw(`
+    CREATE INDEX idx_milestone_embeddings_hnsw
+      ON milestone_embeddings
+      USING hnsw (embedding vector_cosine_ops)
+      WITH (m = 16, ef_construction = 64)
+  `)
+
+  // Create GIN indexes on evidence_references for text similarity search
+  await knex.raw(`
+    CREATE INDEX idx_evidence_refs_url_trgm
+      ON evidence_references
+      USING gin (reference_url gin_trgm_ops)
+  `)
+
+  await knex.raw(`
+    CREATE INDEX idx_evidence_refs_hash_trgm
+      ON evidence_references
+      USING gin (evidence_hash gin_trgm_ops)
+  `)
+}
+
+exports.down = async function (knex) {
+  await knex.raw('DROP INDEX IF EXISTS idx_evidence_refs_hash_trgm')
+  await knex.raw('DROP INDEX IF EXISTS idx_evidence_refs_url_trgm')
+  await knex.raw('DROP INDEX IF EXISTS idx_milestone_embeddings_hnsw')
+
+  // Restore the ivfflat index
+  await knex.raw(`
+    CREATE INDEX idx_milestone_embeddings_vector
+      ON milestone_embeddings
+      USING ivfflat (embedding vector_cosine_ops)
+      WITH (lists = 100)
+  `)
+}

--- a/docs/evidence-storage.md
+++ b/docs/evidence-storage.md
@@ -36,3 +36,15 @@ This table is created by the new database migration `db/migrations/2026052700000
 
 Audit logs do not include the raw signed URL.
 Only evidence metadata such as `evidenceHash` and the fact that evidence was attached are recorded.
+
+## Similarity Search
+
+To detect near-duplicate or low-effort submissions, evidence supports a hybrid similarity search combining vector embeddings and keyword/text matching.
+
+### Hybrid Search Implementation
+- **Vector Search (HNSW)**: The `milestone_embeddings` table uses an HNSW index on the `embedding` column with the `vector_cosine_ops` operator class.
+  - **Tradeoffs**: HNSW provides superior recall and faster query times compared to IVFFlat, though it consumes slightly more memory and index build time.
+  - **Parameters**: Built with `m = 16` and `ef_construction = 64` as standards for 768-dimensional embeddings.
+- **Keyword Search (pg_trgm)**: The `evidence_references` table is indexed with GIN indexes (`gin_trgm_ops`) on `reference_url` and `evidence_hash`.
+  - This acts as a fallback for evidence that shares few embedded features but has exactly or near-exactly matching URLs or hashes.
+- **Scoring**: A fused score is calculated as `w1 * vector_distance + w2 * keyword_distance`. Both vector and keyword use distance metrics where `0` implies an exact match.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,14 @@
         "bcryptjs": "^3.0.3",
         "cors": "^2.8.6",
         "csv-stringify": "^6.6.0",
+        "dataloader": "^2.2.2",
         "date-fns": "^4.1.0",
         "debug": "^4.4.3",
         "express": "^4.21.0",
         "express-rate-limit": "^8.2.1",
+        "graphql": "^16.8.1",
+        "graphql-depth-limit": "^1.1.0",
+        "graphql-http": "^1.22.0",
         "helmet": "^7.2.0",
         "jsonwebtoken": "^9.0.3",
         "pg": "^8.20.0",
@@ -36,6 +40,7 @@
         "@types/cors": "^2.8.19",
         "@types/debug": "^4.1.13",
         "@types/express": "^4.17.21",
+        "@types/graphql-depth-limit": "^1.1.4",
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.9.0",
@@ -165,6 +170,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1058.0.tgz",
       "integrity": "sha512-AfED3hhaBZ121NuiBImgnlF98kQRMk6hGPMGfj/Oo1hSaoMFRzM+N4nlICCasUSM2R8QaIRZRYGpZ3fy0ilGZQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -665,6 +671,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1159,29 +1166,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -4106,6 +4090,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5350,6 +5335,30 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/graphql-depth-limit": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@types/graphql-depth-limit/-/graphql-depth-limit-1.1.6.tgz",
+      "integrity": "sha512-WU4bjoKOzJ8CQE32Pbyq+YshTMcLJf2aJuvVtSLv1BQPwDUGa38m2Vr8GGxf0GZ0luCQcfxlhZeHKu6nmTBvrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graphql": "^14.5.3"
+      }
+    },
+    "node_modules/@types/graphql-depth-limit/node_modules/graphql": {
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+      "deprecated": "No longer supported; please update to a newer version. Details: https://github.com/graphql/graphql-js#version-support",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iterall": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 6.x"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -5594,6 +5603,7 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -5937,6 +5947,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5971,6 +5982,7 @@
       "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6097,6 +6109,15 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -6395,6 +6416,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7082,6 +7104,12 @@
       "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==",
       "license": "MIT"
     },
+    "node_modules/dataloader": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
+      "license": "MIT"
+    },
     "node_modules/date-fns": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
@@ -7530,6 +7558,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8587,6 +8616,46 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-depth-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+      "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
+    "node_modules/graphql-http": {
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.22.4.tgz",
+      "integrity": "sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA==",
+      "license": "MIT",
+      "workspaces": [
+        "implementations/**/*"
+      ],
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -9102,6 +9171,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -12054,6 +12130,7 @@
       "version": "2.6.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -12989,6 +13066,7 @@
       "integrity": "sha512-do+2UsEKRVT70W/QqP2F2sju2x4p2xZo+5/azXqKjXgTk2jfmzsLjzwW0YI8CBEjy4ZUdU8EunXocXXwJdCrtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -14087,6 +14165,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -14351,6 +14430,7 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14361,6 +14441,7 @@
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15358,6 +15439,7 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -15787,6 +15869,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -15867,6 +15950,7 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16041,6 +16125,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16486,6 +16571,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/services/evidence.ts
+++ b/src/services/evidence.ts
@@ -167,3 +167,95 @@ export async function createEvidenceReference(
     createdAt: row.created_at.toISOString(),
   }
 }
+
+export interface SimilarEvidenceResult {
+  milestoneId: string
+  evidenceHash: string
+  referenceUrl: string
+  vectorDistance: number
+  keywordDistance: number
+  fusedScore: number
+}
+
+export interface FindSimilarOptions {
+  limit?: number
+  vectorWeight?: number
+  keywordWeight?: number
+}
+
+export async function findSimilar(
+  milestoneId: string,
+  options: FindSimilarOptions = {},
+): Promise<SimilarEvidenceResult[]> {
+  const limit = options.limit ?? 5
+  const vectorWeight = options.vectorWeight ?? 0.5
+  const keywordWeight = options.keywordWeight ?? 0.5
+
+  // Fetch the query milestone's embedding and evidence text
+  const queryRows = await prisma.$queryRaw<
+    Array<{
+      embedding: string
+      reference_url: string
+      evidence_hash: string
+    }>
+  >`
+    SELECT
+      me.embedding::text AS embedding,
+      er.reference_url,
+      er.evidence_hash
+    FROM milestone_embeddings me
+    JOIN verifications v ON v.target_id = me.milestone_id
+    JOIN evidence_references er ON er.verification_id = v.id
+    WHERE me.milestone_id = ${milestoneId}
+    LIMIT 1
+  `
+
+  const queryRow = queryRows[0]
+  if (!queryRow) {
+    return []
+  }
+
+  // We cast to vector explicitly here and calculate distances.
+  const results = await prisma.$queryRaw<
+    Array<{
+      milestone_id: string
+      evidence_hash: string
+      reference_url: string
+      vector_distance: number
+      keyword_distance: number
+      fused_score: number
+    }>
+  >`
+    SELECT
+      me.milestone_id,
+      er.evidence_hash,
+      er.reference_url,
+      (me.embedding <=> ${queryRow.embedding}::vector) AS vector_distance,
+      LEAST(
+        (er.reference_url <-> ${queryRow.reference_url}),
+        (er.evidence_hash <-> ${queryRow.evidence_hash})
+      ) AS keyword_distance,
+      (
+        ((me.embedding <=> ${queryRow.embedding}::vector) * ${vectorWeight}) +
+        (LEAST(
+          (er.reference_url <-> ${queryRow.reference_url}),
+          (er.evidence_hash <-> ${queryRow.evidence_hash})
+        ) * ${keywordWeight})
+      ) AS fused_score
+    FROM milestone_embeddings me
+    JOIN verifications v ON v.target_id = me.milestone_id
+    JOIN evidence_references er ON er.verification_id = v.id
+    WHERE me.milestone_id != ${milestoneId}
+    ORDER BY fused_score ASC
+    LIMIT ${limit}
+  `
+
+  return results.map((r) => ({
+    milestoneId: r.milestone_id,
+    evidenceHash: r.evidence_hash,
+    referenceUrl: r.reference_url,
+    vectorDistance: Number(r.vector_distance),
+    keywordDistance: Number(r.keyword_distance),
+    fusedScore: Number(r.fused_score),
+  }))
+}

--- a/src/tests/evidence.similarity.test.ts
+++ b/src/tests/evidence.similarity.test.ts
@@ -1,0 +1,159 @@
+import { prisma } from '../lib/prisma.js'
+import { findSimilar } from '../services/evidence.js'
+import crypto from 'crypto'
+
+function makeVector(seed: number, dims = 768): number[] {
+  const v: number[] = []
+  let s = seed
+  for (let i = 0; i < dims; i++) {
+    s = (s * 1664525 + 1013904223) & 0xffffffff
+    v.push((s & 0xffff) / 0xffff - 0.5)
+  }
+  const norm = Math.sqrt(v.reduce((acc, x) => acc + x * x, 0))
+  return v.map((x) => x / norm)
+}
+
+describe('Evidence Similarity Search', () => {
+  let pgvectorAvailable = false
+  let vaultId: string
+  const milestoneIds: string[] = []
+
+  beforeAll(async () => {
+    try {
+      const result = await prisma.$queryRaw`SELECT 1 FROM pg_extension WHERE extname = 'vector'`
+      if (Array.isArray(result) && result.length > 0) {
+        pgvectorAvailable = true
+      }
+    } catch {
+      pgvectorAvailable = false
+      return
+    }
+
+    if (!pgvectorAvailable) return
+
+    // Run migrations just in case
+    await prisma.$executeRaw`CREATE EXTENSION IF NOT EXISTS vector`
+    await prisma.$executeRaw`CREATE EXTENSION IF NOT EXISTS pg_trgm`
+
+    // Setup user and vault
+    const verifierId = 'test-verifier-user'
+    await prisma.$executeRaw`
+      INSERT INTO verifiers (user_id, status, display_name) 
+      VALUES (${verifierId}, 'approved', 'Test Verifier') 
+      ON CONFLICT (user_id) DO NOTHING
+    `
+
+    vaultId = crypto.randomUUID()
+    await prisma.$executeRaw`
+      INSERT INTO vaults (id, name, created_at, updated_at) 
+      VALUES (${vaultId}, 'Test Vault', NOW(), NOW())
+    `
+
+    // Setup dummy evidence (query + 4 targets)
+    const datasets = [
+      { seed: 1, hash: 'hash-abc', url: 'https://example.com/doc1' }, // Query milestone
+      { seed: 1, hash: 'hash-xyz', url: 'https://example.com/doc2' }, // Very similar vector, different text
+      { seed: 9, hash: 'hash-abc', url: 'https://example.com/doc1' }, // Different vector, exact same text
+      { seed: 8, hash: 'hash-123', url: 'https://example.com/other' }, // completely different
+      { seed: 2, hash: 'hash-abd', url: 'https://example.com/doc1-edit' }, // Similar vector, similar text
+    ]
+
+    for (const data of datasets) {
+      const mId = crypto.randomUUID()
+      milestoneIds.push(mId)
+      
+      await prisma.$executeRaw`
+        INSERT INTO milestones (id, vault_id, title, type, criteria, status, created_at, updated_at)
+        VALUES (${mId}, ${vaultId}, 'Test Milestone', 'test', '{}', 'pending', NOW(), NOW())
+      `
+
+      const vec = `[${makeVector(data.seed).join(',')}]`
+      await prisma.$executeRaw`
+        INSERT INTO milestone_embeddings (milestone_id, embedding, created_at, updated_at)
+        VALUES (${mId}, ${vec}::vector, NOW(), NOW())
+      `
+
+      const vId = crypto.randomUUID()
+      await prisma.$executeRaw`
+        INSERT INTO verifications (id, verifier_user_id, target_id, result)
+        VALUES (${vId}, ${verifierId}, ${mId}, 'approved')
+      `
+
+      await prisma.$executeRaw`
+        INSERT INTO evidence_references (verification_id, evidence_hash, reference_url, expires_at, created_at)
+        VALUES (${vId}, ${data.hash}, ${data.url}, NOW() + INTERVAL '1 day', NOW())
+      `
+    }
+  })
+
+  afterAll(async () => {
+    if (pgvectorAvailable && milestoneIds.length > 0) {
+      // Clean up
+      for (const mId of milestoneIds) {
+        await prisma.$executeRaw`DELETE FROM evidence_references WHERE verification_id IN (SELECT id FROM verifications WHERE target_id = ${mId})`
+        await prisma.$executeRaw`DELETE FROM verifications WHERE target_id = ${mId}`
+        await prisma.$executeRaw`DELETE FROM milestone_embeddings WHERE milestone_id = ${mId}`
+        await prisma.$executeRaw`DELETE FROM milestones WHERE id = ${mId}`
+      }
+      await prisma.$executeRaw`DELETE FROM vaults WHERE id = ${vaultId}`
+    }
+    await prisma.$disconnect()
+  })
+
+  function itWhenPgvector(name: string, fn: () => Promise<void>) {
+    if (!pgvectorAvailable) {
+      it.skip(name, fn)
+    } else {
+      it(name, fn)
+    }
+  }
+
+  itWhenPgvector('returns near-duplicate evidence (keyword + vector matching)', async () => {
+    const queryMilestoneId = milestoneIds[0]
+    const results = await findSimilar(queryMilestoneId)
+
+    expect(results.length).toBeGreaterThan(0)
+    
+    // Exact text match (datasets[2]) should rank highly because keywordDistance = 0
+    const exactTextMatch = results.find(r => r.milestoneId === milestoneIds[2])
+    expect(exactTextMatch).toBeDefined()
+    expect(exactTextMatch!.keywordDistance).toBeCloseTo(0)
+
+    // Exact vector match (datasets[1]) should rank highly because vectorDistance = 0
+    const exactVectorMatch = results.find(r => r.milestoneId === milestoneIds[1])
+    expect(exactVectorMatch).toBeDefined()
+    expect(exactVectorMatch!.vectorDistance).toBeCloseTo(0)
+
+    // Check that fused score orders correctly
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].fusedScore).toBeGreaterThanOrEqual(results[i - 1].fusedScore)
+    }
+  })
+
+  itWhenPgvector('can weight vector similarity over keyword similarity', async () => {
+    const queryMilestoneId = milestoneIds[0]
+    const results = await findSimilar(queryMilestoneId, { vectorWeight: 1.0, keywordWeight: 0.0 })
+    
+    // If only vector is weighted, the exact vector match (index 1) should be #1
+    expect(results[0].milestoneId).toBe(milestoneIds[1])
+  })
+
+  itWhenPgvector('can weight keyword similarity over vector similarity', async () => {
+    const queryMilestoneId = milestoneIds[0]
+    const results = await findSimilar(queryMilestoneId, { vectorWeight: 0.0, keywordWeight: 1.0 })
+    
+    // If only keyword is weighted, the exact keyword match (index 2) should be #1
+    expect(results[0].milestoneId).toBe(milestoneIds[2])
+  })
+
+  itWhenPgvector('stays under a latency budget of 50ms', async () => {
+    const queryMilestoneId = milestoneIds[0]
+    
+    const start = performance.now()
+    await findSimilar(queryMilestoneId)
+    const end = performance.now()
+    
+    // Latency
+    expect(end - start).toBeLessThan(50) // 50ms budget
+  })
+})


### PR DESCRIPTION
Closes #656 

## Description

Previously, similarity search on evidence relied solely on a raw distance scan (IVFFlat) without a fallback for keyword or textual matches. As a result, evidence with similar text (URLs or hashes) but different vector features was not accurately flagged as near-duplicates.

This PR introduces a hybrid (keyword + vector) ranking strategy for milestone-evidence similarity searches. 

### Key Changes
- **Migrations**: 
  - Drops the previous `IVFFlat` index on `milestone_embeddings`.
  - Introduces a tuned `HNSW` index (`m=16`, `ef_construction=64`) for better recall and latency on vectors.
  - Adds `pg_trgm` GIN indexes on `evidence_references.reference_url` and `evidence_hash` for fast textual proximity matching.
- **Evidence Service**:
  - Implements `findSimilar(milestoneId, { limit, vectorWeight, keywordWeight })` in `src/services/evidence.ts`.
  - Combines pgvector cosine distance (`<=>`) and pg_trgm word distance (`<->`) into a unified fused score.
- **Documentation**: 
  - Updates `evidence-storage.md` with details on index parameters and latency tradeoffs.
- **Testing**:
  - Adds `evidence.similarity.test.ts` asserting near-duplicate rankings and verifies that execution stays under a 50ms latency budget. 
