### PR TITLE
feat: admin job-queue depth report and stuck-job sweeper

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -27,6 +27,56 @@ Options parsing behavior:
 - If the job has exhausted its `max_attempts` (i.e. is dead-lettered), the request will be refused unless `?force=true` is passed as a query parameter.
 - Emits a `job.retry` audit log upon success.
 
+## Queue depth report
+
+`GET /api/jobs/depth` returns operator-facing queue depth, grouped by job type and state.
+
+- Optional query param `staleLeaseMs` (positive integer) overrides the threshold used to flag
+  `stuckActive` jobs; defaults to the `JOB_STALE_LEASE_MS` environment variable (default `300000`,
+  i.e. 5 minutes).
+- Response shape:
+
+  ```json
+  {
+    "generatedAt": "2026-06-27T00:00:00.000Z",
+    "staleLeaseMs": 300000,
+    "totalDepth": 4,
+    "byType": {
+      "notification.send": { "queued": 0, "delayed": 0, "active": 1, "stuckActive": 1, "deadLetter": 0 }
+    }
+  }
+  ```
+
+- `totalDepth` sums `queued + delayed + active` across all job types (dead-lettered jobs are
+  reported separately and excluded from depth).
+- `stuckActive` counts active jobs whose lease has exceeded `staleLeaseMs` without completing —
+  the candidates a sweep would reclaim.
+
+## Stuck-job sweeper
+
+`POST /api/jobs/sweep` reclaims jobs whose lease has exceeded a stale threshold — for example a
+job claimed by a worker that crashed or hung before releasing it.
+
+- Optional query param `staleLeaseMs` (positive integer) overrides the default threshold for this
+  sweep run only.
+- For each stuck job:
+  - If the job has attempts remaining (`attempt < maxAttempts`), it is re-queued for immediate
+    execution and counted in `reclaimed`.
+  - If the job has exhausted `maxAttempts`, it is moved to the dead-letter queue instead of being
+    retried again, and counted in `deadLettered`.
+- Jobs whose lease is still within the threshold are left untouched.
+- Emits a `job.sweep` audit log with `staleLeaseMs`, `reclaimedCount`, and `deadLetteredCount`.
+- Response shape:
+
+  ```json
+  {
+    "sweptAt": "2026-06-27T00:00:00.000Z",
+    "staleLeaseMs": 300000,
+    "reclaimed": [{ "jobId": "...", "type": "oracle.call", "attempt": 1, "maxAttempts": 3, "leaseAgeMs": 412000 }],
+    "deadLettered": []
+  }
+  ```
+
 ## Error contract
 
 Invalid payloads return:
@@ -37,6 +87,6 @@ Invalid payloads return:
 
 ## Security
 
-- Endpoint requires valid auth token and `ADMIN` role.
+- All `/api/jobs/*` endpoints (including `/depth` and `/sweep`) require valid auth token and `ADMIN` role.
 - Non-admin users receive `403`.
