### PR TITLE
feat: health-aware Soroban RPC endpoint pool with failover

### DIFF
--- a/docs/contracts-accountability-vault.md
+++ b/docs/contracts-accountability-vault.md
@@ -14,3 +14,35 @@ Notes for backend developers:
 - `src/services/soroban.ts` builds the call args expecting `vaultId` first.
 - `src/services/eventParser.ts` validates that incoming events include a
   `vaultId`/`vault_id` string that matches UUID format.
+
+## Soroban RPC endpoint pool
+
+`src/services/soroban.ts` manages a health-aware pool of Soroban RPC
+endpoints. Configure it with the following environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `SOROBAN_RPC_URLS` | — | Comma-separated list of RPC endpoint URLs (preferred). |
+| `SOROBAN_RPC_URL` | — | Single URL fallback (used when `SOROBAN_RPC_URLS` is absent). |
+| `SOROBAN_RPC_FAILURE_THRESHOLD` | `3` | Consecutive per-endpoint failures before it is demoted to `down`. |
+| `SOROBAN_RPC_PROBE_INTERVAL_MS` | `30000` | How often (ms) down endpoints are re-probed. |
+| `SOROBAN_RPC_PROBE_TIMEOUT_MS` | `5000` | Per-probe HTTP timeout (ms). |
+
+### Failover behaviour
+
+1. Endpoints are ordered: `healthy → degraded → down`.
+2. Each call tries endpoints in order. If a pre-send step (`getAccount`,
+   `prepareTransaction`) fails with a network error after all per-call retries
+   are exhausted, the endpoint is demoted and the next one is tried.
+3. Once `sendTransaction` returns any response (even `ERROR`), the operation is
+   **locked to that endpoint** — no failover after that point to prevent
+   double-submission.
+4. Down endpoints are re-probed every `SOROBAN_RPC_PROBE_INTERVAL_MS` via a
+   lightweight `getHealth` JSON-RPC call. A successful probe promotes the
+   endpoint back to `healthy`.
+
+### Health surface
+
+`GET /health/deep` includes a `sorobanRpcPool` array with one entry per
+endpoint. URLs are masked to `protocol://host` to avoid leaking API keys.
+The overall status degrades to `degraded` when any endpoint is `down`.

--- a/src/services/healthService.ts
+++ b/src/services/healthService.ts
@@ -2,6 +2,7 @@ import { prisma } from '../lib/prisma.js';
 import { db } from '../db/knex.js';
 import type { BackgroundJobSystem } from '../jobs/system.js';
 import { getSorobanBootResult } from './sorobanBoot.js';
+import { getRpcPoolHealth, type RpcEndpointHealth } from './soroban.js';
 
 const DEFAULT_TIMEOUT_MS = 3000;
 
@@ -78,10 +79,13 @@ export const healthService = {
         : { status: 'down', error: String(schedulerResult.reason?.message ?? 'Unknown error') };
 
     const sorobanBoot = this.checkSorobanBoot();
+    const sorobanRpcPool = this.checkSorobanRpcPool();
 
     const components = [database, migrations, jobs, horizonListener, expirationScheduler];
     const isDown = components.some((c: any) => c.status === 'down');
-    const isDegraded = components.some((c: any) => c.status === 'stale');
+    const isDegraded =
+      components.some((c: any) => c.status === 'stale') ||
+      (sorobanRpcPool !== null && sorobanRpcPool.some((e: RpcEndpointHealth) => e.status === 'down'));
 
     return {
       status: isDown ? 'error' : isDegraded ? 'degraded' : 'ok',
@@ -94,6 +98,7 @@ export const healthService = {
         horizonListener,
         expirationScheduler,
         sorobanBoot,
+        sorobanRpcPool,
       },
     };
   },
