### PR TITLE
feat: resumable milestone-evidence reindex backfill job

### DIFF
--- a/db/migrations/20260627000000_add_model_version_to_milestone_embeddings.cjs
+++ b/db/migrations/20260627000000_add_model_version_to_milestone_embeddings.cjs
@@ -1,0 +1,25 @@
+/**
+ * Migration: model_version column on milestone_embeddings
+ *
+ * Tracks which embedding model produced each stored vector so the reindex
+ * backfill job can detect drift (rows whose model_version no longer matches
+ * the currently configured model) and regenerate only those rows.
+ *
+ * Existing rows predate model versioning, so they are backfilled with the
+ * 'legacy-unversioned' sentinel — guaranteed to differ from any real model
+ * version string, which makes the backfill job pick them up automatically.
+ */
+
+const LEGACY_MODEL_VERSION = 'legacy-unversioned'
+
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('milestone_embeddings', (table) => {
+    table.string('model_version', 128).notNullable().defaultTo(LEGACY_MODEL_VERSION)
+  })
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('milestone_embeddings', (table) => {
+    table.dropColumn('model_version')
+  })
+}

--- a/db/migrations/20260627000001_create_backfill_cursors.cjs
+++ b/db/migrations/20260627000001_create_backfill_cursors.cjs
@@ -1,0 +1,20 @@
+/**
+ * Migration: backfill_cursors table
+ *
+ * Generic persisted cursor for resumable batch backfill jobs (see
+ * src/services/backfillCursorStore.ts). Each row tracks the last processed
+ * key for one named job so a crash or process restart resumes from where it
+ * left off instead of restarting the whole table scan.
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('backfill_cursors', (table) => {
+    table.string('job_name', 255).primary()
+    table.text('cursor')
+    table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+  })
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.dropTableIfExists('backfill_cursors')
+}

--- a/docs/evidence-storage.md
+++ b/docs/evidence-storage.md
@@ -36,3 +36,11 @@ This table is created by the new database migration `db/migrations/2026052700000
 
 Audit logs do not include the raw signed URL.
 Only evidence metadata such as `evidenceHash` and the fact that evidence was attached are recorded.
+
+## Relationship to milestone embeddings
+
+This service intentionally does **not** generate or store embeddings — see "What is not stored"
+above. Similarity-search embeddings for milestones (used for near-duplicate / low-effort
+submission detection) are a separate subsystem keyed by `milestone_id`, not evidence rows, and are
+kept in sync by an offline reindex backfill job. See "Embedding reindex backfill job" in
+`docs/milestones.md` for that job's design, resumability, and rate-limiting.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -231,3 +231,88 @@ To run the full suite against a local database:
 ```bash
 DATABASE_URL=postgres://user:pw@localhost:5432/disciplr_test npm test -- milestoneEmbeddings
 ```
+
+## Embedding reindex backfill job
+
+The pgvector section above notes that embeddings are "populated asynchronously by an offline
+job" — `embeddings.reindex` is that job. It keeps `milestone_embeddings` in sync with the
+`milestones` table, fixing drift caused by an embedding-model change, a failed enqueue, or a
+fresh `milestone_embeddings` migration where no rows exist yet.
+
+### Why a reindex is needed
+
+A row in `milestone_embeddings` is considered **stale or missing** when either is true:
+
+- No row exists for that `milestone_id` at all.
+- The row's `model_version` no longer matches the currently configured embedding model
+  (`CURRENT_EMBEDDING_MODEL_VERSION`, see `src/services/embeddingProvider.ts`, sourced from the
+  `EMBEDDING_MODEL_VERSION` env var, default `deterministic-v1`).
+
+The `model_version` column (migration `20260627000000_add_model_version_to_milestone_embeddings.cjs`)
+defaults existing legacy rows to the sentinel `legacy-unversioned`, which never matches a real
+configured model — so every embedding that predates this job is picked up and regenerated on the
+first run.
+
+### How it works
+
+Core logic lives in `src/services/evidenceReindex.ts`:
+
+- **`reindexEvidenceBatch(options)`** — processes one bounded page of the `milestones` table
+  (ordered by `id` ascending), regenerates any missing/stale embedding, and advances a persisted
+  cursor to the last milestone id seen in that page.
+- **`runReindexBatches(options)`** — runs up to `maxBatchesPerRun` batches (default 5) in one job
+  invocation, stopping early once the table is fully caught up. This bounds how long a single job
+  execution can take.
+
+The job is registered as `embeddings.reindex` in `src/jobs/types.ts` / `src/jobs/handlers.ts`, and
+runs on a recurring schedule from `BackgroundJobSystem` (every `EMBEDDING_REINDEX_INTERVAL_MS`,
+default 10 minutes; first run 15s after startup). It can also be enqueued on demand:
+
+```ts
+jobSystem.enqueue('embeddings.reindex', { batchSize: 100, maxBatchesPerRun: 10 })
+```
+
+### Resumability
+
+The cursor (last processed milestone id) is persisted via `BackfillCursorStore`
+(`src/services/backfillCursorStore.ts`, table `backfill_cursors`, migration
+`20260627000001_create_backfill_cursors.cjs`) under job name
+`milestone-evidence-embedding-reindex`. If the process crashes or restarts mid-backfill, the next
+run resumes from the persisted cursor instead of rescanning rows that are already current.
+
+### Rate limiting
+
+Between successive embedding-provider calls **within a batch**, the job awaits `rateLimitMs`
+(default 50ms) so it never fires requests at the provider back-to-back. Rows that are skipped
+because they're already current do not count towards this delay — only actual regenerations do.
+
+### Embedding text and provider
+
+The embedding input text is the milestone's `title` and `description` (the same plaintext fields
+already stored on the `milestones` row — no raw evidence content is read or stored, consistent
+with the evidence-storage privacy contract in `docs/evidence-storage.md`).
+
+The default provider (`DeterministicEmbeddingProvider` in `src/services/embeddingProvider.ts`) is
+a network-free, deterministic provider: the same text always produces the same vector, which is
+what makes the backfill idempotent and keeps tests free of real API calls. Swap in a real model
+by implementing the `EmbeddingProvider` interface and passing it into `BackgroundJobSystem`'s
+constructor.
+
+### Progress metrics
+
+After every batch, progress is recorded via `recordEmbeddingReindexProgress` in
+`src/services/dbMetrics.ts` and readable via `getEmbeddingReindexProgress()`:
+
+```ts
+import { getEmbeddingReindexProgress } from './src/services/dbMetrics.js'
+
+getEmbeddingReindexProgress()
+// => { processed, reindexed, skippedUpToDate, cursor, done, modelVersion, recordedAt }
+```
+
+### Tests
+
+`src/tests/evidence.reindex.test.ts` covers the batch/run logic, `MilestoneRepository`'s reindex
+support methods, `BackfillCursorStore`, the embedding provider, and the `embeddings.reindex` job
+handler — all against lightweight in-memory fakes, so the suite runs without a live database (no
+`DATABASE_URL` or pgvector required).

--- a/src/jobs/handlers.ts
+++ b/src/jobs/handlers.ts
@@ -3,6 +3,12 @@ import { processJob as processExportJob } from '../services/exportQueue.js'
 import type { JobHandler, JobType } from './types.js'
 import { markVaultExpiries } from '../services/vaultExpiry.service.js'
 import { cleanupExpiredSessions } from '../services/session.js'
+import {
+  runReindexBatches,
+  type MilestoneEmbeddingSource,
+  type ReindexCursorStore,
+} from '../services/evidenceReindex.js'
+import type { EmbeddingProvider } from '../services/embeddingProvider.js'
 
 type JobHandlerRegistry = {
   [K in JobType]: JobHandler<K>
@@ -18,8 +24,15 @@ const logJob = (type: JobType, message: string): void => {
   console.log(`[jobs:${type}] ${message}`)
 }
 
+export interface EmbeddingReindexDependencies {
+  source: MilestoneEmbeddingSource
+  cursorStore: ReindexCursorStore
+  embeddingProvider: EmbeddingProvider
+}
+
 export const createDefaultJobHandlers = (
   notificationService: NotificationService,
+  embeddingReindex: EmbeddingReindexDependencies,
 ): JobHandlerRegistry => ({
   'notification.send': async (payload, context) => {
     await notificationService.send(payload.recipient, payload.subject, payload.body)
@@ -72,6 +85,20 @@ export const createDefaultJobHandlers = (
     logJob(
       'sessions.cleanup',
       `deleted=${deleted} batchSize=${batchSize} attempt=${context.attempt}`,
+    )
+  },
+  'embeddings.reindex': async (payload, context) => {
+    const result = await runReindexBatches({
+      source: embeddingReindex.source,
+      cursorStore: embeddingReindex.cursorStore,
+      embeddingProvider: embeddingReindex.embeddingProvider,
+      batchSize: payload.batchSize,
+      maxBatchesPerRun: payload.maxBatchesPerRun,
+    })
+    logJob(
+      'embeddings.reindex',
+      `batches=${result.batches} processed=${result.processed} reindexed=${result.reindexed} ` +
+        `skipped=${result.skippedUpToDate} cursor=${result.cursor ?? 'none'} done=${result.done} attempt=${context.attempt}`,
     )
   },
 })

--- a/src/jobs/system.ts
+++ b/src/jobs/system.ts
@@ -1,4 +1,4 @@
-import { createDefaultJobHandlers } from './handlers.js'
+import { createDefaultJobHandlers, type EmbeddingReindexDependencies } from './handlers.js'
 import { InMemoryJobQueue, type QueueMetrics, type QueuedJobReceipt } from './queue.js'
 import { type EnqueueOptions, type JobPayloadByType, type JobType } from './types.js'
 import { recoverPendingExportJobs } from '../services/exportQueue.js'
@@ -6,6 +6,10 @@ import {
   createNotificationService,
   type NotificationService,
 } from '../services/notifications/factory.js'
+import { db } from '../db/index.js'
+import { MilestoneRepository } from '../repositories/milestoneRepository.js'
+import { BackfillCursorStore } from '../services/backfillCursorStore.js'
+import { createEmbeddingProvider } from '../services/embeddingProvider.js'
 
 const parsePositiveInteger = (value: string | undefined, fallback: number): number => {
   if (!value) {
@@ -26,7 +30,10 @@ export class BackgroundJobSystem {
   private started = false
   private shuttingDown = false
 
-  constructor(notificationService?: NotificationService) {
+  constructor(
+    notificationService?: NotificationService,
+    embeddingReindex?: EmbeddingReindexDependencies,
+  ) {
     this.queue = new InMemoryJobQueue({
       concurrency: parsePositiveInteger(process.env.JOB_WORKER_CONCURRENCY, 2),
       pollIntervalMs: parsePositiveInteger(process.env.JOB_QUEUE_POLL_INTERVAL_MS, 250),
@@ -34,7 +41,12 @@ export class BackgroundJobSystem {
     })
     const resolvedNotificationService =
       notificationService ?? createNotificationService(process.env.NOTIFICATION_PROVIDER ?? 'console')
-    const handlers = createDefaultJobHandlers(resolvedNotificationService)
+    const resolvedEmbeddingReindex = embeddingReindex ?? {
+      source: new MilestoneRepository(db),
+      cursorStore: new BackfillCursorStore(db),
+      embeddingProvider: createEmbeddingProvider(),
+    }
+    const handlers = createDefaultJobHandlers(resolvedNotificationService, resolvedEmbeddingReindex)
 
     this.queue.registerHandler('notification.send', handlers['notification.send'])
     this.queue.registerHandler('deadline.check', handlers['deadline.check'])
@@ -42,6 +54,7 @@ export class BackgroundJobSystem {
     this.queue.registerHandler('analytics.recompute', handlers['analytics.recompute'])
     this.queue.registerHandler('export.generate', handlers['export.generate'])
     this.queue.registerHandler('sessions.cleanup', handlers['sessions.cleanup'])
+    this.queue.registerHandler('embeddings.reindex', handlers['embeddings.reindex'])
   }
 
   start(): void {
@@ -123,6 +136,10 @@ export class BackgroundJobSystem {
       process.env.SESSIONS_CLEANUP_INTERVAL_MS,
       86_400_000, // 24 hours
     )
+    const embeddingReindexIntervalMs = parsePositiveInteger(
+      process.env.EMBEDDING_REINDEX_INTERVAL_MS,
+      600_000, // 10 minutes
+    )
 
     this.enqueue('deadline.check', {
       triggerSource: 'scheduler',
@@ -136,6 +153,7 @@ export class BackgroundJobSystem {
       { delayMs: 5_000 },
     )
     this.enqueue('sessions.cleanup', {}, { delayMs: 10_000 })
+    this.enqueue('embeddings.reindex', {}, { delayMs: 15_000 })
 
     const deadlineTimer = setInterval(() => {
       this.enqueue('deadline.check', { triggerSource: 'scheduler' })
@@ -152,6 +170,10 @@ export class BackgroundJobSystem {
       this.enqueue('sessions.cleanup', {})
     }, sessionsCleanupIntervalMs)
 
+    const embeddingReindexTimer = setInterval(() => {
+      this.enqueue('embeddings.reindex', {})
+    }, embeddingReindexIntervalMs)
+
     if (typeof deadlineTimer.unref === 'function') {
       deadlineTimer.unref()
     }
@@ -161,7 +183,10 @@ export class BackgroundJobSystem {
     if (typeof sessionsTimer.unref === 'function') {
       sessionsTimer.unref()
     }
+    if (typeof embeddingReindexTimer.unref === 'function') {
+      embeddingReindexTimer.unref()
+    }
 
-    this.scheduleTimers.push(deadlineTimer, analyticsTimer, sessionsTimer)
+    this.scheduleTimers.push(deadlineTimer, analyticsTimer, sessionsTimer, embeddingReindexTimer)
   }
 }

--- a/src/jobs/types.ts
+++ b/src/jobs/types.ts
@@ -5,6 +5,7 @@ export const JOB_TYPES = [
   'analytics.recompute',
   'export.generate',
   'sessions.cleanup',
+  'embeddings.reindex',
 ] as const
 
 export type JobType = (typeof JOB_TYPES)[number]
@@ -41,6 +42,11 @@ export interface SessionsCleanupJobPayload {
   batchSize?: number
 }
 
+export interface EmbeddingsReindexJobPayload {
+  batchSize?: number
+  maxBatchesPerRun?: number
+}
+
 export interface JobPayloadByType {
   'notification.send': NotificationJobPayload
   'deadline.check': DeadlineCheckJobPayload
@@ -48,6 +54,7 @@ export interface JobPayloadByType {
   'analytics.recompute': AnalyticsRecomputeJobPayload
   'export.generate': ExportGenerateJobPayload
   'sessions.cleanup': SessionsCleanupJobPayload
+  'embeddings.reindex': EmbeddingsReindexJobPayload
 }
 
 export interface JobContext {
@@ -122,6 +129,12 @@ export const isPayloadForJobType = (
       return isNonEmptyString(payload.exportJobId)
     case 'sessions.cleanup':
       return payload.batchSize === undefined || (typeof payload.batchSize === 'number' && payload.batchSize > 0)
+    case 'embeddings.reindex':
+      return (
+        (payload.batchSize === undefined || (typeof payload.batchSize === 'number' && payload.batchSize > 0)) &&
+        (payload.maxBatchesPerRun === undefined ||
+          (typeof payload.maxBatchesPerRun === 'number' && payload.maxBatchesPerRun > 0))
+      )
     default:
       return false
   }

--- a/src/repositories/milestoneRepository.ts
+++ b/src/repositories/milestoneRepository.ts
@@ -1,8 +1,10 @@
 import { Knex } from 'knex'
+import { CURRENT_EMBEDDING_MODEL_VERSION } from '../services/embeddingProvider.js'
 
 export interface MilestoneEmbedding {
   milestone_id: string
   embedding: number[]
+  model_version: string
   created_at: Date
   updated_at: Date
 }
@@ -10,6 +12,12 @@ export interface MilestoneEmbedding {
 export interface NearestNeighborResult {
   milestone_id: string
   distance: number
+}
+
+export interface MilestoneSummary {
+  id: string
+  title: string
+  description: string | null
 }
 
 /**
@@ -23,16 +31,20 @@ export class MilestoneRepository {
 
   /**
    * Upsert an embedding for a milestone.
-   * Replaces any existing embedding for the same milestone_id.
+   * Replaces any existing embedding (and model_version) for the same milestone_id.
    */
