### PR TITLE
test: WebAuthn counter-rollback and registration uniqueness

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -191,16 +191,48 @@ export class AuthService {
     }
 
     static async registerWebAuthnCredential(userId: string, credentialId: string, publicKey: string) {
+        const existing = await getPrisma().$queryRaw<{ credential_id: string }[]>`
+            SELECT "credential_id" FROM "webauthn_credentials"
+            WHERE "credential_id" = ${credentialId}
+            LIMIT 1
+        `
+
+        if (existing.length > 0) {
+            throw new Error('Credential already registered')
+        }
+
         await getPrisma().$executeRaw`
-            INSERT INTO "webauthn_credentials" ("user_id", "credential_id", "public_key")
-            VALUES (${userId}, ${credentialId}, ${publicKey})
-            ON CONFLICT ("credential_id") DO UPDATE SET
-                "public_key" = EXCLUDED."public_key",
-                "updated_at" = CURRENT_TIMESTAMP,
-                "last_used_at" = CURRENT_TIMESTAMP
+            INSERT INTO "webauthn_credentials" ("user_id", "credential_id", "public_key", "counter")
+            VALUES (${userId}, ${credentialId}, ${publicKey}, 0)
         `
 
         return { userId, credentialId, publicKey }
+    }
+
+    static async verifyWebAuthnAssertion(credentialId: string, newCounter: number) {
+        const rows = await getPrisma().$queryRaw<{ counter: number }[]>`
+            SELECT "counter" FROM "webauthn_credentials"
+            WHERE "credential_id" = ${credentialId}
+            LIMIT 1
+        `
+
+        if (rows.length === 0) {
+            throw new Error('Credential not found')
+        }
+
+        const storedCounter = rows[0].counter
+
+        if (newCounter <= storedCounter) {
+            throw new Error('Counter regression detected: possible cloned authenticator')
+        }
+
+        await getPrisma().$executeRaw`
+            UPDATE "webauthn_credentials"
+            SET "counter" = ${newCounter}, "last_used_at" = CURRENT_TIMESTAMP
+            WHERE "credential_id" = ${credentialId}
+        `
+
+        return { credentialId, counter: newCounter }
     }
 }
 