@@ -108,6 +113,14 @@ export const healthService = {
     if (!result.ran) return { status: 'not_applicable' };
     if (result.error) return { status: 'error', error: result.error };
     return { status: 'ok', funded: result.funded ?? false };
+  },
+
+  /**
+   * Returns current health of each Soroban RPC endpoint in the pool.
+   * Returns null when no submissions have been attempted yet (pool not initialised).
+   */
+  checkSorobanRpcPool(): RpcEndpointHealth[] | null {
+    return getRpcPoolHealth();
   },
 
   async checkDatabase(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<{ status: string; error?: string }> {

--- a/src/services/soroban.ts
+++ b/src/services/soroban.ts
@@ -13,6 +13,13 @@ const DEFAULT_SUBMIT_RETRY_MAX_BACKOFF_MS = 5_000
 const DEFAULT_SUBMIT_RETRY_BACKOFF_MULTIPLIER = 2
 const DEFAULT_SUBMIT_RETRY_JITTER_FACTOR = 0.5
 
+export const MEMO_MAX_BYTES = 28
+
+// ─── RPC pool constants ──────────────────────────────────────────────────────
+const DEFAULT_RPC_FAILURE_THRESHOLD = 3
+const DEFAULT_RPC_PROBE_INTERVAL_MS = 30_000
+const DEFAULT_RPC_PROBE_TIMEOUT_MS = 5_000
+
 // ─── Soroban configuration resolved from env ────────────────────────────────
 
 export interface SorobanConfig {
@@ -81,24 +88,226 @@ export const getSorobanConfig = (): SorobanConfig | null => {
  */
 export const isSorobanSubmitEnabled = (): boolean => getSorobanConfig() !== null
 
+// ─── RPC endpoint pool ────────────────────────────────────────────────────────
+
+export type EndpointStatus = 'healthy' | 'degraded' | 'down'
+
+export interface RpcEndpointHealth {
+  maskedUrl: string
+  status: EndpointStatus
+  failureCount: number
+  lastFailureAt: string | null
+  lastProbeAt: string | null
+}
+
+interface EndpointState {
+  url: string
+  status: EndpointStatus
+  consecutiveFailures: number
+  lastFailureAt: number | null
+  lastProbeAt: number | null
+}
+
+type ProbeFunction = (url: string, timeoutMs: number) => Promise<boolean>
+
+const maskUrl = (url: string): string => {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.protocol}//${parsed.host}`
+  } catch {
+    return '[invalid-url]'
+  }
+}
+
+const defaultProbe: ProbeFunction = async (url: string, timeoutMs: number): Promise<boolean> => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'getHealth', id: 1 }),
+      signal: controller.signal,
+    })
+    return res.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export class SorobanRpcPool {
+  private readonly states: EndpointState[]
+  readonly failureThreshold: number
+  readonly probeIntervalMs: number
+  readonly probeTimeoutMs: number
+  private readonly probeFn: ProbeFunction
+  private timer: ReturnType<typeof setInterval> | null = null
+
+  constructor(
+    urls: string[],
+    options?: {
+      failureThreshold?: number
+      probeIntervalMs?: number
+      probeTimeoutMs?: number
+      probe?: ProbeFunction
+    },
+  ) {
+    if (urls.length === 0) throw new Error('SorobanRpcPool requires at least one URL')
+    this.states = urls.map((url) => ({
+      url,
+      status: 'healthy' as EndpointStatus,
+      consecutiveFailures: 0,
+      lastFailureAt: null,
+      lastProbeAt: null,
+    }))
+    this.failureThreshold = options?.failureThreshold ?? DEFAULT_RPC_FAILURE_THRESHOLD
+    this.probeIntervalMs = options?.probeIntervalMs ?? DEFAULT_RPC_PROBE_INTERVAL_MS
+    this.probeTimeoutMs = options?.probeTimeoutMs ?? DEFAULT_RPC_PROBE_TIMEOUT_MS
+    this.probeFn = options?.probe ?? defaultProbe
+  }
+
+  /** Returns URLs ordered by health — healthy first, degraded next, down last. */
+  getOrderedUrls(): string[] {
+    const order: Record<EndpointStatus, number> = { healthy: 0, degraded: 1, down: 2 }
+    return [...this.states]
+      .sort((a, b) => order[a.status] - order[b.status])
+      .map((s) => s.url)
+  }
+
+  isAvailable(url: string): boolean {
+    const state = this.states.find((s) => s.url === url)
+    return !!state && state.status !== 'down'
+  }
+
+  recordSuccess(url: string): void {
+    const state = this.states.find((s) => s.url === url)
+    if (!state) return
+    state.status = 'healthy'
+    state.consecutiveFailures = 0
+  }
+
+  recordFailure(url: string): void {
+    const state = this.states.find((s) => s.url === url)
+    if (!state) return
+    state.consecutiveFailures += 1
+    state.lastFailureAt = Date.now()
+    if (state.consecutiveFailures >= this.failureThreshold) {
+      state.status = 'down'
+    } else {
+      state.status = 'degraded'
+    }
+  }
+
+  getHealthStatuses(): RpcEndpointHealth[] {
+    return this.states.map((s) => ({
+      maskedUrl: maskUrl(s.url),
+      status: s.status,
+      failureCount: s.consecutiveFailures,
+      lastFailureAt: s.lastFailureAt ? new Date(s.lastFailureAt).toISOString() : null,
+      lastProbeAt: s.lastProbeAt ? new Date(s.lastProbeAt).toISOString() : null,
+    }))
+  }
+
+  startProbing(): void {
+    if (this.timer) return
+    this.timer = setInterval(() => void this._probeDownEndpoints(), this.probeIntervalMs)
+    if (typeof (this.timer as any).unref === 'function') {
+      (this.timer as any).unref()
+    }
+  }
+
+  stopProbing(): void {
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  /** Force-probe all down endpoints immediately (useful in tests). */
+  async probeNow(): Promise<void> {
+    await this._probeDownEndpoints()
+  }
+
+  private async _probeDownEndpoints(): Promise<void> {
+    const probes = this.states
+      .filter((s) => s.status === 'down')
+      .map(async (state) => {
+        state.lastProbeAt = Date.now()
+        const healthy = await this.probeFn(state.url, this.probeTimeoutMs)
+        if (healthy) {
+          state.status = 'healthy'
+          state.consecutiveFailures = 0
+          log('info', 'soroban.rpc_pool.endpoint_recovered', { endpoint: maskUrl(state.url) })
+        }
+      })
+    await Promise.all(probes)
+  }
+}
+
+// ─── Module-level pool ────────────────────────────────────────────────────────
+
+let _rpcPool: SorobanRpcPool | null = null
+
+const getOrCreatePool = (config: SorobanConfig): SorobanRpcPool => {
+  if (!_rpcPool) {
+    _rpcPool = new SorobanRpcPool(config.rpcUrls, {
+      failureThreshold: positiveIntFromEnv('SOROBAN_RPC_FAILURE_THRESHOLD', DEFAULT_RPC_FAILURE_THRESHOLD),
+      probeIntervalMs: positiveIntFromEnv('SOROBAN_RPC_PROBE_INTERVAL_MS', DEFAULT_RPC_PROBE_INTERVAL_MS),
+      probeTimeoutMs: positiveIntFromEnv('SOROBAN_RPC_PROBE_TIMEOUT_MS', DEFAULT_RPC_PROBE_TIMEOUT_MS),
+    })
+    _rpcPool.startProbing()
+  }
+  return _rpcPool
+}
+
+/** Create an isolated pool (primarily for testing). */
+export const createRpcPool = (
+  urls: string[],
+  options?: ConstructorParameters<typeof SorobanRpcPool>[1],
+): SorobanRpcPool => new SorobanRpcPool(urls, options)
+
+/** Stop background probing and clear the module-level pool. For testing. */
+export const resetRpcPool = (): void => {
+  if (_rpcPool) {
+    _rpcPool.stopProbing()
+    _rpcPool = null
+  }
+}
+
+/** Returns per-endpoint health for external health checks. Null when not yet initialised. */
+export const getRpcPoolHealth = (): RpcEndpointHealth[] | null =>
+  _rpcPool ? _rpcPool.getHealthStatuses() : null
+
 // ─── Internal helper for transaction submission ───────────────────────────────
 
 /**
  * Common transaction submission logic shared by all contract methods.
  * Handles prepare, sign, send, and poll for completion.
+ *
+ * Accepts an optional pool. When omitted, uses (or lazily creates) the
+ * module-level pool so production calls are covered automatically.
+ *
+ * Failover strategy:
+ *  - Pre-send steps (getAccount, prepareTransaction) use per-call retryRpc.
+ *    If all retries fail with a network error the endpoint is demoted and the
+ *    next healthy pool endpoint is tried.
+ *  - Once sendTransaction returns a response (committed), the endpoint is
+ *    locked in for the polling phase to avoid double-submission.
  */
 async function submitTransaction(
   config: SorobanConfig,
   methodName: string,
   scVals: any[],
   loadSdk: StellarSdkLoader = () => import('@stellar/stellar-sdk'),
+  pool?: SorobanRpcPool,
 ): Promise<{ txHash: string }> {
   const {
     Keypair,
     Contract,
     rpc: SorobanRpc,
     TransactionBuilder,
-    nativeToScVal,
     BASE_FEE,
   } = await loadSdk()
 
@@ -106,52 +315,108 @@ async function submitTransaction(
   const contract = new Contract(config.contractId)
   const callOp = contract.call(methodName, ...scVals)
 
-  const tx = new TransactionBuilder(account, {
-    fee: BASE_FEE,
-    networkPassphrase: config.networkPassphrase,
-  })
-    .addOperation(callOp)
-    .setTimeout(30)
-    .build()
+  const activePool = pool ?? getOrCreatePool(config)
+  const orderedUrls = activePool.getOrderedUrls()
 
-  const prepared = await server.prepareTransaction(tx)
-  prepared.sign(keypair)
+  let lastError: Error = new Error('All RPC endpoints failed')
 
-  const response = await server.sendTransaction(prepared)
+  for (const url of orderedUrls) {
+    if (!activePool.isAvailable(url)) continue
 
-  if (response.status === 'ERROR') {
-    throw new Error(`Soroban sendTransaction failed: ${response.status}`)
-  }
+    // Tracks whether sendTransaction returned a result. Once set, we must not
+    // switch endpoints — the transaction may already be in the mempool.
+    let responseHash: string | null = null
 
-  const deadline = Date.now() + config.submitTimeoutMs
-  const pollConfig: RetryConfig = {
-    maxAttempts: config.submitPollMaxAttempts,
-    initialBackoffMs: config.submitPollIntervalMs,
-    maxBackoffMs: config.submitPollIntervalMs,
-    backoffMultiplier: 1,
-    jitterFactor: 0,
-  }
+    try {
+      const server = new SorobanRpc.Server(url)
 
-  let getResponse = await retryWithBackoff(
-    async () => {
-      if (Date.now() >= deadline) {
-        throw new SorobanTimeoutError(response.hash, config.submitTimeoutMs)
+      const account = await retryRpc('getAccount', config, () =>
+        server.getAccount(config.sourceAccount),
+      )
+
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: config.networkPassphrase,
+      })
+        .addOperation(callOp)
+        .setTimeout(30)
+        .build()
+
+      const prepared = await retryRpc('prepareTransaction', config, () =>
+        server.prepareTransaction(tx),
+      )
+      prepared.sign(keypair)
+
+      // sendTransaction is retried on the SAME endpoint for transient network
+      // errors; switching endpoints only happens if it never returns at all.
+      const response = await retryRpc('sendTransaction', config, () =>
+        server.sendTransaction(prepared),
+      )
+      responseHash = response.hash
+
+      if (response.status === 'ERROR') {
+        activePool.recordFailure(url)
+        throw new Error(`Soroban sendTransaction failed: ${response.status}`)
       }
-      const result = await server.getTransaction(response.hash)
-      if (result.status === 'NOT_FOUND') {
-        throw Object.assign(new Error('transaction_pending'), { retryable: true })
-      }
-      return result
-    },
-    pollConfig,
-    (err) => !!(err as any).retryable,
-  )
 
-  if (getResponse.status !== 'SUCCESS') {
-    throw new Error(`Soroban transaction did not succeed: ${getResponse.status}`)
+      const deadline = Date.now() + config.submitTimeoutMs
+      const pollConfig: RetryConfig = {
+        maxAttempts: config.submitPollMaxAttempts,
+        initialBackoffMs: config.submitPollIntervalMs,
+        maxBackoffMs: config.submitPollIntervalMs,
+        backoffMultiplier: 1,
+        jitterFactor: 0,
+      }
+
+      const getResponse = await retryWithBackoff(
+        async () => {
+          if (Date.now() >= deadline) {
+            throw new SorobanTimeoutError(response.hash, config.submitTimeoutMs)
+          }
+          const result = await server.getTransaction(response.hash)
+          if (result.status === 'NOT_FOUND') {
+            throw Object.assign(new Error('transaction_pending'), { retryable: true })
+          }
+          return result
+        },
+        pollConfig,
+        (err) => !!(err as any).retryable,
+      )
+
+      if (getResponse.status !== 'SUCCESS') {
+        throw new Error(`Soroban transaction did not succeed: ${getResponse.status}`)
+      }
+
+      activePool.recordSuccess(url)
+      return { txHash: response.hash }
+
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err))
+      lastError = error
+
+      // sendTransaction already returned a response — the tx is committed to
+      // this endpoint. Do not switch (prevents double-submit).
+      if (responseHash !== null) {
+        throw error
+      }
+
+      // Network error before sendTransaction committed → demote and try next endpoint.
+      if (isRetryableSorobanRpcError(error)) {
+        activePool.recordFailure(url)
+        log('warn', 'soroban.rpc_pool.failover', {
+          endpoint: maskUrl(url),
+          error: error.message,
+          method: methodName,
+        })
+        continue
+      }
+
+      // Non-network error (contract error, invalid args, etc.) → propagate.
+      throw error
+    }
   }
 
-  throw lastError || new Error('All RPC nodes failed')
+  throw lastError
 }
 
 // ─── Soroban SDK abstraction (mockable for tests) ───────────────────────────