-  async upsertEmbedding(milestoneId: string, embedding: number[]): Promise<void> {
+  async upsertEmbedding(
+    milestoneId: string,
+    embedding: number[],
+    modelVersion: string = CURRENT_EMBEDDING_MODEL_VERSION,
+  ): Promise<void> {
     const vectorLiteral = `[${embedding.join(',')}]`
     await this.db.raw(
-      `INSERT INTO milestone_embeddings (milestone_id, embedding, updated_at)
-       VALUES (:milestoneId, :vector::vector, NOW())
+      `INSERT INTO milestone_embeddings (milestone_id, embedding, model_version, updated_at)
+       VALUES (:milestoneId, :vector::vector, :modelVersion, NOW())
        ON CONFLICT (milestone_id)
-       DO UPDATE SET embedding = EXCLUDED.embedding, updated_at = NOW()`,
-      { milestoneId, vector: vectorLiteral },
+       DO UPDATE SET embedding = EXCLUDED.embedding, model_version = EXCLUDED.model_version, updated_at = NOW()`,
+      { milestoneId, vector: vectorLiteral, modelVersion },
     )
   }
 
@@ -82,6 +94,7 @@ export class MilestoneRepository {
       .select(
         'milestone_id',
         this.db.raw('embedding::text AS embedding'),
+        'model_version',
         'created_at',
         'updated_at',
       )
@@ -100,5 +113,39 @@ export class MilestoneRepository {
    */
   async deleteEmbedding(milestoneId: string): Promise<void> {
     await this.db('milestone_embeddings').where({ milestone_id: milestoneId }).delete()
+  }
+
+  /**
+   * Page through the milestones table in stable ascending-id order. Used by
+   * the embedding reindex backfill to walk the source-of-truth table without
+   * loading it all into memory at once.
+   */
+  async listMilestonesAfter(afterId: string | null, limit: number): Promise<MilestoneSummary[]> {
+    let query = this.db('milestones')
+      .select('id', 'title', 'description')
+      .orderBy('id', 'asc')
+      .limit(limit)
+
+    if (afterId !== null) {
+      query = query.where('id', '>', afterId)
+    }
+
+    return query
+  }
+
+  /**
+   * Return the model_version of every embedding that exists among the given
+   * milestone ids. Ids absent from the returned map have no stored embedding.
+   */
+  async findEmbeddingModelVersions(milestoneIds: string[]): Promise<Map<string, string>> {
+    if (milestoneIds.length === 0) {
+      return new Map()
+    }
+
+    const rows = await this.db('milestone_embeddings')
+      .whereIn('milestone_id', milestoneIds)
+      .select('milestone_id', 'model_version')
+
+    return new Map(rows.map((row: { milestone_id: string; model_version: string }) => [row.milestone_id, row.model_version]))
   }
 }

--- a/src/services/backfillCursorStore.ts
+++ b/src/services/backfillCursorStore.ts
@@ -1,0 +1,50 @@
+import { Knex } from 'knex'
+
+export interface BackfillCursor {
+  jobName: string
+  cursor: string | null
+  updatedAt: Date
+  createdAt: Date
+}
+
+/**
+ * BackfillCursorStore
+ *
+ * Generic persisted-cursor table for resumable batch backfill jobs, modelled
+ * on CheckpointStore (see src/services/checkpointStore.ts). Each job is
+ * identified by a stable `jobName` and advances a single opaque string
+ * cursor (e.g. the last processed primary key) so a crashed or restarted
+ * process resumes from where it left off instead of starting over.
+ */
+export class BackfillCursorStore {
+  constructor(private readonly db: Knex) {}
+
+  async getCursor(jobName: string): Promise<string | null> {
+    const row = await this.db('backfill_cursors').where({ job_name: jobName }).first()
+    return row ? (row.cursor as string | null) : null
+  }
+
+  async upsertCursor(jobName: string, cursor: string | null): Promise<void> {
+    const now = new Date()
+
+    await this.db('backfill_cursors')
+      .insert({
+        job_name: jobName,
+        cursor,
+        updated_at: now,
+        created_at: now,
+      })
+      .onConflict('job_name')
+      .merge({
+        cursor,
+        updated_at: now,
+      })
+  }
+
+  /**
+   * Operator tool: restart a backfill job from the beginning.
+   */
+  async resetCursor(jobName: string): Promise<void> {
+    await this.db('backfill_cursors').where({ job_name: jobName }).delete()
+  }
+}

--- a/src/services/dbMetrics.ts
+++ b/src/services/dbMetrics.ts
@@ -213,4 +213,47 @@ export function getSlowQueries(limit: number = 20): SlowQuerySample[] {
   return slowQueryTracker.getSamples(limit)
 }
 
+/**
+ * Progress snapshot for the milestone-embedding reindex backfill job.
+ * Recorded after every batch so operators can observe backfill progress
+ * (and detect a stalled/backsliding cursor) without querying the DB directly.
+ */
+export interface EmbeddingReindexProgress {
+  processed: number
+  reindexed: number
+  skippedUpToDate: number
+  cursor: string | null
+  done: boolean
+  modelVersion: string
+}
+
+interface EmbeddingReindexMetrics extends EmbeddingReindexProgress {
+  recordedAt: Date
+}
+
+let lastEmbeddingReindexProgress: EmbeddingReindexMetrics | null = null
+
+/**
+ * Record progress from one reindex batch. Called by the embedding reindex
+ * job after each batch; overwrites the previous snapshot.
+ */
+export function recordEmbeddingReindexProgress(progress: EmbeddingReindexProgress): void {
+  lastEmbeddingReindexProgress = { ...progress, recordedAt: new Date() }
+}
+
+/**
+ * Get the most recently recorded embedding reindex progress, or null if the
+ * job has not run yet in this process.
+ */
+export function getEmbeddingReindexProgress(): EmbeddingReindexMetrics | null {
+  return lastEmbeddingReindexProgress
+}
+
+/**
+ * Reset the embedding reindex progress snapshot (useful for tests).
+ */
+export function resetEmbeddingReindexProgress(): void {
+  lastEmbeddingReindexProgress = null
+}
+
 export { SlowQueryTracker, PoolMetrics, DBHealthMetrics, SlowQuerySample }

--- a/src/services/embeddingProvider.ts
+++ b/src/services/embeddingProvider.ts
@@ -1,0 +1,41 @@
+const EMBEDDING_DIMENSIONS = 768
+
+export interface EmbeddingProvider {
+  readonly modelVersion: string
+  embed(text: string): Promise<number[]>
+}
+
+/**
+ * Deterministic, network-free embedding provider used as the default so the
+ * reindex job and its tests never depend on a real embedding API. Two calls
+ * with the same text always produce the same vector, which is what makes the
+ * backfill idempotent.
+ */
+export class DeterministicEmbeddingProvider implements EmbeddingProvider {
+  constructor(readonly modelVersion: string) {}
+
+  async embed(text: string): Promise<number[]> {
+    let seed = hashString(`${this.modelVersion}:${text}`)
+    const vector: number[] = []
+    for (let i = 0; i < EMBEDDING_DIMENSIONS; i++) {
+      seed = (seed * 1664525 + 1013904223) & 0xffffffff
+      vector.push((seed & 0xffff) / 0xffff - 0.5)
+    }
+    const norm = Math.sqrt(vector.reduce((acc, value) => acc + value * value, 0))
+    return norm === 0 ? vector : vector.map((value) => value / norm)
+  }
+}
+
+function hashString(input: string): number {
+  let hash = 0
+  for (let i = 0; i < input.length; i++) {
+    hash = (Math.imul(hash, 31) + input.charCodeAt(i)) | 0
+  }
+  return hash >>> 0
+}
+
+export const CURRENT_EMBEDDING_MODEL_VERSION = process.env.EMBEDDING_MODEL_VERSION ?? 'deterministic-v1'
+
+export const createEmbeddingProvider = (
+  modelVersion: string = CURRENT_EMBEDDING_MODEL_VERSION,
+): EmbeddingProvider => new DeterministicEmbeddingProvider(modelVersion)

--- a/src/services/evidenceReindex.ts
+++ b/src/services/evidenceReindex.ts
@@ -1,0 +1,166 @@
+import type { EmbeddingProvider } from './embeddingProvider.js'
+import { recordEmbeddingReindexProgress } from './dbMetrics.js'
+
+export const EMBEDDING_REINDEX_JOB_NAME = 'milestone-evidence-embedding-reindex'
+
+export interface MilestoneEmbeddingSource {
+  listMilestonesAfter(
+    afterId: string | null,
+    limit: number,
+  ): Promise<Array<{ id: string; title: string; description: string | null }>>
+  findEmbeddingModelVersions(milestoneIds: string[]): Promise<Map<string, string>>
+  upsertEmbedding(milestoneId: string, embedding: number[], modelVersion: string): Promise<void>
+}
+
+/**
+ * Narrow, structural view of BackfillCursorStore (see backfillCursorStore.ts)
+ * — declared as an interface rather than imported as the concrete class so
+ * tests can inject a lightweight in-memory fake instead of a real Knex-backed
+ * store.
+ */
+export interface ReindexCursorStore {
+  getCursor(jobName: string): Promise<string | null>
+  upsertCursor(jobName: string, cursor: string | null): Promise<void>
+}
+
+export interface ReindexBatchOptions {
+  source: MilestoneEmbeddingSource
+  cursorStore: ReindexCursorStore
+  embeddingProvider: EmbeddingProvider
+  batchSize?: number
+  rateLimitMs?: number
+  jobName?: string
+  sleep?: (ms: number) => Promise<void>
+}
+
+export interface ReindexBatchResult {
+  processed: number
+  reindexed: number
+  skippedUpToDate: number
+  cursor: string | null
+  done: boolean
+}
+
+const DEFAULT_BATCH_SIZE = 50
+const DEFAULT_RATE_LIMIT_MS = 50
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+const buildEmbeddingText = (milestone: { title: string; description: string | null }): string =>
+  [milestone.title, milestone.description].filter(Boolean).join('\n')
+
+/**
+ * Process a single bounded page of the milestones table, (re)generating any
+ * embedding that is missing or whose model_version no longer matches the
+ * currently configured embedding model. Resumable: the cursor is the last
+ * milestone id seen, persisted via `cursorStore` so a crash or restart picks
+ * up after this batch instead of reprocessing already-current rows.
+ */
+export async function reindexEvidenceBatch(options: ReindexBatchOptions): Promise<ReindexBatchResult> {
+  const {
+    source,
+    cursorStore,
+    embeddingProvider,
+    batchSize = DEFAULT_BATCH_SIZE,
+    rateLimitMs = DEFAULT_RATE_LIMIT_MS,
+    jobName = EMBEDDING_REINDEX_JOB_NAME,
+    sleep = defaultSleep,
+  } = options
+
+  const cursor = await cursorStore.getCursor(jobName)
+  const milestones = await source.listMilestonesAfter(cursor, batchSize)
+
+  if (milestones.length === 0) {
+    const result: ReindexBatchResult = { processed: 0, reindexed: 0, skippedUpToDate: 0, cursor, done: true }
+    recordEmbeddingReindexProgress({ ...result, modelVersion: embeddingProvider.modelVersion })
+    return result
+  }
+
+  const existingVersions = await source.findEmbeddingModelVersions(milestones.map((m) => m.id))
+
+  let reindexed = 0
+  let skippedUpToDate = 0
+
+  for (const milestone of milestones) {
+    const existingVersion = existingVersions.get(milestone.id) ?? null
+    if (existingVersion === embeddingProvider.modelVersion) {
+      skippedUpToDate += 1
+      continue
+    }
+
+    if (reindexed > 0) {
+      await sleep(rateLimitMs)
+    }
+
+    const text = buildEmbeddingText(milestone)
+    const embedding = await embeddingProvider.embed(text)
+    await source.upsertEmbedding(milestone.id, embedding, embeddingProvider.modelVersion)
+    reindexed += 1
+  }
+
+  const newCursor = milestones[milestones.length - 1].id
+  await cursorStore.upsertCursor(jobName, newCursor)
+
+  const result: ReindexBatchResult = {
+    processed: milestones.length,
+    reindexed,
+    skippedUpToDate,
+    cursor: newCursor,
+    done: milestones.length < batchSize,
+  }
+  recordEmbeddingReindexProgress({ ...result, modelVersion: embeddingProvider.modelVersion })
+  return result
+}
+
+export interface ReindexRunOptions extends ReindexBatchOptions {
+  maxBatchesPerRun?: number
+}
+
+export interface ReindexRunResult {
+  batches: number
+  processed: number
+  reindexed: number
+  skippedUpToDate: number
+  cursor: string | null
+  done: boolean
+}
+
+const DEFAULT_MAX_BATCHES_PER_RUN = 5
+
+/**
+ * Run up to `maxBatchesPerRun` batches in sequence, stopping early once the
+ * table is fully caught up. Intended to be invoked periodically (e.g. by a
+ * recurring job) rather than run to completion in one call, so a single
+ * invocation never blocks the worker for an unbounded amount of time.
+ */
+export async function runReindexBatches(options: ReindexRunOptions): Promise<ReindexRunResult> {
+  const { maxBatchesPerRun = DEFAULT_MAX_BATCHES_PER_RUN, ...batchOptions } = options
+
+  const totals: ReindexRunResult = {
+    batches: 0,
+    processed: 0,
+    reindexed: 0,
+    skippedUpToDate: 0,
+    cursor: null,
+    done: false,
+  }
+
+  for (let i = 0; i < maxBatchesPerRun; i++) {
+    const batch = await reindexEvidenceBatch(batchOptions)
+    totals.batches += 1
+    totals.processed += batch.processed
+    totals.reindexed += batch.reindexed
+    totals.skippedUpToDate += batch.skippedUpToDate
+    totals.cursor = batch.cursor
+    totals.done = batch.done
+
+    if (batch.done) {
+      break
+    }
+  }
+
+  return totals
+}

--- a/src/tests/evidence.reindex.test.ts
+++ b/src/tests/evidence.reindex.test.ts
@@ -1,0 +1,491 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import {
+  reindexEvidenceBatch,
+  runReindexBatches,
+  EMBEDDING_REINDEX_JOB_NAME,
+  type MilestoneEmbeddingSource,
+  type ReindexCursorStore,
+} from '../services/evidenceReindex.js'
+import { DeterministicEmbeddingProvider, createEmbeddingProvider } from '../services/embeddingProvider.js'
+import { MilestoneRepository } from '../repositories/milestoneRepository.js'
+import { BackfillCursorStore } from '../services/backfillCursorStore.js'
+import { getEmbeddingReindexProgress, resetEmbeddingReindexProgress } from '../services/dbMetrics.js'
+
+// ── Fakes ────────────────────────────────────────────────────────────────────
+
+interface FakeMilestoneRow {
+  id: string
+  title: string
+  description: string | null
+}
+
+interface FakeEmbeddingRow {
+  modelVersion: string
+  embedding: number[]
+}
+
+class FakeMilestoneSource implements MilestoneEmbeddingSource {
+  embeddings = new Map<string, FakeEmbeddingRow>()
+  upsertCalls: Array<{ milestoneId: string; modelVersion: string }> = []
+
+  constructor(private readonly milestones: FakeMilestoneRow[]) {}
+
+  async listMilestonesAfter(afterId: string | null, limit: number): Promise<FakeMilestoneRow[]> {
+    const sorted = [...this.milestones].sort((a, b) => a.id.localeCompare(b.id))
+    const filtered = afterId === null ? sorted : sorted.filter((m) => m.id > afterId)
+    return filtered.slice(0, limit)
+  }
+
+  async findEmbeddingModelVersions(milestoneIds: string[]): Promise<Map<string, string>> {
+    const result = new Map<string, string>()
+    for (const id of milestoneIds) {
+      const existing = this.embeddings.get(id)
+      if (existing) {
+        result.set(id, existing.modelVersion)
+      }
+    }
+    return result
+  }
+
+  async upsertEmbedding(milestoneId: string, embedding: number[], modelVersion: string): Promise<void> {
+    this.embeddings.set(milestoneId, { embedding, modelVersion })
+    this.upsertCalls.push({ milestoneId, modelVersion })
+  }
+}
+
+class FakeCursorStore implements ReindexCursorStore {
+  private cursors = new Map<string, string | null>()
+
+  async getCursor(jobName: string): Promise<string | null> {
+    return this.cursors.get(jobName) ?? null
+  }
+
+  async upsertCursor(jobName: string, cursor: string | null): Promise<void> {
+    this.cursors.set(jobName, cursor)
+  }
+}
+
+const makeMilestones = (count: number): FakeMilestoneRow[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `m-${String(i).padStart(3, '0')}`,
+    title: `Milestone ${i}`,
+    description: `Description for milestone ${i}`,
+  }))
+
+const provider = new DeterministicEmbeddingProvider('v1')
+
+// ── reindexEvidenceBatch ─────────────────────────────────────────────────────
+
+describe('reindexEvidenceBatch', () => {
+  it('does nothing and reports done on an empty table', async () => {
+    const source = new FakeMilestoneSource([])
+    const cursorStore = new FakeCursorStore()
+
+    const result = await reindexEvidenceBatch({ source, cursorStore, embeddingProvider: provider })
+
+    expect(result).toEqual({ processed: 0, reindexed: 0, skippedUpToDate: 0, cursor: null, done: true })
+  })
+
+  it('generates embeddings for every milestone missing one', async () => {
+    const source = new FakeMilestoneSource(makeMilestones(3))
+    const cursorStore = new FakeCursorStore()
+
+    const result = await reindexEvidenceBatch({ source, cursorStore, embeddingProvider: provider, batchSize: 10 })
+
+    expect(result.processed).toBe(3)
+    expect(result.reindexed).toBe(3)
+    expect(result.skippedUpToDate).toBe(0)
+    expect(result.done).toBe(true)
+    expect(source.upsertCalls.map((c) => c.milestoneId)).toEqual(['m-000', 'm-001', 'm-002'])
+    expect(source.upsertCalls.every((c) => c.modelVersion === 'v1')).toBe(true)
+  })
+
+  it('only reindexes rows whose model version differs from the current model', async () => {
+    const source = new FakeMilestoneSource(makeMilestones(3))
+    await source.upsertEmbedding('m-000', [0.1], 'v1') // already current
+    await source.upsertEmbedding('m-001', [0.2], 'legacy-unversioned') // stale
+    // m-002 has no embedding at all (missing)
+    source.upsertCalls.length = 0 // discard the seeding calls above
+    const cursorStore = new FakeCursorStore()
+
+    const result = await reindexEvidenceBatch({ source, cursorStore, embeddingProvider: provider, batchSize: 10 })
+
+    expect(result.skippedUpToDate).toBe(1)
+    expect(result.reindexed).toBe(2)
+    expect(source.upsertCalls.map((c) => c.milestoneId).sort()).toEqual(['m-001', 'm-002'])
+  })
+
+  it('persists the cursor as the last milestone id seen in the batch', async () => {
+    const source = new FakeMilestoneSource(makeMilestones(5))
+    const cursorStore = new FakeCursorStore()
+
+    const result = await reindexEvidenceBatch({ source, cursorStore, embeddingProvider: provider, batchSize: 2 })
+
+    expect(result.processed).toBe(2)
+    expect(result.cursor).toBe('m-001')
+    expect(result.done).toBe(false) // batch was full; more rows may remain
+    expect(await cursorStore.getCursor(EMBEDDING_REINDEX_JOB_NAME)).toBe('m-001')
+  })
+
+  it('resumes from the persisted cursor after a simulated crash, without reprocessing earlier rows', async () => {
+    const source = new FakeMilestoneSource(makeMilestones(5))
+    const cursorStore = new FakeCursorStore()
+
+    const firstBatch = await reindexEvidenceBatch({ source, cursorStore, embeddingProvider: provider, batchSize: 2 })
+    expect(firstBatch.cursor).toBe('m-001')
+
+    // Simulate a crash: a brand-new call only has access to what's durable —
+    // the cursor store and the source — not any in-process state.
+    const secondBatch = await reindexEvidenceBatch({ source, cursorStore, embeddingProvider: provider, batchSize: 2 })
+
+    expect(secondBatch.processed).toBe(2)
+    expect(source.upsertCalls.map((c) => c.milestoneId)).toEqual(['m-000', 'm-001', 'm-002', 'm-003'])
+    expect(secondBatch.cursor).toBe('m-003')
+    expect(secondBatch.done).toBe(false)
+
+    const thirdBatch = await reindexEvidenceBatch({ source, cursorStore, embeddingProvider: provider, batchSize: 2 })
+    expect(thirdBatch.processed).toBe(1)
+    expect(thirdBatch.done).toBe(true)
+    expect(thirdBatch.cursor).toBe('m-004')
+  })
+
+  it('rate-limits successive embedding calls but never sleeps before the first or after a skip-only batch', async () => {
+    const source = new FakeMilestoneSource(makeMilestones(3))
+    const cursorStore = new FakeCursorStore()
+    const sleep = jest.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined)
+
+    await reindexEvidenceBatch({
+      source,
+      cursorStore,
+      embeddingProvider: provider,
+      batchSize: 10,
+      rateLimitMs: 25,
+      sleep,
+    })
+
+    // 3 rows reindexed -> 2 inter-call delays, never a delay before the first call.
+    expect(sleep).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledWith(25)
+  })
+
+  it('never sleeps when every row in the batch is already up to date', async () => {
+    const source = new FakeMilestoneSource(makeMilestones(2))
+    await source.upsertEmbedding('m-000', [0.1], 'v1')
+    await source.upsertEmbedding('m-001', [0.2], 'v1')
+    source.upsertCalls.length = 0 // discard the seeding calls above
+    const cursorStore = new FakeCursorStore()
+    const sleep = jest.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined)
+
+    const result = await reindexEvidenceBatch({ source, cursorStore, embeddingProvider: provider, sleep })
+
+    expect(result.reindexed).toBe(0)
+    expect(result.skippedUpToDate).toBe(2)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('records progress metrics consumable via dbMetrics', async () => {
+    resetEmbeddingReindexProgress()
+    expect(getEmbeddingReindexProgress()).toBeNull()
+
+    const source = new FakeMilestoneSource(makeMilestones(1))
+    const cursorStore = new FakeCursorStore()
+
+    await reindexEvidenceBatch({ source, cursorStore, embeddingProvider: provider })
+
+    const progress = getEmbeddingReindexProgress()
+    expect(progress).not.toBeNull()
+    expect(progress).toMatchObject({ processed: 1, reindexed: 1, modelVersion: 'v1', done: true })
+    expect(progress!.recordedAt).toBeInstanceOf(Date)
+  })
+})
+
+// ── runReindexBatches ────────────────────────────────────────────────────────
+
+describe('runReindexBatches', () => {
+  it('runs multiple batches until the table is fully caught up', async () => {
+    const source = new FakeMilestoneSource(makeMilestones(5))
+    const cursorStore = new FakeCursorStore()
+
+    const result = await runReindexBatches({
+      source,
+      cursorStore,
+      embeddingProvider: provider,
+      batchSize: 2,
+      maxBatchesPerRun: 10,
+    })
+
+    expect(result.batches).toBe(3) // 2 + 2 + 1
+    expect(result.processed).toBe(5)
+    expect(result.reindexed).toBe(5)
+    expect(result.done).toBe(true)
+  })
+
+  it('stops after maxBatchesPerRun even if more rows remain', async () => {
+    const source = new FakeMilestoneSource(makeMilestones(10))
+    const cursorStore = new FakeCursorStore()
+
+    const result = await runReindexBatches({
+      source,
+      cursorStore,
+      embeddingProvider: provider,
+      batchSize: 2,
+      maxBatchesPerRun: 2,
+    })
+
+    expect(result.batches).toBe(2)
+    expect(result.processed).toBe(4)
+    expect(result.done).toBe(false)
+    expect(result.cursor).toBe('m-003')
+  })
+})
+
+// ── MilestoneRepository — reindex support (mocked Knex) ────────────────────
+
+function makeQueryBuilder(rows: unknown[] = []) {
+  const qb: any = {
+    select: jest.fn<any>().mockReturnThis(),
+    orderBy: jest.fn<any>().mockReturnThis(),
+    limit: jest.fn<any>().mockReturnThis(),
+    where: jest.fn<any>().mockReturnThis(),
+    whereIn: jest.fn<any>().mockReturnThis(),
+    then: (resolve: (value: unknown) => unknown) => resolve(rows),
+  }
+  return qb
+}
+
+function makeMockDb(qb: ReturnType<typeof makeQueryBuilder>) {
+  const db: any = jest.fn<any>().mockReturnValue(qb)
+  db.raw = jest.fn<any>().mockResolvedValue(undefined)
+  return db
+}
+
+describe('MilestoneRepository — reindex support', () => {
+  it('listMilestonesAfter queries without a lower bound when afterId is null', async () => {
+    const qb = makeQueryBuilder([{ id: 'm-000', title: 'A', description: null }])
+    const db = makeMockDb(qb)
+    const repo = new MilestoneRepository(db)
+
+    const rows = await repo.listMilestonesAfter(null, 50)
+
+    expect(db).toHaveBeenCalledWith('milestones')
+    expect(qb.where).not.toHaveBeenCalled()
+    expect(qb.limit).toHaveBeenCalledWith(50)
+    expect(rows).toEqual([{ id: 'm-000', title: 'A', description: null }])
+  })
+
+  it('listMilestonesAfter filters by id > afterId when a cursor is given', async () => {
+    const qb = makeQueryBuilder([])
+    const db = makeMockDb(qb)
+    const repo = new MilestoneRepository(db)
+
+    await repo.listMilestonesAfter('m-005', 25)
+
+    expect(qb.where).toHaveBeenCalledWith('id', '>', 'm-005')
+    expect(qb.limit).toHaveBeenCalledWith(25)
+  })
+
+  it('findEmbeddingModelVersions returns an empty map without querying when given no ids', async () => {
+    const qb = makeQueryBuilder([])
+    const db = makeMockDb(qb)
+    const repo = new MilestoneRepository(db)
+
+    const result = await repo.findEmbeddingModelVersions([])
+
+    expect(result.size).toBe(0)
+    expect(db).not.toHaveBeenCalled()
+  })
+
+  it('findEmbeddingModelVersions maps milestone_id to model_version', async () => {
+    const qb = makeQueryBuilder([
+      { milestone_id: 'm-000', model_version: 'v1' },
+      { milestone_id: 'm-001', model_version: 'legacy-unversioned' },
+    ])
+    const db = makeMockDb(qb)
+    const repo = new MilestoneRepository(db)
+
+    const result = await repo.findEmbeddingModelVersions(['m-000', 'm-001', 'm-002'])
+
+    expect(qb.whereIn).toHaveBeenCalledWith('milestone_id', ['m-000', 'm-001', 'm-002'])
+    expect(result.get('m-000')).toBe('v1')
+    expect(result.get('m-001')).toBe('legacy-unversioned')
+    expect(result.has('m-002')).toBe(false)
+  })
+
+  it('upsertEmbedding passes the model version through to the raw insert', async () => {
+    const db: any = jest.fn<any>()
+    db.raw = jest.fn<any>().mockResolvedValue(undefined)
+    const repo = new MilestoneRepository(db)
+
+    await repo.upsertEmbedding('m-000', [0.1, 0.2], 'custom-model-v2')
+
+    expect(db.raw).toHaveBeenCalledWith(
+      expect.stringContaining('model_version'),
+      expect.objectContaining({ milestoneId: 'm-000', modelVersion: 'custom-model-v2' }),
+    )
+  })
+
+  it('upsertEmbedding defaults to the current configured model version', async () => {
+    const db: any = jest.fn<any>()
+    db.raw = jest.fn<any>().mockResolvedValue(undefined)
+    const repo = new MilestoneRepository(db)
+
+    await repo.upsertEmbedding('m-000', [0.1])
+
+    expect(db.raw).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ modelVersion: 'deterministic-v1' }),
+    )
+  })
+
+  it('findEmbedding includes model_version in the returned record', async () => {
+    const qb = makeQueryBuilder([])
+    qb.select = jest.fn<any>().mockReturnThis()
+    qb.first = jest
+      .fn<any>()
+      .mockResolvedValue({
+        milestone_id: 'm-000',
+        embedding: '[0.1,0.2]',
+        model_version: 'v1',
+        created_at: new Date('2026-01-01'),
+        updated_at: new Date('2026-01-01'),
+      })
+    const db = makeMockDb(qb)
+    const repo = new MilestoneRepository(db)
+
+    const result = await repo.findEmbedding('m-000')
+
+    expect(qb.select).toHaveBeenCalledWith(
+      'milestone_id',
+      expect.anything(),
+      'model_version',
+      'created_at',
+      'updated_at',
+    )
+    expect(result).toMatchObject({ milestone_id: 'm-000', model_version: 'v1', embedding: [0.1, 0.2] })
+  })
+
+  it('findEmbedding returns null when no row exists', async () => {
+    const qb = makeQueryBuilder([])
+    qb.select = jest.fn<any>().mockReturnThis()
+    qb.first = jest.fn<any>().mockResolvedValue(null)
+    const db = makeMockDb(qb)
+    const repo = new MilestoneRepository(db)
+
+    const result = await repo.findEmbedding('missing')
+
+    expect(result).toBeNull()
+  })
+})
+
+// ── embeddingProvider ────────────────────────────────────────────────────────
+
+describe('createEmbeddingProvider', () => {
+  it('uses the given model version and produces a normalised vector', async () => {
+    const created = createEmbeddingProvider('test-model')
+    expect(created.modelVersion).toBe('test-model')
+
+    const embedding = await created.embed('hello world')
+    expect(embedding).toHaveLength(768)
+    const norm = Math.sqrt(embedding.reduce((acc, v) => acc + v * v, 0))
+    expect(norm).toBeCloseTo(1, 5)
+  })
+
+  it('falls back to the configured CURRENT_EMBEDDING_MODEL_VERSION when none is given', () => {
+    const created = createEmbeddingProvider()
+    expect(created.modelVersion).toBe('deterministic-v1')
+  })
+})
+
+// ── BackfillCursorStore (mocked Knex) ───────────────────────────────────────
+
+function makeCursorQueryBuilder(overrides: Partial<Record<string, any>> = {}) {
+  const qb: any = {
+    where: jest.fn<any>().mockReturnThis(),
+    first: jest.fn<any>().mockResolvedValue(null),
+    insert: jest.fn<any>().mockReturnThis(),
+    onConflict: jest.fn<any>().mockReturnThis(),
+    merge: jest.fn<any>().mockResolvedValue(undefined),
+    delete: jest.fn<any>().mockResolvedValue(1),
+    ...overrides,
+  }
+  return qb
+}
+
+function makeCursorMockDb(qb: ReturnType<typeof makeCursorQueryBuilder>) {
+  const db: any = jest.fn<any>().mockReturnValue(qb)
+  db._qb = qb
+  return db
+}
+
+describe('BackfillCursorStore', () => {
+  it('getCursor returns null when no row exists', async () => {
+    const qb = makeCursorQueryBuilder({ first: jest.fn<any>().mockResolvedValue(null) })
+    const db = makeCursorMockDb(qb)
+    const store = new BackfillCursorStore(db)
+
+    const result = await store.getCursor('my-job')
+
+    expect(result).toBeNull()
+    expect(db).toHaveBeenCalledWith('backfill_cursors')
+    expect(qb.where).toHaveBeenCalledWith({ job_name: 'my-job' })
+  })
+
+  it('getCursor returns the stored cursor when a row exists', async () => {
+    const qb = makeCursorQueryBuilder({ first: jest.fn<any>().mockResolvedValue({ cursor: 'm-042' }) })
+    const db = makeCursorMockDb(qb)
+    const store = new BackfillCursorStore(db)
+
+    const result = await store.getCursor('my-job')
+
+    expect(result).toBe('m-042')
+  })
+
+  it('upsertCursor inserts with onConflict merge', async () => {
+    const qb = makeCursorQueryBuilder()
+    const db = makeCursorMockDb(qb)
+    const store = new BackfillCursorStore(db)
+
+    await store.upsertCursor('my-job', 'm-099')
+
+    expect(qb.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_name: 'my-job', cursor: 'm-099' }),
+    )
+    expect(qb.onConflict).toHaveBeenCalledWith('job_name')
+    expect(qb.merge).toHaveBeenCalledWith(expect.objectContaining({ cursor: 'm-099' }))
+  })
+
+  it('resetCursor deletes the row for the job', async () => {
+    const qb = makeCursorQueryBuilder()
+    const db = makeCursorMockDb(qb)
+    const store = new BackfillCursorStore(db)
+
+    await store.resetCursor('my-job')
+
+    expect(qb.where).toHaveBeenCalledWith({ job_name: 'my-job' })
+    expect(qb.delete).toHaveBeenCalled()
+  })
+})
+
+// ── createDefaultJobHandlers — embeddings.reindex ───────────────────────────
+
+describe('embeddings.reindex job handler', () => {
+  let createDefaultJobHandlers: any
+
+  beforeEach(async () => {
+    const module = await import('../jobs/handlers.js')
+    createDefaultJobHandlers = module.createDefaultJobHandlers
+  })
+
+  it('runs the reindex against the injected dependencies and completes', async () => {
+    const source = new FakeMilestoneSource(makeMilestones(2))
+    const cursorStore = new FakeCursorStore()
+    const handlers = createDefaultJobHandlers(
+      { send: jest.fn() },
+      { source, cursorStore, embeddingProvider: provider },
+    )
+
+    await handlers['embeddings.reindex']({}, { jobId: 'job-1', attempt: 1 })
+
+    expect(source.upsertCalls).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Summary

**Scope note (read first):** the issue describes `src/services/evidence.ts` generating embeddings at write time with model-version drift. Neither exists in this codebase — `evidence.ts` only stores signed-URL references and explicitly never touches embeddings (see `docs/evidence-storage.md`'s "What is not stored"), and the real embeddings infrastructure (`milestone_embeddings` table / `MilestoneRepository`) has no `model_version` column and `upsertEmbedding` is never called outside its own test file. `docs/milestones.md` already documents embeddings as "populated asynchronously by an offline job" — that job didn't exist yet. This PR builds the reindex backfill against that real system instead of inventing a parallel one on top of `evidence.ts`.

- Adds a `model_version` column to `milestone_embeddings` (migration `20260627000000_add_model_version_to_milestone_embeddings.cjs`); legacy rows default to a sentinel that always needs reindexing.
- Adds an `EmbeddingProvider` abstraction (`src/services/embeddingProvider.ts`) with a deterministic, network-free default provider — no real API dependency required.
- Extends `MilestoneRepository`: `listMilestonesAfter` (keyset-paginated scan of the `milestones` table) and `findEmbeddingModelVersions` (batched staleness check), and threads `model_version` through `upsertEmbedding`/`findEmbedding`.
- Adds `BackfillCursorStore` (`src/services/backfillCursorStore.ts`, new `backfill_cursors` table, migration `20260627000001_create_backfill_cursors.cjs`), a generic persisted cursor modelled on `checkpointStore.ts`, so a crash/restart resumes instead of rescanning.
- Adds the batched/resumable/rate-bounded reindex logic in `src/services/evidenceReindex.ts` (`reindexEvidenceBatch` for one page, `runReindexBatches` to bound work per job invocation), registered as the `embeddings.reindex` job (`types.ts`/`handlers.ts`/`system.ts`) on a recurring schedule (`EMBEDDING_REINDEX_INTERVAL_MS`, default 10 min) and enqueueable on demand.
- Records per-batch progress in `src/services/dbMetrics.ts` (`recordEmbeddingReindexProgress`/`getEmbeddingReindexProgress`), mirroring that file's existing `SlowQueryTracker` idiom.
- Documents the job in `docs/milestones.md` (full design: drift detection, resumability, rate limiting, embedding text source) with a pointer note in `docs/evidence-storage.md` clarifying the relationship between the two subsystems.

Closes #711

## Note on CI

Same pre-existing situation as in #814 (still open): `npm run build` already fails on a clean `main` checkout due to unrelated bugs predating this change. Verified my diff adds no new `tsc`/`eslint` errors (full before/after error-list diff is identical except line-number drift). Also note: adding `'embeddings.reindex'` to `JOB_TYPES` surfaces the same pre-existing `createEmptyTypeMetrics` bug already fixed in #814 for `'sessions.cleanup'` — confirmed via full test-suite diff that this introduces zero new test failures (identical 209 failing / 744 passing baseline before vs. 209 failing / 769 passing after, the +25 being this PR's new tests). Left `queue.ts` untouched here to avoid duplicating/conflicting with the fix already in #814.

## Test plan

- [x] `src/tests/evidence.reindex.test.ts` (new, 25 tests): empty table, full backfill from scratch, model-version-mismatch-only reindexing, cursor persistence, crash-and-resume across multiple batches, rate-limit backpressure (and no delay on skip-only batches), multi-batch run bounding, `MilestoneRepository`'s new methods, `BackfillCursorStore`, the embedding provider, and the `embeddings.reindex` job handler — all against in-memory fakes, no live DB/pgvector required.
- [x] Coverage on new/changed lines: 100% statements/lines/functions across `evidenceReindex.ts`, `backfillCursorStore.ts`, `embeddingProvider.ts`; changed lines in `milestoneRepository.ts`, `handlers.ts`, `dbMetrics.ts` covered (verified via `--coverage`, diffed against pre-existing untouched lines).
- [x] Confirmed no regressions: full `npm test` run shows identical pre-existing failure count before/after, plus 25 new passing tests.