-- On success, enqueue action writes `job.enqueue` audit logs.
+- On success, enqueue action writes `job.enqueue` audit logs; sweeping writes `job.sweep` audit logs.

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -15,6 +15,7 @@ interface InternalQueuedJob<T extends JobType = JobType> {
   maxAttempts: number
   createdAt: number
   runAt: number
+  leasedAt?: number
 }
 
 interface CompletedJobRecord {
@@ -78,15 +79,47 @@ export interface QueueMetrics {
   recentFailures: FailedJobRecord[]
 }
 
+export interface ReclaimedJobRecord {
+  jobId: string
+  type: JobType
+  attempt: number
+  maxAttempts: number
+  leaseAgeMs: number
+}
+
+export interface SweepResult {
+  sweptAt: string
+  staleLeaseMs: number
+  reclaimed: ReclaimedJobRecord[]
+  deadLettered: DeadLetterJobRecord[]
+}
+
+export interface QueueDepthByState {
+  queued: number
+  delayed: number
+  active: number
+  stuckActive: number
+  deadLetter: number
+}
+
+export interface QueueDepthReport {
+  generatedAt: string
+  staleLeaseMs: number
+  totalDepth: number
+  byType: Record<JobType, QueueDepthByState>
+}
+
 export interface JobQueueOptions {
   concurrency?: number
   pollIntervalMs?: number
   historyLimit?: number
+  staleLeaseMs?: number
 }
 
 const DEFAULT_CONCURRENCY = 2
 const DEFAULT_POLL_INTERVAL_MS = 250
 const DEFAULT_HISTORY_LIMIT = 50
+const DEFAULT_STALE_LEASE_MS = 300_000
 const SHUTDOWN_WAIT_MS = 2_000
 
 const sleep = async (ms: number): Promise<void> => {
@@ -96,13 +129,19 @@ const sleep = async (ms: number): Promise<void> => {
 }
 
 const createEmptyTypeMetrics = (): Record<JobType, QueueTypeMetrics> => {
-  return {
-    'notification.send': { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
-    'deadline.check': { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
-    'oracle.call': { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
-    'analytics.recompute': { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
-    'export.generate': { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 },
+  const byType = {} as Record<JobType, QueueTypeMetrics>
+  for (const type of JOB_TYPES) {
+    byType[type] = { queued: 0, delayed: 0, active: 0, completed: 0, failed: 0, deadLetter: 0 }
   }
+  return byType
+}
+
+const createEmptyDepthByState = (): Record<JobType, QueueDepthByState> => {
+  const byType = {} as Record<JobType, QueueDepthByState>
+  for (const type of JOB_TYPES) {
+    byType[type] = { queued: 0, delayed: 0, active: 0, stuckActive: 0, deadLetter: 0 }
+  }
+  return byType
 }
 
 const getErrorMessage = (error: unknown): string => {
@@ -140,6 +179,7 @@ export class InMemoryJobQueue {
   private readonly concurrency: number
   private readonly pollIntervalMs: number
   private readonly historyLimit: number
+  private readonly staleLeaseMs: number
 
   private startedAt: number | null = null
   private running = false
@@ -150,6 +190,7 @@ export class InMemoryJobQueue {
     this.concurrency = asPositiveInteger(options.concurrency, DEFAULT_CONCURRENCY)
     this.pollIntervalMs = asPositiveInteger(options.pollIntervalMs, DEFAULT_POLL_INTERVAL_MS)
     this.historyLimit = asPositiveInteger(options.historyLimit, DEFAULT_HISTORY_LIMIT)
+    this.staleLeaseMs = asPositiveInteger(options.staleLeaseMs, DEFAULT_STALE_LEASE_MS)
   }
 
   registerHandler<T extends JobType>(type: T, handler: JobHandler<T>): void {
@@ -282,6 +323,91 @@ export class InMemoryJobQueue {
     }
   }
 
+  getQueueDepthReport(staleLeaseMs: number = this.staleLeaseMs): QueueDepthReport {
+    const now = Date.now()
+    const byType = createEmptyDepthByState()
+
+    for (const job of this.pendingJobs) {
+      if (job.runAt <= now) {
+        byType[job.type].queued += 1
+      } else {
+        byType[job.type].delayed += 1
+      }
+    }
+
+    for (const job of this.activeJobs.values()) {
+      byType[job.type].active += 1
+      if (now - job.leasedAt! > staleLeaseMs) {
+        byType[job.type].stuckActive += 1
+      }
+    }
+
+    for (const deadLetter of this.deadLetterJobs) {
+      byType[deadLetter.type].deadLetter += 1
+    }
+
+    let totalDepth = 0
+    for (const type of JOB_TYPES) {
+      totalDepth += byType[type].queued + byType[type].delayed + byType[type].active
+    }
+
+    return {
+      generatedAt: new Date(now).toISOString(),
+      staleLeaseMs,
+      totalDepth,
+      byType,
+    }
+  }
+
+  sweepStaleLeases(staleLeaseMs: number = this.staleLeaseMs): SweepResult {
+    const now = Date.now()
+    const reclaimed: ReclaimedJobRecord[] = []
+    const deadLettered: DeadLetterJobRecord[] = []
+
+    for (const [jobId, job] of [...this.activeJobs]) {
+      const leaseAgeMs = now - job.leasedAt!
+      if (leaseAgeMs <= staleLeaseMs) {
+        continue
+      }
+
+      this.activeJobs.delete(jobId)
+
+      if (job.attempt >= job.maxAttempts) {
+        this.moveToDeadLetter(
+          job,
+          `Stuck job reclaimed: lease age ${leaseAgeMs}ms exceeded staleLeaseMs ${staleLeaseMs}ms`,
+        )
+        deadLettered.push(this.deadLetterJobs[0])
+      } else {
+        this.totals.retried += 1
+        job.leasedAt = undefined
+        job.runAt = now
+        this.pendingJobs.push(job)
+        reclaimed.push({
+          jobId: job.id,
+          type: job.type,
+          attempt: job.attempt,
+          maxAttempts: job.maxAttempts,
+          leaseAgeMs,
+        })
+      }
+    }
+
+    if (reclaimed.length > 0) {
+      this.sortPendingJobs()
+      if (this.running) {
+        void this.drain()
+      }
+    }
+
+    return {
+      sweptAt: new Date(now).toISOString(),
+      staleLeaseMs,
+      reclaimed,
+      deadLettered,
+    }
+  }
+
   private async drain(): Promise<void> {
     if (!this.running || this.draining) {
       return
@@ -313,9 +439,10 @@ export class InMemoryJobQueue {
     }
 
     job.attempt += 1
+    const startedAt = Date.now()
+    job.leasedAt = startedAt
     this.activeJobs.set(job.id, job)
     this.totals.executions += 1
-    const startedAt = Date.now()
 
     try {
       await handler(job.payload, {

--- a/src/jobs/system.ts
+++ b/src/jobs/system.ts
@@ -1,5 +1,11 @@
 import { createDefaultJobHandlers } from './handlers.js'
-import { InMemoryJobQueue, type QueueMetrics, type QueuedJobReceipt } from './queue.js'
+import {
+  InMemoryJobQueue,
+  type QueueMetrics,
+  type QueuedJobReceipt,
+  type QueueDepthReport,
+  type SweepResult,
+} from './queue.js'
 import { type EnqueueOptions, type JobPayloadByType, type JobType } from './types.js'
 import { recoverPendingExportJobs } from '../services/exportQueue.js'
 import {
@@ -31,6 +37,7 @@ export class BackgroundJobSystem {
       concurrency: parsePositiveInteger(process.env.JOB_WORKER_CONCURRENCY, 2),
       pollIntervalMs: parsePositiveInteger(process.env.JOB_QUEUE_POLL_INTERVAL_MS, 250),
       historyLimit: parsePositiveInteger(process.env.JOB_HISTORY_LIMIT, 50),
+      staleLeaseMs: parsePositiveInteger(process.env.JOB_STALE_LEASE_MS, 300_000),
     })
     const resolvedNotificationService =
       notificationService ?? createNotificationService(process.env.NOTIFICATION_PROVIDER ?? 'console')
@@ -104,6 +111,17 @@ export class BackgroundJobSystem {
 
   getMetrics(): QueueMetrics {
     return this.queue.getMetrics()
+  }
+
+  getQueueDepthReport(staleLeaseMs?: number): QueueDepthReport {
+    return this.queue.getQueueDepthReport(staleLeaseMs)
+  }
+
+  sweepStaleLeases(staleLeaseMs?: number): SweepResult {
+    if (this.shuttingDown) {
+      throw new Error('Cannot sweep jobs: system is shutting down')
+    }
+    return this.queue.sweepStaleLeases(staleLeaseMs)
   }
 
   private scheduleRecurringJobs(): void {

--- a/src/routes/jobs.ts
+++ b/src/routes/jobs.ts
@@ -19,6 +19,20 @@ import { enqueueJobSchema } from '../lib/validation.js'
 const jobsJson = requireJson({ maxBytes: JOBS_JSON_MAX_BYTES })
 
 // Helpers
+const parseOptionalPositiveInt = (value: unknown): number | undefined => {
+  if (value === undefined) {
+    return undefined
+  }
+  if (typeof value !== 'string' || value.trim() === '') {
+    return NaN
+  }
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    return NaN
+  }
+  return parsed
+}
+
 const enqueueTypedJob = (
   jobSystem: BackgroundJobSystem,
   type: JobType,
@@ -57,6 +71,42 @@ export const createJobsRouter = (jobSystem: BackgroundJobSystem, options: JobsRo
   // GET /metrics — internal queue metrics (admin only)
   jobsRouter.get('/metrics', (_req, res) => {
     res.json(jobSystem.getMetrics())
+  })
+
+  // GET /depth — queue depth report grouped by job type and state (admin only)
+  jobsRouter.get('/depth', (req, res) => {
+    const staleLeaseMs = parseOptionalPositiveInt(req.query.staleLeaseMs)
+    if (Number.isNaN(staleLeaseMs)) {
+      res.status(400).json({ error: 'staleLeaseMs must be a positive integer' })
+      return
+    }
+
+    res.json(jobSystem.getQueueDepthReport(staleLeaseMs))
+  })
+
+  // POST /sweep — reclaim jobs whose lease exceeded the stale threshold (admin only)
+  jobsRouter.post('/sweep', (req, res) => {
+    const staleLeaseMs = parseOptionalPositiveInt(req.query.staleLeaseMs)
+    if (Number.isNaN(staleLeaseMs)) {
+      res.status(400).json({ error: 'staleLeaseMs must be a positive integer' })
+      return
+    }
+
+    const result = jobSystem.sweepStaleLeases(staleLeaseMs)
+
+    createAuditLog({
+      actor_user_id: req.user!.userId,
+      action: 'job.sweep',
+      target_type: 'job_queue',
+      target_id: 'sweep',
+      metadata: {
+        staleLeaseMs: result.staleLeaseMs,
+        reclaimedCount: result.reclaimed.length,
+        deadLetteredCount: result.deadLettered.length,
+      },
+    })
+
+    res.status(200).json(result)
   })
 
   // GET /deadletters — inspect failed jobs that exhausted retries

--- a/src/tests/jobs.sweeper.test.ts
+++ b/src/tests/jobs.sweeper.test.ts
@@ -1,0 +1,313 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it, beforeAll, jest } from '@jest/globals'
+import { InMemoryJobQueue } from '../jobs/queue.js'
+import { generateValidToken, UserRole } from './helpers/rbacTestUtils.js'
+import type { BackgroundJobSystem } from '../jobs/system.js'
+import type { SweepResult, QueueDepthReport } from '../jobs/queue.js'
+import type { RequestHandler } from 'express'
+
+jest.unstable_mockModule('../lib/audit-logs.js', () => ({
+  createAuditLog: jest.fn(),
+}))
+
+let createJobsRouter: any
+let createAuditLog: any
+const noopLimiter: RequestHandler = (_req, _res, next) => next()
+const adminToken = generateValidToken({ userId: 'test-admin', role: UserRole.ADMIN })
+const userToken = generateValidToken({ userId: 'test-user', role: UserRole.USER })
+
+beforeAll(async () => {
+  const routerModule = await import('../routes/jobs.js')
+  createJobsRouter = routerModule.createJobsRouter
+  const auditModule = await import('../lib/audit-logs.js')
+  createAuditLog = auditModule.createAuditLog
+})
+
+/**
+ * Forces a pending job into the active map without waiting on real timers,
+ * then rewrites its lease timestamp so sweep behaviour is deterministic.
+ */
+const leaseJobWithAge = async (queue: InMemoryJobQueue, jobId: string, ageMs: number): Promise<void> => {
+  const internal = queue as unknown as {
+    running: boolean
+    drain: () => Promise<void>
+    activeJobs: Map<string, { leasedAt?: number }>
+  }
+  internal.running = true
+  await internal.drain()
+  internal.running = false
+  const job = internal.activeJobs.get(jobId)
+  if (!job) {
+    throw new Error(`Job ${jobId} did not become active`)
+  }
+  job.leasedAt = Date.now() - ageMs
+}
+
+describe('InMemoryJobQueue.sweepStaleLeases', () => {
+  it('reclaims a job whose lease exceeds the stale threshold and retries it', async () => {
+    const queue = new InMemoryJobQueue({ concurrency: 1, pollIntervalMs: 10_000 })
+    queue.registerHandler('oracle.call', () => new Promise<void>(() => {}))
+    const receipt = queue.enqueue('oracle.call', { oracle: 'chainlink', symbol: 'XLM' }, { maxAttempts: 3 })
+
+    await leaseJobWithAge(queue, receipt.id, 10_000)
+    expect(queue.getMetrics().activeJobs).toBe(1)
+
+    const result = queue.sweepStaleLeases(5_000)
+
+    expect(result.reclaimed).toHaveLength(1)
+    expect(result.reclaimed[0]).toMatchObject({
+      jobId: receipt.id,
+      type: 'oracle.call',
+      attempt: 1,
+      maxAttempts: 3,
+    })
+    expect(result.deadLettered).toHaveLength(0)
+
+    const metrics = queue.getMetrics()
+    expect(metrics.activeJobs).toBe(0)
+    expect(metrics.queueDepth).toBe(1)
+  })
+
+  it('leaves a job untouched when its lease is within the stale threshold', async () => {
+    const queue = new InMemoryJobQueue({ concurrency: 1, pollIntervalMs: 10_000 })
+    queue.registerHandler('oracle.call', () => new Promise<void>(() => {}))
+    const receipt = queue.enqueue('oracle.call', { oracle: 'chainlink', symbol: 'XLM' }, { maxAttempts: 3 })
+
+    await leaseJobWithAge(queue, receipt.id, 100)
+
+    const result = queue.sweepStaleLeases(5_000)
+
+    expect(result.reclaimed).toHaveLength(0)
+    expect(result.deadLettered).toHaveLength(0)
+    expect(queue.getMetrics().activeJobs).toBe(1)
+  })
+
+  it('routes a stuck job to the dead-letter queue once max attempts are reached', async () => {
+    const queue = new InMemoryJobQueue({ concurrency: 1, pollIntervalMs: 10_000 })
+    queue.registerHandler('oracle.call', () => new Promise<void>(() => {}))
+    const receipt = queue.enqueue('oracle.call', { oracle: 'chainlink', symbol: 'XLM' }, { maxAttempts: 1 })
+
+    await leaseJobWithAge(queue, receipt.id, 10_000)
+
+    const result = queue.sweepStaleLeases(5_000)
+
+    expect(result.reclaimed).toHaveLength(0)
+    expect(result.deadLettered).toHaveLength(1)
+    expect(result.deadLettered[0].jobId).toBe(receipt.id)
+    expect(queue.getDeadLetters()).toHaveLength(1)
+    expect(queue.getMetrics().activeJobs).toBe(0)
+    expect(queue.getMetrics().totals.failed).toBe(1)
+  })
+
+  it('resumes draining automatically after a reclaim when the queue is running', async () => {
+    const queue = new InMemoryJobQueue({ concurrency: 1, pollIntervalMs: 10_000 })
+    let callCount = 0
+    queue.registerHandler('oracle.call', () => {
+      callCount += 1
+      return callCount === 1 ? new Promise<void>(() => {}) : Promise.resolve()
+    })
+    const receipt = queue.enqueue('oracle.call', { oracle: 'chainlink', symbol: 'XLM' }, { maxAttempts: 3 })
+
+    await leaseJobWithAge(queue, receipt.id, 10_000)
+
+    const internal = queue as unknown as { running: boolean }
+    internal.running = true
+    const result = queue.sweepStaleLeases(5_000)
+    internal.running = false
+
+    expect(result.reclaimed).toHaveLength(1)
+    expect(callCount).toBe(2)
+    expect(queue.getMetrics().activeJobs).toBe(1)
+  })
+})
+
+describe('InMemoryJobQueue.getQueueDepthReport', () => {
+  it('groups depth by job type and state, including stuck-active and dead-lettered jobs', async () => {
+    const queue = new InMemoryJobQueue({ concurrency: 2, pollIntervalMs: 10_000 })
+    queue.registerHandler('notification.send', () => new Promise<void>(() => {}))
+    queue.registerHandler('deadline.check', () => new Promise<void>(() => {}))
+    queue.registerHandler('oracle.call', () => new Promise<void>(() => {}))
+
+    // Stuck active job — leased well past the threshold.
+    const stuck = queue.enqueue(
+      'notification.send',
+      { recipient: 'ops@example.com', subject: 's', body: 'b' },
+      { maxAttempts: 3 },
+    )
+    await leaseJobWithAge(queue, stuck.id, 10_000)
+
+    // Fresh active job — leased moments ago, under the threshold.
+    const fresh = queue.enqueue('deadline.check', { triggerSource: 'manual' }, { maxAttempts: 3 })
+    await leaseJobWithAge(queue, fresh.id, 100)
+
+    // Untouched queued and delayed jobs.
+    queue.enqueue('oracle.call', { oracle: 'a', symbol: 'A' }, { maxAttempts: 3 })
+    queue.enqueue('oracle.call', { oracle: 'b', symbol: 'B' }, { delayMs: 60_000, maxAttempts: 3 })
+
+    // Synthetic dead-letter entry to exercise the deadLetter grouping.
+    const internal = queue as unknown as {
+      deadLetterJobs: Array<Record<string, unknown>>
+    }
+    internal.deadLetterJobs.push({
+      jobId: 'dlq-synthetic',
+      type: 'analytics.recompute',
+      failedAt: new Date().toISOString(),
+      attempts: 1,
+      error: 'exhausted',
+      payload: { scope: 'global' },
+      createdAt: Date.now(),
+      runAt: Date.now(),
+      maxAttempts: 1,
+    })
+
+    const report = queue.getQueueDepthReport(5_000)
+
+    expect(report.byType['oracle.call']).toMatchObject({
+      queued: 1,
+      delayed: 1,
+      active: 0,
+      stuckActive: 0,
+      deadLetter: 0,
+    })
+    expect(report.byType['notification.send']).toMatchObject({
+      queued: 0,
+      delayed: 0,
+      active: 1,
+      stuckActive: 1,
+      deadLetter: 0,
+    })
+    expect(report.byType['deadline.check']).toMatchObject({
+      queued: 0,
+      delayed: 0,
+      active: 1,
+      stuckActive: 0,
+      deadLetter: 0,
+    })
+    expect(report.byType['analytics.recompute']).toMatchObject({
+      queued: 0,
+      delayed: 0,
+      active: 0,
+      stuckActive: 0,
+      deadLetter: 1,
+    })
+    expect(report.totalDepth).toBe(4)
+  })
+})
+
+describe('Jobs router — depth and sweep endpoints', () => {
+  const makeApp = (mockJobSystem: Partial<BackgroundJobSystem>) => {
+    const app = express()
+    app.use(express.json())
+    app.use('/api/jobs', createJobsRouter(mockJobSystem as BackgroundJobSystem, { enqueueLimiter: noopLimiter }))
+    return app
+  }
+
+  it('returns 401 with no token on /depth', async () => {
+    const app = makeApp({})
+    const res = await request(app).get('/api/jobs/depth')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for non-admin role on /depth', async () => {
+    const app = makeApp({})
+    const res = await request(app).get('/api/jobs/depth').set('Authorization', `Bearer ${userToken}`)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns the depth report for an admin', async () => {
+    const report: QueueDepthReport = {
+      generatedAt: new Date().toISOString(),
+      staleLeaseMs: 300_000,
+      totalDepth: 2,
+      byType: {
+        'notification.send': { queued: 1, delayed: 0, active: 0, stuckActive: 0, deadLetter: 0 },
+        'deadline.check': { queued: 0, delayed: 0, active: 0, stuckActive: 0, deadLetter: 0 },
+        'oracle.call': { queued: 0, delayed: 0, active: 1, stuckActive: 1, deadLetter: 0 },
+        'analytics.recompute': { queued: 0, delayed: 0, active: 0, stuckActive: 0, deadLetter: 0 },
+        'export.generate': { queued: 0, delayed: 0, active: 0, stuckActive: 0, deadLetter: 0 },
+        'sessions.cleanup': { queued: 0, delayed: 0, active: 0, stuckActive: 0, deadLetter: 0 },
+      },
+    }
+    const getQueueDepthReport = jest.fn(() => report)
+    const app = makeApp({ getQueueDepthReport })
+
+    const res = await request(app).get('/api/jobs/depth').set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(report)
+    expect(getQueueDepthReport).toHaveBeenCalledWith(undefined)
+  })
+
+  it('passes a valid staleLeaseMs query param through to the job system', async () => {
+    const getQueueDepthReport = jest.fn(() => ({
+      generatedAt: new Date().toISOString(),
+      staleLeaseMs: 60_000,
+      totalDepth: 0,
+      byType: {},
+    }))
+    const app = makeApp({ getQueueDepthReport })
+
+    const res = await request(app)
+      .get('/api/jobs/depth?staleLeaseMs=60000')
+      .set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(200)
+    expect(getQueueDepthReport).toHaveBeenCalledWith(60_000)
+  })
+
+  it('rejects an invalid staleLeaseMs query param', async () => {
+    const app = makeApp({ getQueueDepthReport: jest.fn() })
+
+    const res = await request(app)
+      .get('/api/jobs/depth?staleLeaseMs=not-a-number')
+      .set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 403 for non-admin role on /sweep', async () => {
+    const app = makeApp({})
+    const res = await request(app).post('/api/jobs/sweep').set('Authorization', `Bearer ${userToken}`)
+    expect(res.status).toBe(403)
+  })
+
+  it('triggers a sweep, returns the result, and records an audit log', async () => {
+    const sweepResult: SweepResult = {
+      sweptAt: new Date().toISOString(),
+      staleLeaseMs: 300_000,
+      reclaimed: [{ jobId: 'job-1', type: 'oracle.call', attempt: 1, maxAttempts: 3, leaseAgeMs: 400_000 }],
+      deadLettered: [],
+    }
+    const sweepStaleLeases = jest.fn(() => sweepResult)
+    const app = makeApp({ sweepStaleLeases })
+
+    const res = await request(app).post('/api/jobs/sweep').set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(sweepResult)
+    expect(sweepStaleLeases).toHaveBeenCalledWith(undefined)
+    expect(createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor_user_id: 'test-admin',
+        action: 'job.sweep',
+        target_type: 'job_queue',
+        metadata: {
+          staleLeaseMs: 300_000,
+          reclaimedCount: 1,
+          deadLetteredCount: 0,
+        },
+      }),
+    )
+  })
+
+  it('rejects an invalid staleLeaseMs query param on /sweep', async () => {
+    const app = makeApp({ sweepStaleLeases: jest.fn() })
+
+    const res = await request(app)
+      .post('/api/jobs/sweep?staleLeaseMs=-5')
+      .set('Authorization', `Bearer ${adminToken}`)
+
+    expect(res.status).toBe(400)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /api/jobs/depth` — queue depth grouped by job type and state (`queued`, `delayed`, `active`, `stuckActive`, `deadLetter`), with an optional `staleLeaseMs` override.
- Adds `POST /api/jobs/sweep` — reclaims jobs whose lease has exceeded the stale threshold; jobs with attempts remaining are re-queued immediately, jobs that have exhausted `maxAttempts` are routed to the dead-letter queue instead of being retried forever. Emits a `job.sweep` audit log.
- Both endpoints sit behind the existing admin-only middleware on the jobs router.
- Fixes a pre-existing bug in `InMemoryJobQueue.getMetrics()` that crashed on any real queue instance because `createEmptyTypeMetrics` was missing the `sessions.cleanup` job type — this was already failing an existing test (`jobs.deadletter.test.ts`) on `main`.
- Documents both endpoints in `docs/jobs.md`.

Closes #725

## Note on CI

I checked CI history on `main` before opening this PR: `npm run build` already fails on a clean `main` checkout due to pre-existing, unrelated bugs (duplicate `argon2` import in `src/services/apiKeys.ts`, dangling undefined references in `src/services/soroban.ts`, duplicate `getEnv` in `src/index.ts`, etc.), and `main`'s CI has been red for the last several merges. This PR's CI will likely show the same pre-existing failures — they are not introduced by this change. I verified my diff doesn't add any new `tsc` or `eslint` errors (compared the full error list before/after this change — identical modulo line-number drift, minus the one bug I fixed).

## Test plan

- [x] `src/tests/jobs.sweeper.test.ts` (new, 13 tests): stale-lease reclaim, fresh-lease untouched, max-attempts → DLQ, automatic re-drain after reclaim, depth grouping accuracy (queued/delayed/active/stuckActive/deadLetter), `/depth` and `/sweep` route auth + behavior.
- [x] `npm test -- src/tests/jobs.sweeper.test.ts src/tests/jobs.deadletter.test.ts` — all pass (20/20).
- [x] Coverage on new/changed lines in `src/jobs/queue.ts` and `src/routes/jobs.ts` is 100% (verified via `--coverage`).
- [x] Confirmed no regressions: full `npm test` run shows strictly fewer failures than baseline `main` (one pre-existing bug fixed, no new failures).