@@ -246,9 +511,13 @@ const retryRpc = async <T>(
  * Default production client that calls the real Stellar SDK.
  * Imported lazily so the module loads even when @stellar/stellar-sdk
  * is not fully configured (e.g. in unit test environments).
+ *
+ * An optional `pool` can be supplied to override the module-level endpoint
+ * pool — useful in tests that need deterministic endpoint routing.
  */
 export const createDefaultSorobanClient = (
   loadSdk: StellarSdkLoader = () => import('@stellar/stellar-sdk'),
+  pool?: SorobanRpcPool,
 ): SorobanClient => ({
   async submitVaultCreation(config, args) {
     const { nativeToScVal } = await loadSdk()
@@ -263,6 +532,7 @@ export const createDefaultSorobanClient = (
         nativeToScVal(args.failureDestination, { type: 'string' }),
       ],
       loadSdk,
+      pool,
     )
   },
 
@@ -276,6 +546,7 @@ export const createDefaultSorobanClient = (
         nativeToScVal(args.amount, { type: 'string' }),
       ],
       loadSdk,
+      pool,
     )
   },
 
@@ -294,6 +565,7 @@ export const createDefaultSorobanClient = (
         evidenceHashScVal,
       ],
       loadSdk,
+      pool,
     )
   },
 
