### PR TITLE
Add idempotent webhook subscriber upsert and signing-secret rotation to src/repositories/webhookSubscriberRepository.ts

### DIFF
--- a/db/migrations/20260627130000_add_webhook_secret_rotation.cjs
+++ b/db/migrations/20260627130000_add_webhook_secret_rotation.cjs
@@ -1,0 +1,41 @@
+/**
+ * Adds secret rotation support to webhook_subscribers.
+ *
+ * previous_secret: the old secret, retained during the overlap grace window so
+ *   in-flight deliveries signed with it continue to verify.
+ * rotated_at: when the rotation occurred; the grace window ends at
+ *   rotated_at + WEBHOOK_SECRET_GRACE_WINDOW_MS (default 24 h).
+ *
+ * A unique index on (organization_id, url) enforces the idempotent-upsert
+ * invariant: only one active subscriber per (org, URL) pair.
+ */
+exports.up = async function up(knex) {
+  const hasPreviousSecret = await knex.schema.hasColumn('webhook_subscribers', 'previous_secret')
+
+  if (!hasPreviousSecret) {
+    await knex.schema.alterTable('webhook_subscribers', (table) => {
+      table.text('previous_secret').nullable()
+      table.timestamp('rotated_at', { useTz: true }).nullable()
+    })
+  }
+
+  // Unique index that makes upsert idempotent on (org, url).
+  // Only one row per (organization_id, url) is allowed; the upsert logic
+  // relies on this constraint via ON CONFLICT DO UPDATE.
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_webhook_subscribers_org_url
+    ON webhook_subscribers (organization_id, url)
+  `)
+}
+
+exports.down = async function down(knex) {
+  await knex.raw('DROP INDEX IF EXISTS idx_webhook_subscribers_org_url')
+
+  const hasPreviousSecret = await knex.schema.hasColumn('webhook_subscribers', 'previous_secret')
+  if (hasPreviousSecret) {
+    await knex.schema.alterTable('webhook_subscribers', (table) => {
+      table.dropColumn('previous_secret')
+      table.dropColumn('rotated_at')
+    })
+  }
+}

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -107,13 +107,15 @@ Webhook subscribers are stored in the `webhook_subscribers` table:
 | `id` | `uuid` (PK, auto-generated) | Unique subscriber identifier |
 | `organization_id` | `varchar(255)` | Owning organization (NOT NULL) |
 | `url` | `varchar(2048)` | Target webhook URL |
-| `secret` | `text` | HMAC signing secret |
+| `secret` | `text` | Current HMAC signing secret |
+| `previous_secret` | `text` (nullable) | Previous secret retained during rotation grace window |
+| `rotated_at` | `timestamptz` (nullable) | When the most recent rotation occurred |
 | `events` | `jsonb` | Array of event types to receive; empty array = wildcard (all events) |
 | `active` | `boolean` | Whether the subscriber is active |
 | `created_at` | `timestamptz` | Creation timestamp |
 | `updated_at` | `timestamptz` | Last update timestamp |
 
-Index: `(organization_id, active)` for efficient org-scoped lookups.
+Unique constraint: `(organization_id, url)` — only one active subscriber per org/URL pair.
 
 ## Secret Handling Decision
 
@@ -135,17 +137,129 @@ All subscriber queries are scoped by `organization_id`. When dispatching events,
 
 Creates a new webhook subscriber. The URL is validated against the SSRF allowlist (`isUrlAllowed`). Returns the created subscriber.
 
+### `upsertSubscriber(organizationId, url, secret, events)`
+
+Idempotent alternative to `addSubscriber`. Re-registering the same `(organizationId, url)` pair updates the existing row in-place — no duplicate rows are created and delivery history (dead-letter entries keyed on the subscriber id) is preserved. The upsert is scoped to the calling org so a cross-org overwrite is impossible.
+
+### `rotateSubscriberSecret(id, organizationId, newSecret)`
+
+Rotates the signing secret for a subscriber:
+
+1. The current `secret` is moved to `previous_secret`.
+2. `newSecret` becomes the active `secret`.
+3. `rotated_at` is stamped to `now()`.
+
+The `previousSecret` remains valid for signature verification for the duration of the **grace window** (env `WEBHOOK_SECRET_GRACE_WINDOW_MS`, default **24 hours**). This lets receivers that haven't yet updated their expected secret continue to verify in-flight deliveries without interruption.
+
+Returns `null` when the subscriber does not exist or the `organizationId` does not match (cross-org rotation is silently rejected to avoid enumeration).
+
+### `verifySignatureWithGrace(subscriber, body, signature)`
+
+Verifies a signature against a subscriber's **current** secret and, if within the grace window, also against the **previous** secret. Returns `true` if either matches. Use this instead of bare `verifySignature` wherever subscriber-scoped verification is needed (e.g., inbound callbacks that embed a subscriber ID).
+
+### `isPreviousSecretInGrace(subscriber)`
+
+Returns `true` when `previousSecret` is set and `Date.now() - rotatedAt < graceWindowMs`.
+
 ### `removeSubscriber(id)`
 
 Deletes a subscriber by ID. Returns `true` if found.
 
 ### `listSubscribers(organizationId)`
 
-Returns all active subscribers for an organization.
+Returns all active subscribers for an organization. **Secret material is never included in list responses.**
 
 ### `dispatchWebhookEvent(payload)`
 
-Delivers an event to all eligible active subscribers for the organization specified in `payload.organizationId`. Uses exponential-backoff retry (max 3 attempts). Failures are collected per-subscriber.
+Delivers an event to all eligible active subscribers for the organization specified in `payload.organizationId`. Outbound deliveries are always signed with the **current** secret. Uses exponential-backoff retry (max 3 attempts). Failures are collected per-subscriber.
+
+---
+
+## Secret Rotation Flow
+
+```
+Operator                      Disciplr API                  Subscriber
+   |                               |                              |
+   |-- POST /rotate-secret ------->|                              |
+   |   { new_secret: "v2" }        |                              |
+   |<-- 200 { rotated_at }---------|                              |
+   |                               |                              |
+   |                               |-- deliver (signed w/ v2) --->|
+   |                               |   (subscriber may still      |
+   |                               |    verify with v1 during     |
+   |                               |    grace window)             |
+   |   [ grace window: 24 h ]      |                              |
+   |                               |                              |
+   |   Subscriber updates its      |                              |
+   |   expected secret to v2       |                              |
+   |                               |-- deliver (signed w/ v2) --->|
+   |                               |   (subscriber now verifies   |
+   |                               |    with v2 exclusively)      |
+```
+
+Key properties:
+- Outbound deliveries are **always signed with the current (new) secret** immediately after rotation.
+- The previous secret is retained server-side for the grace window so receivers don't need to update instantaneously.
+- After the grace window closes, `verifySignatureWithGrace` only accepts the current secret.
+- Operators can tune the overlap duration via `WEBHOOK_SECRET_GRACE_WINDOW_MS`.
+
+---
+
+## Admin API Endpoints
+
+### `POST /api/admin/webhooks/subscribers`
+
+Idempotent upsert. Creates or updates a subscriber for the given `(organization_id, url)` pair.
+
+**Body:**
+```json
+{
+  "organization_id": "org-123",
+  "url": "https://hooks.example.com/disciplr",
+  "secret": "my-signing-secret",
+  "events": ["vault_created", "vault_completed"]
+}
+```
+
+**Response 200:**
+```json
+{
+  "id": "uuid",
+  "organization_id": "org-123",
+  "url": "https://hooks.example.com/disciplr",
+  "events": ["vault_created", "vault_completed"],
+  "active": true,
+  "created_at": "2026-06-27T13:00:00.000Z"
+}
+```
+
+The secret is **never returned** in any response.
+
+### `GET /api/admin/webhooks/subscribers?organization_id=<org>`
+
+Lists active subscribers for an organization. Secret material is stripped.
+
+### `POST /api/admin/webhooks/subscribers/:id/rotate-secret`
+
+Rotates the signing secret. Previous secret is preserved in the grace window.
+
+**Body:**
+```json
+{
+  "organization_id": "org-123",
+  "new_secret": "my-new-signing-secret"
+}
+```
+
+**Response 200:**
+```json
+{
+  "id": "uuid",
+  "rotated_at": "2026-06-27T14:00:00.000Z"
+}
+```
+
+**Response 404** – subscriber not found or belongs to a different org (identical to avoid enumeration).
 
 ---
 

--- a/src/repositories/webhookSubscriberRepository.ts
+++ b/src/repositories/webhookSubscriberRepository.ts
@@ -6,6 +6,8 @@ interface SubscriberRow {
   organization_id: string
   url: string
   secret: string
+  previous_secret: string | null
+  rotated_at: Date | null
   events: string[]
   active: boolean
   created_at: Date
@@ -18,11 +20,14 @@ function toSubscriber(row: SubscriberRow): WebhookSubscriber {
     organizationId: row.organization_id,
     url: row.url,
     secret: row.secret,
+    previousSecret: row.previous_secret ?? null,
+    rotatedAt: row.rotated_at instanceof Date
+      ? row.rotated_at.toISOString()
+      : (row.rotated_at ? String(row.rotated_at) : null),
     events: row.events ?? [],
     active: row.active,
-    createdAt: row.created_at instanceof Date
-      ? row.created_at.toISOString()
-      : String(row.created_at),
+    createdAt:
+      row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
   }
 }
 
@@ -45,7 +50,9 @@ export class WebhookSubscriberRepository {
     const rows = await this.db<SubscriberRow>('webhook_subscribers')
       .where({ organization_id: organizationId, active: true })
       .andWhere(function () {
-        this.whereRaw("events = '[]'::jsonb").orWhereRaw('events @> ?', [JSON.stringify([eventType])])
+        this.whereRaw("events = '[]'::jsonb").orWhereRaw('events @> ?', [
+          JSON.stringify([eventType]),
+        ])
       })
       .orderBy('created_at', 'asc')
     return rows.map(toSubscriber)
@@ -66,6 +73,81 @@ export class WebhookSubscriberRepository {
       })
       .returning('*')
     return toSubscriber(row)
+  }
+
+  /**
+   * Idempotent upsert keyed on (organization_id, url).
+   *
+   * - If no row exists for the (org, url) pair a new subscriber is inserted.
+   * - If a row already exists the `secret`, `events`, and `active` fields are
+   *   updated in-place so the caller does not end up with duplicate rows.
+   * - Cross-org overwrites are impossible: the WHERE clause in the ON CONFLICT
+   *   DO UPDATE is scoped to the same organization_id.
+   *
+   * The secret material in the response is intentionally included so callers
+   * that manage secrets (e.g., the admin service) can confirm what was stored.
+   * List endpoints must strip the secret before returning to API consumers.
+   */
+  async upsert(data: {
+    organizationId: string
+    url: string
+    secret: string
+    events: string[]
+  }): Promise<WebhookSubscriber> {
+    const [row] = await this.db
+      .raw<{ rows: SubscriberRow[] }>(
+        `
+        INSERT INTO webhook_subscribers (organization_id, url, secret, events, active)
+        VALUES (:organizationId, :url, :secret, :events::jsonb, true)
+        ON CONFLICT (organization_id, url)
+        DO UPDATE SET
+          secret     = EXCLUDED.secret,
+          events     = EXCLUDED.events,
+          active     = true,
+          updated_at = now()
+        WHERE webhook_subscribers.organization_id = :organizationId
+        RETURNING *
+        `,
+        {
+          organizationId: data.organizationId,
+          url: data.url,
+          secret: data.secret,
+          events: JSON.stringify(data.events),
+        },
+      )
+      .then((result) => result.rows)
+
+    return toSubscriber(row)
+  }
+
+  /**
+   * Rotates the signing secret for a subscriber.
+   *
+   * The current secret is moved to `previous_secret` and `rotated_at` is
+   * stamped to now so the delivery layer can honour the grace window.
+   * The new secret begins signing immediately; the previous secret remains
+   * valid for verification until the grace window closes.
+   *
+   * Returns `null` if the subscriber does not exist or belongs to a different
+   * organization (cross-org rotation is rejected silently to avoid enumeration).
+   */
+  async rotateSecret(
+    id: string,
+    organizationId: string,
+    newSecret: string,
+  ): Promise<WebhookSubscriber | null> {
+    const rows = await this.db<SubscriberRow>('webhook_subscribers')
+      .where({ id, organization_id: organizationId })
+      .update({
+        previous_secret: this.db.raw('secret'),
+        secret: newSecret,
+        rotated_at: this.db.fn.now(),
+        updated_at: this.db.fn.now(),
+      })
+      .returning('*')
+
+    if (rows.length === 0) return null
+    return toSubscriber(rows[0])
   }
 
   async deactivate(id: string): Promise<boolean> {

--- a/src/routes/adminWebhooks.ts
+++ b/src/routes/adminWebhooks.ts
@@ -4,7 +4,12 @@ import { requireAdmin } from '../middleware/rbac.js'
 import { UserRole } from '../types/user.js'
 import { createAuditLog } from '../lib/audit-logs.js'
 import { db } from '../db/knex.js'
-import { replayDeadLetter } from '../services/webhooks.js'
+import {
+  replayDeadLetter,
+  upsertSubscriber,
+  rotateSubscriberSecret,
+  listSubscribers,
+} from '../services/webhooks.js'
 
 export const adminWebhooksRouter = Router()
 
@@ -64,3 +69,151 @@ adminWebhooksRouter.post('/dead-letters/:id/replay', async (req: Request, res: R
     res.status(500).json({ error: 'Failed to replay dead letter' })
   }
 })
+
+/**
+ * POST /api/admin/webhooks/subscribers
+ *
+ * Idempotent upsert: registers a new subscriber or updates the existing one
+ * for the same (organization_id, url) pair without creating duplicates.
+ * Delivery history is preserved across re-registrations.
+ *
+ * Body: { organization_id, url, secret, events? }
+ * Response 200: { id, organization_id, url, events, active, created_at }
+ *   (secret is never returned)
+ */
+adminWebhooksRouter.post('/subscribers', async (req: Request, res: Response) => {
+  try {
+    const { organization_id, url, secret, events = [] } = req.body ?? {}
+
+    if (!organization_id || typeof organization_id !== 'string') {
+      res.status(400).json({ error: 'organization_id is required' })
+      return
+    }
+    if (!url || typeof url !== 'string') {
+      res.status(400).json({ error: 'url is required' })
+      return
+    }
+    if (!secret || typeof secret !== 'string') {
+      res.status(400).json({ error: 'secret is required' })
+      return
+    }
+    if (!Array.isArray(events)) {
+      res.status(400).json({ error: 'events must be an array' })
+      return
+    }
+
+    const subscriber = await upsertSubscriber(organization_id, url, secret, events)
+
+    createAuditLog({
+      actor_user_id: req.user!.userId,
+      action: 'webhook.subscriber.upsert',
+      target_type: 'webhook_subscriber',
+      target_id: subscriber.id,
+      metadata: { organizationId: organization_id, url },
+    })
+
+    // Never return the secret in responses
+    res.status(200).json({
+      id: subscriber.id,
+      organization_id: subscriber.organizationId,
+      url: subscriber.url,
+      events: subscriber.events,
+      active: subscriber.active,
+      created_at: subscriber.createdAt,
+    })
+  } catch (error: any) {
+    if (error?.message?.toLowerCase().includes('not permitted')) {
+      res.status(422).json({ error: error.message })
+      return
+    }
+    console.error('Error upserting webhook subscriber:', error)
+    res.status(500).json({ error: 'Failed to upsert subscriber' })
+  }
+})
+
+/**
+ * GET /api/admin/webhooks/subscribers?organization_id=<org>
+ *
+ * Lists active subscribers for an organization.
+ * Secret material is stripped from all responses.
+ */
+adminWebhooksRouter.get('/subscribers', async (req: Request, res: Response) => {
+  try {
+    const organizationId = req.query.organization_id as string | undefined
+    if (!organizationId) {
+      res.status(400).json({ error: 'organization_id query param is required' })
+      return
+    }
+
+    const subscribers = await listSubscribers(organizationId)
+
+    res.status(200).json({
+      subscribers: subscribers.map((s) => ({
+        id: s.id,
+        organization_id: s.organizationId,
+        url: s.url,
+        events: s.events,
+        active: s.active,
+        created_at: s.createdAt,
+        rotated_at: s.rotatedAt,
+      })),
+    })
+  } catch (error) {
+    console.error('Error listing webhook subscribers:', error)
+    res.status(500).json({ error: 'Failed to list subscribers' })
+  }
+})
+
+/**
+ * POST /api/admin/webhooks/subscribers/:id/rotate-secret
+ *
+ * Rotates the signing secret for a subscriber.  The previous secret is
+ * preserved in a grace window (default 24 h, configurable via
+ * WEBHOOK_SECRET_GRACE_WINDOW_MS) so in-flight deliveries continue to verify.
+ *
+ * Body: { organization_id, new_secret }
+ * Response 200: { id, rotated_at }
+ *   (secret material is never returned)
+ */
+adminWebhooksRouter.post(
+  '/subscribers/:id/rotate-secret',
+  async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params
+      const { organization_id, new_secret } = req.body ?? {}
+
+      if (!organization_id || typeof organization_id !== 'string') {
+        res.status(400).json({ error: 'organization_id is required' })
+        return
+      }
+      if (!new_secret || typeof new_secret !== 'string') {
+        res.status(400).json({ error: 'new_secret is required' })
+        return
+      }
+
+      const updated = await rotateSubscriberSecret(id, organization_id, new_secret)
+
+      if (!updated) {
+        // Return 404 for both "not found" and "wrong org" to avoid enumeration
+        res.status(404).json({ error: 'Subscriber not found' })
+        return
+      }
+
+      createAuditLog({
+        actor_user_id: req.user!.userId,
+        action: 'webhook.subscriber.rotate_secret',
+        target_type: 'webhook_subscriber',
+        target_id: id,
+        metadata: { organizationId: organization_id },
+      })
+
+      res.status(200).json({
+        id: updated.id,
+        rotated_at: updated.rotatedAt,
+      })
+    } catch (error) {
+      console.error('Error rotating webhook subscriber secret:', error)
+      res.status(500).json({ error: 'Failed to rotate secret' })
+    }
+  },
+)

--- a/src/services/webhooks.ts
+++ b/src/services/webhooks.ts
@@ -21,6 +21,18 @@ export interface WebhookSubscriber {
   organizationId: string
   url: string
   secret: string
+  /**
+   * The previous signing secret retained during the rotation grace window.
+   * Null when no rotation has occurred or after the grace window has closed
+   * and the column has been cleared.
+   */
+  previousSecret: string | null
+  /**
+   * ISO 8601 timestamp of when the most recent secret rotation occurred.
+   * Used together with WEBHOOK_SECRET_GRACE_WINDOW_MS to determine whether
+   * the previous secret is still valid for verifying inbound signatures.
+   */
+  rotatedAt: string | null
   events: string[]
   active: boolean
   createdAt: string
@@ -137,6 +149,27 @@ export const verifySignature = (secret: string, body: string, signature: string)
   return timingSafeEqual(Buffer.from(expected, 'utf8'), Buffer.from(signature, 'utf8'))
 }
 
+/**
+ * Verifies a signature against a subscriber's current secret and, when within
+ * the rotation grace window, also against the previous secret.
+ *
+ * This lets subscribers that have not yet updated their secret still pass
+ * verification until the grace window closes.
+ *
+ * Returns `true` if at least one of the valid secrets matches.
+ */
+export const verifySignatureWithGrace = (
+  subscriber: WebhookSubscriber,
+  body: string,
+  signature: string,
+): boolean => {
+  if (verifySignature(subscriber.secret, body, signature)) return true
+  if (isPreviousSecretInGrace(subscriber)) {
+    return verifySignature(subscriber.previousSecret!, body, signature)
+  }
+  return false
+}
+
 export const addSubscriber = async (
   organizationId: string,
   url: string,
@@ -148,6 +181,68 @@ export const addSubscriber = async (
   }
 
   return repo.create({ organizationId, url, secret, events })
+}
+
+/**
+ * Idempotent variant of addSubscriber.
+ *
+ * Re-registering the same (org, URL) pair updates the existing row in-place
+ * instead of inserting a duplicate.  Delivery history (dead letters keyed on
+ * subscriber_id) is preserved because the row's primary key does not change.
+ */
+export const upsertSubscriber = async (
+  organizationId: string,
+  url: string,
+  secret: string,
+  events: string[],
+): Promise<WebhookSubscriber> => {
+  if (!isUrlAllowed(url)) {
+    throw new Error(`Webhook URL not permitted: ${url}`)
+  }
+
+  return repo.upsert({ organizationId, url, secret, events })
+}
+
+/**
+ * Rotates the signing secret for a subscriber.
+ *
+ * The previous secret is stored alongside the new one for
+ * WEBHOOK_SECRET_GRACE_WINDOW_MS milliseconds (default 24 h) so any
+ * in-flight deliveries signed with the old key continue to verify.
+ *
+ * Returns null when the subscriber does not exist or belongs to a different
+ * organization.
+ */
+export const rotateSubscriberSecret = async (
+  id: string,
+  organizationId: string,
+  newSecret: string,
+): Promise<WebhookSubscriber | null> => {
+  return repo.rotateSecret(id, organizationId, newSecret)
+}
+
+/**
+ * Default grace window: 24 hours. Override via WEBHOOK_SECRET_GRACE_WINDOW_MS.
+ */
+const DEFAULT_GRACE_WINDOW_MS = 24 * 60 * 60 * 1000
+
+export const getGraceWindowMs = (): number => {
+  const raw = process.env.WEBHOOK_SECRET_GRACE_WINDOW_MS
+  if (raw) {
+    const parsed = parseInt(raw, 10)
+    if (!Number.isNaN(parsed) && parsed >= 0) return parsed
+  }
+  return DEFAULT_GRACE_WINDOW_MS
+}
+
+/**
+ * Returns true if the previous secret for a subscriber is still within its
+ * rotation grace window (i.e. it should still be accepted for verification).
+ */
+export const isPreviousSecretInGrace = (subscriber: WebhookSubscriber): boolean => {
+  if (!subscriber.previousSecret || !subscriber.rotatedAt) return false
+  const rotatedAt = new Date(subscriber.rotatedAt).getTime()
+  return Date.now() - rotatedAt < getGraceWindowMs()
 }
 
 export const removeSubscriber = async (id: string): Promise<boolean> => repo.remove(id)

--- a/src/tests/webhookSubscriber.rotation.test.ts
+++ b/src/tests/webhookSubscriber.rotation.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Tests for idempotent webhook subscriber upsert and signing-secret rotation.
+ *
+ * These tests require a PostgreSQL database (DATABASE_URL env var).  Without
+ * it they are skipped gracefully so the suite still passes in CI environments
+ * that run the unit-test-only job.
+ *
+ * Run locally:
+ *   DATABASE_URL=postgres://... npx jest webhookSubscriber.rotation
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals'
+import knex, { Knex } from 'knex'
+import { WebhookSubscriberRepository } from '../repositories/webhookSubscriberRepository.js'
+
+// ─── Conditional suite ────────────────────────────────────────────────────────
+
+const hasDb = !!process.env.DATABASE_URL
+const describeDb = hasDb ? describe : describe.skip
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ORG_A = 'rotation-test-org-a'
+const ORG_B = 'rotation-test-org-b'
+const HOOK_URL = 'https://hooks.example.com/disciplr'
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
+describeDb('WebhookSubscriberRepository – upsert & secret rotation', () => {
+  let db: Knex
+  let repo: WebhookSubscriberRepository
+
+  // ---------------------------------------------------------------------------
+  // Setup / teardown
+  // ---------------------------------------------------------------------------
+
+  beforeAll(async () => {
+    db = knex({
+      client: 'pg',
+      connection: process.env.DATABASE_URL,
+    })
+
+    // Ensure the schema exists (mirrors what the migration creates)
+    const hasTable = await db.schema.hasTable('webhook_subscribers')
+    if (!hasTable) {
+      await db.schema.createTable('webhook_subscribers', (t) => {
+        t.uuid('id').primary().defaultTo(db.raw('gen_random_uuid()'))
+        t.string('organization_id', 255).notNullable()
+        t.string('url', 2048).notNullable()
+        t.text('secret').notNullable()
+        t.text('previous_secret').nullable()
+        t.timestamp('rotated_at', { useTz: true }).nullable()
+        t.jsonb('events').notNullable().defaultTo(db.raw("'[]'::jsonb"))
+        t.boolean('active').notNullable().defaultTo(true)
+        t.timestamp('created_at', { useTz: true }).notNullable().defaultTo(db.fn.now())
+        t.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(db.fn.now())
+      })
+      await db.raw(
+        'CREATE UNIQUE INDEX IF NOT EXISTS idx_webhook_subscribers_org_url ON webhook_subscribers (organization_id, url)',
+      )
+    } else {
+      // If the table exists, make sure the new columns are present (for envs
+      // that ran an earlier migration but not the rotation one).
+      const hasPrev = await db.schema.hasColumn('webhook_subscribers', 'previous_secret')
+      if (!hasPrev) {
+        await db.schema.alterTable('webhook_subscribers', (t) => {
+          t.text('previous_secret').nullable()
+          t.timestamp('rotated_at', { useTz: true }).nullable()
+        })
+        await db.raw(
+          'CREATE UNIQUE INDEX IF NOT EXISTS idx_webhook_subscribers_org_url ON webhook_subscribers (organization_id, url)',
+        )
+      }
+    }
+
+    repo = new WebhookSubscriberRepository(db)
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  beforeEach(async () => {
+    // Isolate each test: only remove rows for the test orgs used in this suite
+    await db('webhook_subscribers').whereIn('organization_id', [ORG_A, ORG_B]).del()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Idempotent upsert
+  // ---------------------------------------------------------------------------
+
+  describe('upsert()', () => {
+    it('creates a new subscriber when none exists for the (org, url) pair', async () => {
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'initial-secret',
+        events: ['vault_created'],
+      })
+
+      expect(sub.id).toBeTruthy()
+      expect(sub.organizationId).toBe(ORG_A)
+      expect(sub.url).toBe(HOOK_URL)
+      expect(sub.events).toEqual(['vault_created'])
+      expect(sub.active).toBe(true)
+      expect(sub.previousSecret).toBeNull()
+      expect(sub.rotatedAt).toBeNull()
+    })
+
+    it('returns the same id on a second upsert for the same (org, url)', async () => {
+      const first = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'secret-v1',
+        events: [],
+      })
+
+      const second = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'secret-v2',
+        events: ['vault_completed'],
+      })
+
+      expect(second.id).toBe(first.id)
+    })
+
+    it('updates secret and events on re-registration without creating duplicates', async () => {
+      await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'old-secret',
+        events: [],
+      })
+
+      await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'new-secret',
+        events: ['vault_created', 'vault_completed'],
+      })
+
+      const all = await db('webhook_subscribers')
+        .where({ organization_id: ORG_A, url: HOOK_URL })
+        .select('*')
+
+      // Must have exactly one row — no duplicates
+      expect(all).toHaveLength(1)
+      expect(all[0].secret).toBe('new-secret')
+      expect(all[0].events).toEqual(['vault_created', 'vault_completed'])
+    })
+
+    it('re-activates a previously deactivated subscriber on upsert', async () => {
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'secret',
+        events: [],
+      })
+
+      await repo.deactivate(sub.id)
+      expect((await repo.findByOrg(ORG_A))).toHaveLength(0)
+
+      await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'secret',
+        events: [],
+      })
+
+      const active = await repo.findByOrg(ORG_A)
+      expect(active).toHaveLength(1)
+      expect(active[0].active).toBe(true)
+    })
+
+    it('does not overwrite a different org's subscriber at the same URL', async () => {
+      await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'secret-a',
+        events: [],
+      })
+
+      await repo.upsert({
+        organizationId: ORG_B,
+        url: HOOK_URL,
+        secret: 'secret-b',
+        events: [],
+      })
+
+      const rowsA = await db('webhook_subscribers')
+        .where({ organization_id: ORG_A, url: HOOK_URL })
+        .select('secret')
+      const rowsB = await db('webhook_subscribers')
+        .where({ organization_id: ORG_B, url: HOOK_URL })
+        .select('secret')
+
+      expect(rowsA).toHaveLength(1)
+      expect(rowsB).toHaveLength(1)
+      // Org A's secret must remain untouched when org B upserts the same URL
+      expect(rowsA[0].secret).toBe('secret-a')
+      expect(rowsB[0].secret).toBe('secret-b')
+    })
+
+    it('preserves delivery history (dead letter rows) across re-registration', async () => {
+      // Skip if dead_letters table is absent
+      const hasDlq = await db.schema.hasTable('webhook_dead_letters')
+      if (!hasDlq) return
+
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'secret-v1',
+        events: [],
+      })
+
+      // Plant a synthetic dead-letter keyed on the subscriber's id
+      await db('webhook_dead_letters').insert({
+        subscriber_id: sub.id,
+        event_id: 'tx:history-0',
+        event_type: 'vault_created',
+        payload: { eventId: 'tx:history-0', eventType: 'vault_created', timestamp: new Date().toISOString(), data: {}, organizationId: ORG_A },
+        last_error: 'simulated failure',
+        attempts: 3,
+      })
+
+      // Re-register (upsert) — same id must survive
+      const updated = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'secret-v2',
+        events: ['vault_created'],
+      })
+
+      expect(updated.id).toBe(sub.id)
+
+      const dlqRows = await db('webhook_dead_letters').where({ subscriber_id: sub.id })
+      expect(dlqRows).toHaveLength(1)
+      expect(dlqRows[0].event_id).toBe('tx:history-0')
+
+      // Cleanup
+      await db('webhook_dead_letters').where({ subscriber_id: sub.id }).del()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // rotateSecret()
+  // ---------------------------------------------------------------------------
+
+  describe('rotateSecret()', () => {
+    it('moves current secret to previous_secret and sets rotated_at', async () => {
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'original-secret',
+        events: [],
+      })
+
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+
+      expect(rotated).not.toBeNull()
+      expect(rotated!.secret).toBe('new-secret')
+      expect(rotated!.previousSecret).toBe('original-secret')
+      expect(rotated!.rotatedAt).not.toBeNull()
+    })
+
+    it('returns null for a non-existent subscriber id', async () => {
+      const result = await repo.rotateSecret(
+        '00000000-0000-0000-0000-000000000000',
+        ORG_A,
+        'new-secret',
+      )
+      expect(result).toBeNull()
+    })
+
+    it('returns null (cross-org rejection) when org does not match', async () => {
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'secret-a',
+        events: [],
+      })
+
+      const result = await repo.rotateSecret(sub.id, ORG_B, 'attacker-secret')
+      expect(result).toBeNull()
+
+      // Confirm the row is unchanged
+      const row = await db('webhook_subscribers').where({ id: sub.id }).first()
+      expect(row.secret).toBe('secret-a')
+    })
+
+    it('overwrites previous_secret on a second rotation', async () => {
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'v1',
+        events: [],
+      })
+
+      await repo.rotateSecret(sub.id, ORG_A, 'v2')
+      const second = await repo.rotateSecret(sub.id, ORG_A, 'v3')
+
+      expect(second!.secret).toBe('v3')
+      // previous_secret is now v2 (the secret that was active before v3)
+      expect(second!.previousSecret).toBe('v2')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Grace-window dual-secret verification (via isPreviousSecretInGrace)
+  // ---------------------------------------------------------------------------
+
+  describe('grace-window dual-secret verification', () => {
+    // Import service helpers inline to avoid top-level import issues with
+    // Jest module mocking in other test files.
+    let signPayload: (secret: string, body: string) => string
+    let verifySignatureWithGrace: (sub: any, body: string, sig: string) => boolean
+    let isPreviousSecretInGrace: (sub: any) => boolean
+
+    beforeAll(async () => {
+      // Dynamic import so Jest module isolation in other suites is unaffected
+      const mod = await import('../services/webhooks.js')
+      signPayload = mod.signPayload
+      verifySignatureWithGrace = mod.verifySignatureWithGrace
+      isPreviousSecretInGrace = mod.isPreviousSecretInGrace
+    })
+
+    it('verifies with new secret immediately after rotation', async () => {
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'old-secret',
+        events: [],
+      })
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+
+      const body = '{"hello":"world"}'
+      const sig = signPayload('new-secret', body)
+
+      expect(verifySignatureWithGrace(rotated!, body, sig)).toBe(true)
+    })
+
+    it('verifies with old secret during grace window', async () => {
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'old-secret',
+        events: [],
+      })
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+
+      const body = '{"hello":"world"}'
+      // Sign with the OLD secret (simulates an in-flight delivery)
+      const oldSig = signPayload('old-secret', body)
+
+      expect(verifySignatureWithGrace(rotated!, body, oldSig)).toBe(true)
+    })
+
+    it('rejects old secret after grace window has expired', async () => {
+      // Simulate an expired rotation by back-dating rotated_at
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'old-secret',
+        events: [],
+      })
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+
+      // Back-date rotated_at to 48 h ago (beyond 24 h grace window)
+      const expiredRotatedAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+      const expiredSub = { ...rotated!, rotatedAt: expiredRotatedAt }
+
+      const body = '{"hello":"world"}'
+      const oldSig = signPayload('old-secret', body)
+
+      // Grace window has closed – old secret should be rejected
+      expect(isPreviousSecretInGrace(expiredSub)).toBe(false)
+      expect(verifySignatureWithGrace(expiredSub, body, oldSig)).toBe(false)
+    })
+
+    it('verifies with new secret after grace window expires', async () => {
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'old-secret',
+        events: [],
+      })
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+
+      const expiredRotatedAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+      const expiredSub = { ...rotated!, rotatedAt: expiredRotatedAt }
+
+      const body = '{"hello":"world"}'
+      const newSig = signPayload('new-secret', body)
+
+      expect(verifySignatureWithGrace(expiredSub, body, newSig)).toBe(true)
+    })
+
+    it('isPreviousSecretInGrace returns false when no previous secret', async () => {
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'secret',
+        events: [],
+      })
+      expect(isPreviousSecretInGrace(sub)).toBe(false)
+    })
+
+    it('respects WEBHOOK_SECRET_GRACE_WINDOW_MS env override', async () => {
+      const sub = await repo.upsert({
+        organizationId: ORG_A,
+        url: HOOK_URL,
+        secret: 'old-secret',
+        events: [],
+      })
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+
+      // Set a very short grace window (1 ms) then back-date by 1 second
+      const originalEnv = process.env.WEBHOOK_SECRET_GRACE_WINDOW_MS
+      process.env.WEBHOOK_SECRET_GRACE_WINDOW_MS = '1'
+
+      const rotatedLongAgo = { ...rotated!, rotatedAt: new Date(Date.now() - 1000).toISOString() }
+
+      expect(isPreviousSecretInGrace(rotatedLongAgo)).toBe(false)
+
+      // Restore
+      if (originalEnv === undefined) {
+        delete process.env.WEBHOOK_SECRET_GRACE_WINDOW_MS
+      } else {
+        process.env.WEBHOOK_SECRET_GRACE_WINDOW_MS = originalEnv
+      }
+    })
+  })
+})

--- a/src/tests/webhooks.test.ts
+++ b/src/tests/webhooks.test.ts
@@ -34,6 +34,8 @@ jest.unstable_mockModule('../repositories/webhookSubscriberRepository.js', () =>
           organizationId: data.organizationId,
           url: data.url,
           secret: data.secret,
+          previousSecret: null,
+          rotatedAt: null,
           events: [...data.events],
           active: true,
           createdAt: new Date().toISOString(),


### PR DESCRIPTION
Closes #710  Add idempotent webhook subscriber upsert and signing-secret rotation to src/repositories/webhookSubscriberRepository.ts
Add upsert() keyed on (organization_id, url) so re-registering a webhook does not create duplicate rows and preserves delivery history.

Add rotateSecret() with a configurable grace window (default 24 h) during which signatures made with the previous secret still verify, allowing operators to rotate without breaking in-flight deliveries.

- migration: add previous_secret, rotated_at columns + unique index
- repo: upsert() via ON CONFLICT DO UPDATE, rotateSecret() atomic swap
- service: upsertSubscriber, rotateSubscriberSecret, verifySignatureWithGrace, isPreviousSecretInGrace, getGraceWindowMs
- routes: POST /subscribers (upsert), GET /subscribers, POST /subscribers/:id/rotate-secret (admin-only)
- tests: webhookSubscriber.rotation.test.ts covering all edge cases
- docs: rotation flow, grace window, new API endpoints documented