--- a/src/tests/webauthn.counter.test.ts
+++ b/src/tests/webauthn.counter.test.ts
@@ -1,0 +1,127 @@
+import { jest } from '@jest/globals'
+
+// In-memory credential store keyed by credential_id
+const credentialStore = new Map<string, { userId: string; publicKey: string; counter: number }>()
+
+const mockPrisma = {
+  $queryRaw: jest.fn(async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    // Parse the query to determine which operation is being called
+    const sql = strings.join('?')
+    if (sql.includes('SELECT "credential_id"')) {
+      const credentialId = values[0] as string
+      const existing = credentialStore.get(credentialId)
+      return existing ? [{ credential_id: credentialId }] : []
+    }
+    if (sql.includes('SELECT "counter"')) {
+      const credentialId = values[0] as string
+      const existing = credentialStore.get(credentialId)
+      return existing ? [{ counter: existing.counter }] : []
+    }
+    return []
+  }),
+  $executeRaw: jest.fn(async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const sql = strings.join('?')
+    if (sql.includes('INSERT INTO "webauthn_credentials"')) {
+      const [userId, credentialId, publicKey] = values as [string, string, string]
+      credentialStore.set(credentialId, { userId, publicKey, counter: 0 })
+    } else if (sql.includes('UPDATE "webauthn_credentials"')) {
+      const [newCounter, credentialId] = values as [number, string]
+      const existing = credentialStore.get(credentialId)
+      if (existing) {
+        existing.counter = newCounter
+      }
+    }
+    return 1
+  }),
+}
+
+jest.unstable_mockModule('../lib/prismaScope.js', () => ({
+  getPrisma: () => mockPrisma,
+  prismaStorage: { getStore: () => undefined },
+}))
+
+const { AuthService } = await import('../services/auth.service.js')
+
+describe('WebAuthn credential registration uniqueness', () => {
+  beforeEach(() => {
+    credentialStore.clear()
+    jest.clearAllMocks()
+  })
+
+  it('registers a new credential successfully', async () => {
+    const result = await AuthService.registerWebAuthnCredential('user-1', 'cred-abc', 'pubkey-abc')
+    expect(result).toEqual({ userId: 'user-1', credentialId: 'cred-abc', publicKey: 'pubkey-abc' })
+    expect(credentialStore.has('cred-abc')).toBe(true)
+  })
+
+  it('rejects duplicate credential registration', async () => {
+    await AuthService.registerWebAuthnCredential('user-1', 'cred-dup', 'pubkey-1')
+    await expect(
+      AuthService.registerWebAuthnCredential('user-2', 'cred-dup', 'pubkey-2'),
+    ).rejects.toThrow('Credential already registered')
+  })
+
+  it('allows different credentials for the same user', async () => {
+    await AuthService.registerWebAuthnCredential('user-1', 'cred-1', 'pubkey-1')
+    await AuthService.registerWebAuthnCredential('user-1', 'cred-2', 'pubkey-2')
+    expect(credentialStore.size).toBe(2)
+  })
+})
+
+describe('WebAuthn assertion counter verification', () => {
+  const CREDENTIAL_ID = 'cred-counter-test'
+
+  beforeEach(async () => {
+    credentialStore.clear()
+    jest.clearAllMocks()
+    await AuthService.registerWebAuthnCredential('user-1', CREDENTIAL_ID, 'pubkey-x')
+    // Seed counter to 5 to allow regression tests
+    credentialStore.get(CREDENTIAL_ID)!.counter = 5
+  })
+
+  it('accepts a monotonically increasing counter', async () => {
+    const result = await AuthService.verifyWebAuthnAssertion(CREDENTIAL_ID, 6)
+    expect(result).toEqual({ credentialId: CREDENTIAL_ID, counter: 6 })
+    expect(credentialStore.get(CREDENTIAL_ID)!.counter).toBe(6)
+  })
+
+  it('accepts a large counter increment', async () => {
+    const result = await AuthService.verifyWebAuthnAssertion(CREDENTIAL_ID, 999)
+    expect(result.counter).toBe(999)
+  })
+
+  it('rejects an equal counter (clone detection)', async () => {
+    await expect(AuthService.verifyWebAuthnAssertion(CREDENTIAL_ID, 5)).rejects.toThrow(
+      'Counter regression detected',
+    )
+  })
+
+  it('rejects a counter lower than stored (clone detection)', async () => {
+    await expect(AuthService.verifyWebAuthnAssertion(CREDENTIAL_ID, 4)).rejects.toThrow(
+      'Counter regression detected',
+    )
+  })
+
+  it('rejects counter 0 against a stored counter of 5', async () => {
+    await expect(AuthService.verifyWebAuthnAssertion(CREDENTIAL_ID, 0)).rejects.toThrow(
+      'Counter regression detected',
+    )
+  })
+
+  it('does not update the stored counter on rejection', async () => {
+    await expect(AuthService.verifyWebAuthnAssertion(CREDENTIAL_ID, 3)).rejects.toThrow()
+    expect(credentialStore.get(CREDENTIAL_ID)!.counter).toBe(5)
+  })
+
+  it('throws when credential does not exist', async () => {
+    await expect(AuthService.verifyWebAuthnAssertion('nonexistent-cred', 1)).rejects.toThrow(
+      'Credential not found',
+    )
+  })
+
+  it('accepts counter 1 when stored counter is 0 (fresh credential)', async () => {
+    credentialStore.get(CREDENTIAL_ID)!.counter = 0
+    const result = await AuthService.verifyWebAuthnAssertion(CREDENTIAL_ID, 1)
+    expect(result.counter).toBe(1)
+  })
+})


### PR DESCRIPTION
Closes #740 
 Summary
  
  Adds WebAuthn credential registration uniqueness enforcement
  and signature-counter rollback rejection (clone detection) to
  AuthService, with full test coverage in
  src/tests/webauthn.counter.test.ts.
  
  Changes
  
  src/services/auth.service.ts
  
  - registerWebAuthnCredential — replaced silent upsert with an
  explicit uniqueness check; throws if credential_id already
  exists. Initializes counter = 0 on insert.
  - verifyWebAuthnAssertion (new) — reads the stored counter and
  rejects any assertion where newCounter <= storedCounter,
  satisfying the WebAuthn clone-detection requirement.
  
  src/tests/webauthn.counter.test.ts (new, 11 tests)
  
  - Duplicate credential registration is rejected
  - Monotonically increasing counter is accepted
  - Equal counter is rejected (clone detection)
  - Regressed counter is rejected (clone detection)
  - Stored counter is not mutated on a failed assertion
  - Credential-not-found throws
  - Fresh credential accepts counter 1 from 0
  