@@ -307,6 +579,7 @@ export const createDefaultSorobanClient = (
         nativeToScVal(args.milestoneId, { type: 'string' }),
       ],
       loadSdk,
+      pool,
     )
   },
 
@@ -317,6 +590,7 @@ export const createDefaultSorobanClient = (
       'claim',
       [nativeToScVal(args.vaultId, { type: 'string' })],
       loadSdk,
+      pool,
     )
   },
 
@@ -327,6 +601,7 @@ export const createDefaultSorobanClient = (
       'withdraw',
       [nativeToScVal(args.vaultId, { type: 'string' })],
       loadSdk,
+      pool,
     )
   },
 })

--- a/src/tests/soroban.failover.test.ts
+++ b/src/tests/soroban.failover.test.ts
@@ -1,0 +1,522 @@
+/**
+ * Health-aware Soroban RPC endpoint pool — failover and probe tests.
+ *
+ * These tests exercise the SorobanRpcPool class and the failover behaviour
+ * wired into createDefaultSorobanClient / submitTransaction.  They do NOT
+ * hit the network; every RPC call is mocked at the SDK layer.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals'
+import type { SorobanConfig } from '../services/soroban.js'
+import {
+  createDefaultSorobanClient,
+  createRpcPool,
+  resetRpcPool,
+  getRpcPoolHealth,
+  SorobanRpcPool,
+} from '../services/soroban.js'
+
+// ─── Shared fixtures ──────────────────────────────────────────────────────────
+
+const PRIMARY_URL = 'https://rpc-primary.example.com'
+const SECONDARY_URL = 'https://rpc-secondary.example.com'
+const stellar = (char = 'A'): string => `G${char.repeat(55)}`
+
+const BASE_CONFIG: SorobanConfig = {
+  contractId: 'CABCDEF1234567890',
+  networkPassphrase: 'Test SDF Network ; September 2015',
+  sourceAccount: stellar(),
+  secretKey: 'SCZANGBA5YHTNYVVV3C7CAZMCLPVAR3LXKLHEADMPROMU3QAHZGOSN6A',
+  rpcUrls: [PRIMARY_URL, SECONDARY_URL],
+  rpcUrl: PRIMARY_URL,
+  submitPollIntervalMs: 1,
+  submitPollMaxAttempts: 3,
+  rpcTimeoutMs: 5_000,
+  submitTimeoutMs: 10_000,
+  submitRetry: {
+    maxAttempts: 1,
+    initialBackoffMs: 1,
+    maxBackoffMs: 1,
+    backoffMultiplier: 1,
+    jitterFactor: 0,
+  },
+}
+
+const VAULT_ARGS = {
+  vaultId: 'vault-failover-test',
+  amount: '1000',
+  verifier: stellar('B'),
+  successDestination: stellar('C'),
+  failureDestination: stellar('D'),
+}
+
+// ─── SDK factory ─────────────────────────────────────────────────────────────
+//
+// Builds a fake Stellar SDK that routes `new rpc.Server(url)` to a per-URL
+// mock server, allowing each test to control which endpoint succeeds.
+
+type MockServer = {
+  getAccount: jest.Mock
+  prepareTransaction: jest.Mock
+  sendTransaction: jest.Mock
+  getTransaction: jest.Mock
+}
+
+const makeOkServer = (txHash = 'tx-hash-ok'): MockServer => ({
+  getAccount: jest.fn<MockServer['getAccount']>().mockResolvedValue({ accountId: stellar() }),
+  prepareTransaction: jest.fn<MockServer['prepareTransaction']>().mockResolvedValue({ sign: jest.fn() }),
+  sendTransaction: jest.fn<MockServer['sendTransaction']>().mockResolvedValue({ status: 'PENDING', hash: txHash }),
+  getTransaction: jest.fn<MockServer['getTransaction']>().mockResolvedValue({ status: 'SUCCESS' }),
+})
+
+const makeNetworkErrorServer = (message = 'connection refused'): MockServer => ({
+  getAccount: jest.fn<MockServer['getAccount']>().mockRejectedValue(new Error(message)),
+  prepareTransaction: jest.fn<MockServer['prepareTransaction']>().mockRejectedValue(new Error(message)),
+  sendTransaction: jest.fn<MockServer['sendTransaction']>().mockRejectedValue(new Error(message)),
+  getTransaction: jest.fn<MockServer['getTransaction']>().mockRejectedValue(new Error(message)),
+})
+
+const makeFakeSdkWithRouting = (serverMap: Record<string, MockServer>) => {
+  const ServerCtor = jest.fn((url: string) => serverMap[url] ?? makeNetworkErrorServer('no server for url'))
+  return async () => ({
+    Keypair: { fromSecret: jest.fn(() => ({ sign: jest.fn(), publicKey: jest.fn() })) },
+    Contract: class {
+      call = jest.fn(() => ({}))
+    },
+    rpc: { Server: ServerCtor },
+    TransactionBuilder: class {
+      addOperation = jest.fn(() => this)
+      setTimeout = jest.fn(() => this)
+      build = jest.fn(() => ({}))
+    },
+    nativeToScVal: jest.fn((v: unknown) => v),
+    xdr: { ScVal: { scvBytes: jest.fn((b: Buffer) => b) } },
+    BASE_FEE: '100',
+  })
+}
+
+// ─── Test setup ──────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetRpcPool()
+})
+
+afterEach(() => {
+  resetRpcPool()
+})
+
+// ─── SorobanRpcPool unit tests ───────────────────────────────────────────────
+
+describe('SorobanRpcPool', () => {
+  it('starts all endpoints as healthy', () => {
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL])
+    const statuses = pool.getHealthStatuses()
+    expect(statuses).toHaveLength(2)
+    expect(statuses.every((s) => s.status === 'healthy')).toBe(true)
+  })
+
+  it('demotes an endpoint to degraded after one failure (below threshold)', () => {
+    const pool = createRpcPool([PRIMARY_URL], { failureThreshold: 3 })
+    pool.recordFailure(PRIMARY_URL)
+    const [status] = pool.getHealthStatuses()
+    expect(status.status).toBe('degraded')
+    expect(status.failureCount).toBe(1)
+  })
+
+  it('demotes an endpoint to down after reaching the failure threshold', () => {
+    const pool = createRpcPool([PRIMARY_URL], { failureThreshold: 2 })
+    pool.recordFailure(PRIMARY_URL)
+    pool.recordFailure(PRIMARY_URL)
+    const [status] = pool.getHealthStatuses()
+    expect(status.status).toBe('down')
+    expect(status.failureCount).toBe(2)
+  })
+
+  it('promotes a down endpoint back to healthy on recordSuccess', () => {
+    const pool = createRpcPool([PRIMARY_URL], { failureThreshold: 1 })
+    pool.recordFailure(PRIMARY_URL)
+    expect(pool.getHealthStatuses()[0].status).toBe('down')
+    pool.recordSuccess(PRIMARY_URL)
+    expect(pool.getHealthStatuses()[0].status).toBe('healthy')
+    expect(pool.getHealthStatuses()[0].failureCount).toBe(0)
+  })
+
+  it('orders healthy endpoints before degraded and down', () => {
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL, 'https://rpc-tertiary.example.com'], {
+      failureThreshold: 3,
+    })
+    pool.recordFailure(PRIMARY_URL)   // degraded
+    pool.recordFailure(PRIMARY_URL)
+    pool.recordFailure(PRIMARY_URL)   // now down
+    pool.recordFailure(SECONDARY_URL) // degraded
+
+    const ordered = pool.getOrderedUrls()
+    expect(ordered[0]).toBe('https://rpc-tertiary.example.com') // healthy
+    expect(ordered[1]).toBe(SECONDARY_URL)                       // degraded
+    expect(ordered[2]).toBe(PRIMARY_URL)                         // down
+  })
+
+  it('isAvailable returns false for down endpoints and true for healthy/degraded', () => {
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 1 })
+    pool.recordFailure(PRIMARY_URL)
+    expect(pool.isAvailable(PRIMARY_URL)).toBe(false)
+    expect(pool.isAvailable(SECONDARY_URL)).toBe(true)
+  })
+
+  it('masks URLs to protocol://host only', () => {
+    const pool = createRpcPool(['https://api.example.com:8080/rpc?key=secret'])
+    const [status] = pool.getHealthStatuses()
+    expect(status.maskedUrl).toBe('https://api.example.com:8080')
+    expect(status.maskedUrl).not.toContain('secret')
+  })
+
+  it('records lastFailureAt timestamp on failure', () => {
+    const before = Date.now()
+    const pool = createRpcPool([PRIMARY_URL])
+    pool.recordFailure(PRIMARY_URL)
+    const [status] = pool.getHealthStatuses()
+    expect(status.lastFailureAt).not.toBeNull()
+    expect(new Date(status.lastFailureAt!).getTime()).toBeGreaterThanOrEqual(before)
+  })
+
+  it('resets failureCount and clears degraded status on recordSuccess', () => {
+    const pool = createRpcPool([PRIMARY_URL], { failureThreshold: 5 })
+    pool.recordFailure(PRIMARY_URL)
+    pool.recordFailure(PRIMARY_URL)
+    expect(pool.getHealthStatuses()[0].failureCount).toBe(2)
+    pool.recordSuccess(PRIMARY_URL)
+    expect(pool.getHealthStatuses()[0].failureCount).toBe(0)
+    expect(pool.getHealthStatuses()[0].status).toBe('healthy')
+  })
+
+  it('throws when constructed with an empty URL list', () => {
+    expect(() => createRpcPool([])).toThrow('SorobanRpcPool requires at least one URL')
+  })
+
+  // ─── Probe tests ───────────────────────────────────────────────────────────
+
+  it('re-probes a down endpoint and promotes it when probe succeeds', async () => {
+    const probe = jest.fn<ProbeFunction>().mockResolvedValue(true)
+    const pool = createRpcPool([PRIMARY_URL], { failureThreshold: 1, probe })
+    pool.recordFailure(PRIMARY_URL)
+    expect(pool.getHealthStatuses()[0].status).toBe('down')
+
+    await pool.probeNow()
+
+    expect(probe).toHaveBeenCalledWith(PRIMARY_URL, expect.any(Number))
+    expect(pool.getHealthStatuses()[0].status).toBe('healthy')
+  })
+
+  it('leaves a down endpoint as down when probe fails', async () => {
+    const probe = jest.fn<ProbeFunction>().mockResolvedValue(false)
+    const pool = createRpcPool([PRIMARY_URL], { failureThreshold: 1, probe })
+    pool.recordFailure(PRIMARY_URL)
+
+    await pool.probeNow()
+
+    expect(pool.getHealthStatuses()[0].status).toBe('down')
+  })
+
+  it('does not probe healthy or degraded endpoints', async () => {
+    const probe = jest.fn<ProbeFunction>().mockResolvedValue(true)
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 3, probe })
+    pool.recordFailure(SECONDARY_URL) // degraded
+
+    await pool.probeNow()
+
+    expect(probe).not.toHaveBeenCalled()
+  })
+
+  it('sets lastProbeAt after a probe attempt', async () => {
+    const before = Date.now()
+    const probe = jest.fn<ProbeFunction>().mockResolvedValue(false)
+    const pool = createRpcPool([PRIMARY_URL], { failureThreshold: 1, probe })
+    pool.recordFailure(PRIMARY_URL)
+
+    await pool.probeNow()
+
+    const [status] = pool.getHealthStatuses()
+    expect(status.lastProbeAt).not.toBeNull()
+    expect(new Date(status.lastProbeAt!).getTime()).toBeGreaterThanOrEqual(before)
+  })
+
+  it('stopProbing clears the background timer', () => {
+    const pool = createRpcPool([PRIMARY_URL])
+    pool.startProbing()
+    pool.stopProbing()
+    // No assertion needed — this verifies no error is thrown and timer is cleared
+    pool.stopProbing() // safe to call twice
+  })
+})
+
+// ─── getRpcPoolHealth ─────────────────────────────────────────────────────────
+
+describe('getRpcPoolHealth', () => {
+  it('returns null when the pool has not been initialised', () => {
+    expect(getRpcPoolHealth()).toBeNull()
+  })
+})
+
+// ─── Failover integration tests ───────────────────────────────────────────────
+
+describe('submitTransaction failover (via createDefaultSorobanClient)', () => {
+  it('succeeds immediately when the primary endpoint is healthy', async () => {
+    const primaryServer = makeOkServer('tx-primary')
+    const secondaryServer = makeOkServer('tx-secondary')
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 3 })
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer, [SECONDARY_URL]: secondaryServer }),
+      pool,
+    )
+
+    const result = await client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)
+
+    expect(result.txHash).toBe('tx-primary')
+    expect(primaryServer.getAccount).toHaveBeenCalledTimes(1)
+    expect(secondaryServer.getAccount).not.toHaveBeenCalled()
+  })
+
+  it('fails over to secondary when primary getAccount fails with network error', async () => {
+    const primaryServer = makeNetworkErrorServer('econnrefused')
+    const secondaryServer = makeOkServer('tx-from-secondary')
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 3 })
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer, [SECONDARY_URL]: secondaryServer }),
+      pool,
+    )
+
+    const result = await client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)
+
+    expect(result.txHash).toBe('tx-from-secondary')
+    expect(primaryServer.getAccount).toHaveBeenCalledTimes(1)
+    expect(secondaryServer.getAccount).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails over to secondary when primary prepareTransaction fails with network error', async () => {
+    const primaryServer: MockServer = {
+      getAccount: jest.fn<MockServer['getAccount']>().mockResolvedValue({ accountId: stellar() }),
+      prepareTransaction: jest.fn<MockServer['prepareTransaction']>().mockRejectedValue(new Error('timeout')),
+      sendTransaction: jest.fn(),
+      getTransaction: jest.fn(),
+    }
+    const secondaryServer = makeOkServer('tx-prepare-failover')
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 3 })
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer, [SECONDARY_URL]: secondaryServer }),
+      pool,
+    )
+
+    const result = await client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)
+
+    expect(result.txHash).toBe('tx-prepare-failover')
+    expect(primaryServer.sendTransaction).not.toHaveBeenCalled()
+    expect(secondaryServer.sendTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT failover to secondary after sendTransaction commits (prevents double-submit)', async () => {
+    const primaryServer: MockServer = {
+      getAccount: jest.fn<MockServer['getAccount']>().mockResolvedValue({ accountId: stellar() }),
+      prepareTransaction: jest.fn<MockServer['prepareTransaction']>().mockResolvedValue({ sign: jest.fn() }),
+      sendTransaction: jest.fn<MockServer['sendTransaction']>().mockResolvedValue({
+        status: 'PENDING',
+        hash: 'tx-committed',
+      }),
+      // getTransaction always returns NOT_FOUND → will exhaust poll attempts
+      getTransaction: jest.fn<MockServer['getTransaction']>().mockResolvedValue({ status: 'NOT_FOUND' }),
+    }
+    const secondaryServer = makeOkServer('tx-secondary-should-not-be-used')
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 3 })
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer, [SECONDARY_URL]: secondaryServer }),
+      pool,
+    )
+
+    await expect(client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)).rejects.toThrow(
+      'Soroban transaction did not succeed',
+    )
+
+    // sendTransaction was called exactly once on the primary; secondary was never used
+    expect(primaryServer.sendTransaction).toHaveBeenCalledTimes(1)
+    expect(secondaryServer.getAccount).not.toHaveBeenCalled()
+    expect(secondaryServer.sendTransaction).not.toHaveBeenCalled()
+  })
+
+  it('throws when all endpoints fail before sendTransaction', async () => {
+    const primaryServer = makeNetworkErrorServer('econnrefused')
+    const secondaryServer = makeNetworkErrorServer('connection reset')
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 3 })
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer, [SECONDARY_URL]: secondaryServer }),
+      pool,
+    )
+
+    await expect(client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)).rejects.toThrow()
+  })
+
+  it('skips already-down endpoints and goes directly to healthy ones', async () => {
+    const primaryServer = makeOkServer('tx-healthy-secondary')
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 1 })
+
+    // Pre-mark the secondary as down
+    pool.recordFailure(SECONDARY_URL)
+    expect(pool.getHealthStatuses().find((s) => s.maskedUrl.includes('secondary'))?.status).toBe('down')
+
+    // Client maps SECONDARY to a server that would succeed — but pool skips it
+    const goodSecondaryServer = makeOkServer('should-not-be-used')
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer, [SECONDARY_URL]: goodSecondaryServer }),
+      pool,
+    )
+
+    const result = await client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)
+    expect(result.txHash).toBe('tx-healthy-secondary')
+    expect(goodSecondaryServer.getAccount).not.toHaveBeenCalled()
+  })
+
+  it('records success on pool after a successful transaction', async () => {
+    const primaryServer = makeOkServer('tx-ok')
+    const pool = createRpcPool([PRIMARY_URL], { failureThreshold: 3 })
+    // Pre-degrade the endpoint
+    pool.recordFailure(PRIMARY_URL)
+    expect(pool.getHealthStatuses()[0].status).toBe('degraded')
+
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer }),
+      pool,
+    )
+    await client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)
+
+    expect(pool.getHealthStatuses()[0].status).toBe('healthy')
+    expect(pool.getHealthStatuses()[0].failureCount).toBe(0)
+  })
+
+  it('records failure on pool when primary endpoint fails (network error before send)', async () => {
+    const primaryServer = makeNetworkErrorServer('econnreset')
+    const secondaryServer = makeOkServer('tx-after-fail')
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 3 })
+
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer, [SECONDARY_URL]: secondaryServer }),
+      pool,
+    )
+    await client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)
+
+    const primaryHealth = pool.getHealthStatuses().find((s) => s.maskedUrl.includes('primary'))
+    expect(primaryHealth?.status).toBe('degraded')
+    expect(primaryHealth?.failureCount).toBe(1)
+  })
+
+  it('demotes endpoint to down after failure threshold is reached across calls', async () => {
+    const alwaysFailServer = makeNetworkErrorServer('503 service unavailable')
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 2 })
+
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({
+        [PRIMARY_URL]: alwaysFailServer,
+        [SECONDARY_URL]: makeOkServer('tx-secondary'),
+      }),
+      pool,
+    )
+
+    // First call: primary fails once → degraded
+    await client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)
+    expect(pool.getHealthStatuses().find((s) => s.maskedUrl.includes('primary'))?.status).toBe('degraded')
+
+    // Second call: primary fails again → down
+    const alwaysFailServer2 = makeNetworkErrorServer('503 service unavailable')
+    const client2 = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({
+        [PRIMARY_URL]: alwaysFailServer2,
+        [SECONDARY_URL]: makeOkServer('tx-secondary-2'),
+      }),
+      pool,
+    )
+    await client2.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)
+    expect(pool.getHealthStatuses().find((s) => s.maskedUrl.includes('primary'))?.status).toBe('down')
+  })
+
+  // ─── Re-probe and recovery ─────────────────────────────────────────────────
+
+  it('re-probes a down endpoint and uses it again after recovery', async () => {
+    let probeResult = false
+    const probe = jest.fn(async (_url: string, _timeoutMs: number) => probeResult)
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 1, probe })
+
+    // Mark primary as down
+    pool.recordFailure(PRIMARY_URL)
+    expect(pool.getHealthStatuses().find((s) => s.maskedUrl.includes('primary'))?.status).toBe('down')
+
+    // Probe fails → still down
+    await pool.probeNow()
+    expect(pool.getHealthStatuses().find((s) => s.maskedUrl.includes('primary'))?.status).toBe('down')
+
+    // Probe succeeds → primary is healthy again
+    probeResult = true
+    await pool.probeNow()
+    expect(pool.getHealthStatuses().find((s) => s.maskedUrl.includes('primary'))?.status).toBe('healthy')
+
+    // Next transaction uses primary again
+    const primaryServer = makeOkServer('tx-recovered')
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer, [SECONDARY_URL]: makeOkServer() }),
+      pool,
+    )
+    const result = await client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)
+    expect(result.txHash).toBe('tx-recovered')
+    expect(primaryServer.getAccount).toHaveBeenCalledTimes(1)
+  })
+
+  // ─── Non-network errors ────────────────────────────────────────────────────
+
+  it('does not failover for non-network errors (e.g. account not found)', async () => {
+    const primaryServer: MockServer = {
+      getAccount: jest
+        .fn<MockServer['getAccount']>()
+        .mockRejectedValue(new Error('account does not exist on the network')),
+      prepareTransaction: jest.fn(),
+      sendTransaction: jest.fn(),
+      getTransaction: jest.fn(),
+    }
+    const secondaryServer = makeOkServer('should-not-be-reached')
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 3 })
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer, [SECONDARY_URL]: secondaryServer }),
+      pool,
+    )
+
+    await expect(client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)).rejects.toThrow(
+      'account does not exist',
+    )
+
+    // Secondary was never tried — non-network errors are not retried across endpoints
+    expect(secondaryServer.getAccount).not.toHaveBeenCalled()
+  })
+
+  // ─── healthService integration ─────────────────────────────────────────────
+
+  it('getRpcPoolHealth reflects pool state after a failover', async () => {
+    const primaryServer = makeNetworkErrorServer('econnrefused')
+    const secondaryServer = makeOkServer('tx-health-check')
+    const pool = createRpcPool([PRIMARY_URL, SECONDARY_URL], { failureThreshold: 3 })
+    const client = createDefaultSorobanClient(
+      makeFakeSdkWithRouting({ [PRIMARY_URL]: primaryServer, [SECONDARY_URL]: secondaryServer }),
+      pool,
+    )
+
+    // Inject pool into the module-level slot by making the pool the one returned
+    // by getRpcPoolHealth. We do this by performing a call that populates it.
+    // (In these tests we pass pool explicitly, so getRpcPoolHealth() is null.
+    // We verify pool.getHealthStatuses() directly instead.)
+    await client.submitVaultCreation(BASE_CONFIG, VAULT_ARGS)
+
+    const statuses = pool.getHealthStatuses()
+    const primaryStatus = statuses.find((s) => s.maskedUrl.includes('primary'))
+    const secondaryStatus = statuses.find((s) => s.maskedUrl.includes('secondary'))
+
+    expect(primaryStatus?.status).toBe('degraded')
+    expect(secondaryStatus?.status).toBe('healthy')
+  })
+})
+
+// ─── Type alias so the ProbeFunction type is visible in test scope ─────────
+type ProbeFunction = (url: string, timeoutMs: number) => Promise<boolean>


### PR DESCRIPTION
## Summary

Closes #721

`src/services/soroban.ts` previously talked to a single Soroban RPC endpoint with no failover. This PR adds a health-aware `SorobanRpcPool` that routes calls across a configurable list of endpoints, demotes failing ones, and periodically re-probes them so they rejoin the pool when they recover.

## Changes

### `src/services/soroban.ts`
- Added `SorobanRpcPool` class with per-endpoint health states (`healthy / degraded / down`), ordered selection (healthy first), background re-probing via `setInterval`, and a `probeNow()` hook for tests.
- Fixed the previously broken `submitTransaction` function (it referenced undefined `server` and `account` variables); it now correctly creates `new SorobanRpc.Server(url)` and calls `server.getAccount(sourceAccount)` per attempt.
- **Failover strategy**: pre-send steps (`getAccount`, `prepareTransaction`) retry on the same endpoint via `retryRpc`; if those exhaust with a network error the endpoint is demoted and the next healthy URL is tried. Once `sendTransaction` returns any response, the endpoint is locked — no switching to prevent double-submission.
- `createDefaultSorobanClient` accepts an optional `pool` param so tests can inject a controlled pool without touching module state.
- New exports: `SorobanRpcPool`, `createRpcPool`, `resetRpcPool`, `getRpcPoolHealth`, `RpcEndpointHealth`, `EndpointStatus`, `MEMO_MAX_BYTES`.

### `src/services/healthService.ts`
- Added `checkSorobanRpcPool()` method backed by `getRpcPoolHealth()`.
- `buildDeepHealthStatus` now includes a `sorobanRpcPool` array in `details`; overall status degrades to `degraded` when any endpoint is `down`. URLs are masked to `protocol://host` to avoid leaking API keys.

### `docs/contracts-accountability-vault.md`
- Documented all new env vars, failover behaviour, and how the pool status surfaces in `GET /health/deep`.

### `src/tests/soroban.failover.test.ts` (new, 26 tests)
- **Pool unit tests**: demotion/promotion lifecycle, ordered URL selection, `isAvailable` gating, URL masking, timestamp recording, empty-list guard.
- **Probe tests**: successful re-probe promotes to healthy, failed probe leaves endpoint down, only `down` endpoints are probed, `lastProbeAt` is set.
- **Failover integration** (via `createDefaultSorobanClient` with per-URL mock SDK servers):
  - Primary healthy → uses primary, secondary untouched.
  - Primary `getAccount` fails (network error) → fails over to secondary.
  - Primary `prepareTransaction` fails (network error) → fails over to secondary; `sendTransaction` never called on primary.
  - `sendTransaction` commits on primary → **no failover** even if polling fails (double-submit prevention).
  - All endpoints fail → throws error.
  - Already-`down` endpoint is skipped immediately.
  - Successful call promotes a degraded endpoint back to healthy.
  - Failure accumulation across calls demotes endpoint to `down` at threshold.
  - Re-probe recovers a `down` endpoint and it is used again on the next call.
  - Non-network errors (e.g. account not found) do **not** trigger failover.
  - `pool.getHealthStatuses()` reflects accurate per-endpoint state after a failover.

## Configuration

| Env var | Default | Description |
|---|---|---|
| `SOROBAN_RPC_URLS` | — | Comma-separated list of RPC URLs (preferred over `SOROBAN_RPC_URL`) |
| `SOROBAN_RPC_FAILURE_THRESHOLD` | `3` | Consecutive failures before endpoint is marked `down` |
| `SOROBAN_RPC_PROBE_INTERVAL_MS` | `30000` | How often down endpoints are re-probed |
| `SOROBAN_RPC_PROBE_TIMEOUT_MS` | `5000` | Per-probe HTTP timeout |

## Test plan

- [ ] All existing `src/tests/soroban.test.ts` tests pass without modification (mock-client path bypasses the pool; `defaultSorobanClient` path uses a single-URL pool identically to the old single-endpoint behaviour).
- [ ] `src/tests/soroban.failover.test.ts` — 26 new tests all pass (`npm test` or `bun test`).
- [ ] `GET /health/deep` response includes `sorobanRpcPool: [{ maskedUrl, status, failureCount, lastFailureAt, lastProbeAt }]` when at least one Soroban submission has been made.
- [ ] With two URLs in `SOROBAN_RPC_URLS` and the first one down, requests succeed on the second and the first is reported as `down` in health.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
