### PR TITLE
Add risk analytics endpoint and corresponding service logic

### DIFF
--- a/docs/analytics-metrics.md
+++ b/docs/analytics-metrics.md
@@ -14,6 +14,13 @@ This document describes the calculations and assumptions used by the analytics e
   - Query: userId (required), windowDays=30, baseScorePerSuccess=5, penaltyPerFailure=2, streakBonusPerDay=1
   - Response: per-user metrics and a behaviorScore
 
+- GET /api/orgs/:orgId/analytics/risk
+  - Query: startDate, endDate (ISO 8601, inclusive, UTC)
+  - Response: slash-rate and capital-at-risk for the requested org and window
+    - slashRate: resolved vaults that ended in slash_on_miss divided by all resolved vaults in the range
+    - capitalAtRisk: sum of the net-staked amount for active vaults in the range
+    - resolvedVaults, slashedVaults, activeVaults, totalVaults: supporting counts
+
 ## Data Model
 
 In-memory milestone events:

--- a/src/app-bootstrap.ts
+++ b/src/app-bootstrap.ts
@@ -66,6 +66,7 @@ export function bootstrapApp(options: BootstrapOptions = {}) {
   app.use('/api/privacy', privacyRouter)
   app.use('/api/organizations', orgVaultsRouter)
   app.use('/api/organizations', orgAnalyticsRouter)
+  app.use('/api/orgs', orgAnalyticsRouter)
   app.use('/api/organizations', orgMembersRouter)
   app.use('/api/orgs', orgMembersRouter)
   app.use('/api/organizations/:orgId/graphql', graphqlRouter)

--- a/src/routes/orgAnalytics.ts
+++ b/src/routes/orgAnalytics.ts
@@ -2,9 +2,29 @@ import { orgAnalyticsRateLimiter } from '../middleware/rateLimiter.js'
 import { Router, Request, Response } from 'express'
 import { authenticate } from '../middleware/auth.js'
 import { requireOrgAccess } from '../middleware/orgAuth.js'
+import { getOrgRiskAnalytics } from '../services/analytics.service.js'
 import { vaults, Vault } from './vaults.js'
 
 export const orgAnalyticsRouter = Router()
+
+orgAnalyticsRouter.get(
+  '/:orgId/analytics/risk',
+  authenticate,
+  requireOrgAccess('owner', 'admin'),
+  orgAnalyticsRateLimiter,
+  async (req: Request, res: Response) => {
+    const { orgId } = req.params
+    const startDate = typeof req.query.startDate === 'string' ? req.query.startDate : undefined
+    const endDate = typeof req.query.endDate === 'string' ? req.query.endDate : undefined
+
+    try {
+      const result = getOrgRiskAnalytics(orgId, vaults, { startDate, endDate })
+      res.json(result)
+    } catch (error: any) {
+      res.status(400).json({ error: error.message })
+    }
+  }
+)
 
 orgAnalyticsRouter.get(
   '/:orgId/analytics',

--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -7,8 +7,136 @@ import {
   getTimeRangeFilter
 } from '../db/database.js'
 import type { VaultAnalytics, VaultAnalyticsWithPeriod } from '../types/vault.js'
-import { utcNow } from '../utils/timestamps.js'
+import { parseAndNormalizeToUTC, utcNow } from '../utils/timestamps.js'
 import { getOrSet, invalidate } from '../lib/cache.js'
+
+export interface OrgRiskAnalyticsVault {
+  id?: string
+  orgId?: string
+  amount?: string | number | null
+  status?: string | null
+  createdAt?: string | null
+  startTimestamp?: string | null
+  endTimestamp?: string | null
+  stakedAmount?: string | number | null
+  netStakedAmount?: string | number | null
+  resolution?: string | null
+  finalStatus?: string | null
+  outcome?: string | null
+  result?: string | null
+  terminationReason?: string | null
+  statusReason?: string | null
+  [key: string]: unknown
+}
+
+export interface OrgRiskAnalyticsResponse {
+  orgId: string
+  generatedAt: string
+  range: {
+    startDate: string
+    endDate: string
+  }
+  analytics: {
+    totalVaults: number
+    activeVaults: number
+    resolvedVaults: number
+    slashedVaults: number
+    slashRate: number
+    capitalAtRisk: string
+  }
+}
+
+function normalizeOrgRiskRange(startDate?: string, endDate?: string): { startDate: string; endDate: string } {
+  const normalizedStart = startDate ? parseAndNormalizeToUTC(startDate) : new Date(0).toISOString()
+  const normalizedEnd = endDate ? parseAndNormalizeToUTC(endDate) : utcNow()
+
+  if (new Date(normalizedStart).getTime() > new Date(normalizedEnd).getTime()) {
+    throw new Error('startDate must be before or equal to endDate')
+  }
+
+  return { startDate: normalizedStart, endDate: normalizedEnd }
+}
+
+function readNumericAmount(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+function getVaultAmount(vault: OrgRiskAnalyticsVault): number {
+  const candidates = [
+    vault.stakedAmount,
+    vault.netStakedAmount,
+    vault.amount,
+  ]
+
+  for (const candidate of candidates) {
+    const value = readNumericAmount(candidate)
+    if (value > 0) return value
+  }
+
+  return 0
+}
+
+function isInRange(vault: OrgRiskAnalyticsVault, startDate: string, endDate: string): boolean {
+  const anchor = vault.createdAt ?? vault.startTimestamp ?? vault.endTimestamp
+  if (!anchor) return true
+
+  const normalizedAnchor = parseAndNormalizeToUTC(anchor)
+  return normalizedAnchor >= startDate && normalizedAnchor <= endDate
+}
+
+function isSlashOutcome(vault: OrgRiskAnalyticsVault): boolean {
+  const candidates = [
+    vault.resolution,
+    vault.finalStatus,
+    vault.outcome,
+    vault.result,
+    vault.terminationReason,
+    vault.statusReason,
+  ]
+
+  for (const candidate of candidates) {
+    const normalized = String(candidate ?? '').trim().toLowerCase()
+    if (normalized === 'slash_on_miss' || normalized === 'slashed' || normalized === 'slash') {
+      return true
+    }
+  }
+
+  return vault.status === 'failed'
+}
+
+export function getOrgRiskAnalytics(
+  orgId: string,
+  vaults: OrgRiskAnalyticsVault[],
+  options: { startDate?: string; endDate?: string } = {},
+): OrgRiskAnalyticsResponse {
+  const { startDate, endDate } = normalizeOrgRiskRange(options.startDate, options.endDate)
+  const scopedVaults = vaults.filter((vault) => vault.orgId === orgId && isInRange(vault, startDate, endDate))
+
+  const activeVaults = scopedVaults.filter((vault) => vault.status === 'active')
+  const resolvedVaults = scopedVaults.filter((vault) => vault.status === 'completed' || vault.status === 'failed')
+  const slashedVaults = resolvedVaults.filter((vault) => isSlashOutcome(vault))
+  const capitalAtRisk = activeVaults.reduce((sum, vault) => sum + getVaultAmount(vault), 0)
+  const slashRate = resolvedVaults.length > 0 ? slashedVaults.length / resolvedVaults.length : 0
+
+  return {
+    orgId,
+    generatedAt: utcNow(),
+    range: { startDate, endDate },
+    analytics: {
+      totalVaults: scopedVaults.length,
+      activeVaults: activeVaults.length,
+      resolvedVaults: resolvedVaults.length,
+      slashedVaults: slashedVaults.length,
+      slashRate,
+      capitalAtRisk: capitalAtRisk.toString(),
+    },
+  }
+}
 
 export async function getOverallAnalytics(): Promise<VaultAnalytics> {
   return getOrSet('analytics:overall', 300, async () => {

--- a/src/tests/orgAnalytics.risk.test.ts
+++ b/src/tests/orgAnalytics.risk.test.ts
@@ -1,0 +1,208 @@
+import express from 'express'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { beforeEach, afterEach, describe, expect, it } from '@jest/globals'
+import { orgAnalyticsRouter } from '../routes/orgAnalytics.js'
+import { setVaults } from '../routes/vaults.js'
+import { setOrganizations, setOrgMembers } from '../models/organizations.js'
+import { UserRole } from '../types/user.js'
+
+const ORG_ID = 'org-1'
+const OTHER_ORG_ID = 'org-2'
+
+const app = express()
+app.use(express.json())
+app.use('/api/orgs', orgAnalyticsRouter)
+
+function authHeader(userId: string) {
+  const token = jwt.sign({ userId, role: UserRole.ADMIN }, process.env.JWT_SECRET ?? 'change-me-in-production')
+  return `Bearer ${token}`
+}
+
+function seedVaults(vaults: Array<any>) {
+  setOrganizations([
+    { id: ORG_ID, name: 'Test Org', createdAt: '2025-01-01T00:00:00Z' },
+    { id: OTHER_ORG_ID, name: 'Other Org', createdAt: '2025-01-01T00:00:00Z' },
+  ])
+
+  setOrgMembers([
+    { orgId: ORG_ID, userId: 'alice', role: 'owner' },
+    { orgId: OTHER_ORG_ID, userId: 'alice', role: 'owner' },
+  ])
+
+  setVaults(vaults)
+}
+
+describe('GET /api/orgs/:orgId/analytics/risk', () => {
+  beforeEach(() => {
+    setVaults([])
+    setOrganizations([])
+    setOrgMembers([])
+  })
+
+  afterEach(() => {
+    setVaults([])
+    setOrganizations([])
+    setOrgMembers([])
+  })
+
+  it('returns zeroed metrics when there are no vaults in the org', async () => {
+    seedVaults([])
+
+    const res = await request(app)
+      .get(`/api/orgs/${ORG_ID}/analytics/risk`)
+      .set('Authorization', authHeader('alice'))
+
+    expect(res.status).toBe(200)
+    expect(res.body.analytics).toEqual({
+      activeVaults: 0,
+      capitalAtRisk: '0',
+      resolvedVaults: 0,
+      slashRate: 0,
+      slashedVaults: 0,
+      totalVaults: 0,
+    })
+  })
+
+  it('excludes in-flight vaults from the slash-rate denominator and uses net staked amounts', async () => {
+    seedVaults([
+      {
+        id: 'v1',
+        creator: 'alice',
+        amount: '1000',
+        status: 'active',
+        startTimestamp: '2025-01-01T00:00:00Z',
+        endTimestamp: '2025-02-01T00:00:00Z',
+        successDestination: 'success',
+        failureDestination: 'failure',
+        createdAt: '2025-01-01T00:00:00Z',
+        stakedAmount: '500',
+        orgId: ORG_ID,
+      },
+      {
+        id: 'v2',
+        creator: 'alice',
+        amount: '4000',
+        status: 'completed',
+        startTimestamp: '2025-01-01T00:00:00Z',
+        endTimestamp: '2025-02-01T00:00:00Z',
+        successDestination: 'success',
+        failureDestination: 'failure',
+        createdAt: '2025-01-01T00:00:00Z',
+        stakedAmount: '4000',
+        orgId: ORG_ID,
+      },
+      {
+        id: 'v3',
+        creator: 'alice',
+        amount: '2000',
+        status: 'failed',
+        startTimestamp: '2025-01-01T00:00:00Z',
+        endTimestamp: '2025-02-01T00:00:00Z',
+        successDestination: 'success',
+        failureDestination: 'failure',
+        createdAt: '2025-01-02T00:00:00Z',
+        stakedAmount: '2000',
+        orgId: ORG_ID,
+        resolution: 'slash_on_miss',
+      },
+      {
+        id: 'v4',
+        creator: 'alice',
+        amount: '100',
+        status: 'active',
+        startTimestamp: '2025-02-01T00:00:00Z',
+        endTimestamp: '2025-03-01T00:00:00Z',
+        successDestination: 'success',
+        failureDestination: 'failure',
+        createdAt: '2025-02-01T00:00:00Z',
+        stakedAmount: '100',
+        orgId: ORG_ID,
+      },
+      {
+        id: 'v5',
+        creator: 'alice',
+        amount: '6000',
+        status: 'failed',
+        startTimestamp: '2025-01-01T00:00:00Z',
+        endTimestamp: '2025-02-01T00:00:00Z',
+        successDestination: 'success',
+        failureDestination: 'failure',
+        createdAt: '2025-01-03T00:00:00Z',
+        stakedAmount: '6000',
+        orgId: OTHER_ORG_ID,
+      },
+    ])
+
+    const res = await request(app)
+      .get(`/api/orgs/${ORG_ID}/analytics/risk`)
+      .set('Authorization', authHeader('alice'))
+
+    expect(res.status).toBe(200)
+    expect(res.body.analytics).toMatchObject({
+      activeVaults: 2,
+      capitalAtRisk: '600',
+      resolvedVaults: 2,
+      slashedVaults: 1,
+      slashRate: 0.5,
+      totalVaults: 4,
+    })
+  })
+
+  it('treats the date range boundaries as inclusive UTC bounds', async () => {
+    const start = '2025-02-01T00:00:00.000Z'
+    const end = '2025-02-01T23:59:59.999Z'
+
+    seedVaults([
+      {
+        id: 'v1',
+        creator: 'alice',
+        amount: '1000',
+        status: 'completed',
+        startTimestamp: '2025-02-01T00:00:00Z',
+        endTimestamp: '2025-02-02T00:00:00Z',
+        successDestination: 'success',
+        failureDestination: 'failure',
+        createdAt: start,
+        orgId: ORG_ID,
+      },
+      {
+        id: 'v2',
+        creator: 'alice',
+        amount: '2000',
+        status: 'failed',
+        startTimestamp: '2025-02-01T23:59:59Z',
+        endTimestamp: '2025-02-02T00:00:00Z',
+        successDestination: 'success',
+        failureDestination: 'failure',
+        createdAt: end,
+        orgId: ORG_ID,
+      },
+      {
+        id: 'v3',
+        creator: 'alice',
+        amount: '3000',
+        status: 'completed',
+        startTimestamp: '2025-02-02T00:00:00Z',
+        endTimestamp: '2025-02-03T00:00:00Z',
+        successDestination: 'success',
+        failureDestination: 'failure',
+        createdAt: '2025-02-02T00:00:00Z',
+        orgId: ORG_ID,
+      },
+    ])
+
+    const res = await request(app)
+      .get(`/api/orgs/${ORG_ID}/analytics/risk`)
+      .query({ startDate: start, endDate: end })
+      .set('Authorization', authHeader('alice'))
+
+    expect(res.status).toBe(200)
+    expect(res.body.analytics).toMatchObject({
+      resolvedVaults: 2,
+      totalVaults: 2,
+      slashRate: 0.5,
+      capitalAtRisk: '0',
+    })
+  })
+})


### PR DESCRIPTION
closes 
#713 
PR Summary
Adds a new org-level risk analytics endpoint that returns slash rate and capital-at-risk for an organization, with inclusive UTC date-range filtering and tenant isolation.

What changed
GET /api/orgs/:orgId/analytics/risk
Implemented aggregation logic in [analytics.service.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added route wiring in [orgAnalytics.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Mounted the new endpoint in [app-bootstrap.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Documented the metric definitions in [analytics-metrics.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Metrics
[slashRate](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

[slashedVaults / resolvedVaults](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Only counts vaults that have resolved ([completed](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) or [failed](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Excludes in-flight / active vaults from the denominator
Recognizes slash outcomes via [slash_on_miss](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [slashed](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), slash, or [failed](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[capitalAtRisk](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Sum of net staked amounts for active vaults