### PR TITLE
feat: add configurable webhook payload field masking and PII stripping

### DIFF
--- a/db/migrations/20260628150000_add_webhook_field_policy.cjs
+++ b/db/migrations/20260628150000_add_webhook_field_policy.cjs
@@ -1,0 +1,31 @@
+/**
+ * Adds field_policy column to webhook_subscribers for configurable field masking.
+ *
+ * field_policy is a JSONB column with structure:
+ * {
+ *   mode: 'allowlist' | 'denylist' | 'default',
+ *   fields: string[],       // field paths to include/exclude
+ *   stripPii: boolean       // whether to apply PII masking (default true)
+ * }
+ *
+ * When mode is 'default', standard PII stripping is applied per PRIVACY.md.
+ * When mode is 'allowlist', only specified fields are included (plus PII stripping if enabled).
+ * When mode is 'denylist', specified fields are excluded (plus PII stripping if enabled).
+ */
+exports.up = async function up(knex) {
+  const hasColumn = await knex.schema.hasColumn('webhook_subscribers', 'field_policy')
+  if (!hasColumn) {
+    await knex.schema.alterTable('webhook_subscribers', (table) => {
+      table.jsonb('field_policy').nullable().defaultTo(knex.raw("'{\"mode\": \"default\", \"fields\": [], \"stripPii\": true}'::jsonb"))
+    })
+  }
+}
+
+exports.down = async function down(knex) {
+  const hasColumn = await knex.schema.hasColumn('webhook_subscribers', 'field_policy')
+  if (hasColumn) {
+    await knex.schema.alterTable('webhook_subscribers', (table) => {
+      table.dropColumn('field_policy')
+    })
+  }
+}

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -154,6 +154,7 @@ Webhook subscribers are stored in the `webhook_subscribers` table:
 | `events` | `jsonb` | Array of event types to receive; empty array = wildcard (all events) |
 | `active` | `boolean` | Whether the subscriber is active |
 | `schema_version` | `integer` (default `1`) | Payload schema version (see Payload Schema Versioning) |
+| `field_policy` | `jsonb` | Field masking policy (see Field Masking & PII Stripping) |
 | `created_at` | `timestamptz` | Creation timestamp |
 | `updated_at` | `timestamptz` | Last update timestamp |
 
@@ -353,6 +354,166 @@ await addSubscriber(orgId, url, secret, events, 2)
 4. After the deprecation window expires the old version is **removed** and `addSubscriber` rejects it. Existing subscribers that still reference the removed version are downgraded to the earliest still-supported version and logged.
 5. The `LATEST_SCHEMA_VERSION` constant always points to the current stable version.
 6. The `SUPPORTED_SCHEMA_VERSIONS` set contains all versions that are neither removed nor deprecated.
+
+---
+
+## Field Masking & PII Stripping
+
+Each webhook subscriber can have a configurable **field policy** that controls which fields appear in delivered payloads and whether PII is stripped. Field masking is applied **before** the HMAC signature is computed, ensuring subscribers can verify the signature on the masked payload.
+
+### Field Policy Schema
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | `'default' \| 'allowlist' \| 'denylist'` | `'default'` | How to filter fields |
+| `fields` | `string[]` | `[]` | Field paths to include/exclude (depending on mode) |
+| `stripPii` | `boolean` | `true` | Whether to apply PII masking |
+
+### Policy Modes
+
+| Mode | Behavior |
+|------|----------|
+| **default** | All fields are included. If `stripPii` is true, known PII fields are masked. |
+| **allowlist** | Only fields listed in `fields` are included. All other fields are omitted. |
+| **denylist** | All fields except those listed in `fields` are included. |
+
+### Field Path Syntax
+
+Field paths use dot notation for nested fields:
+- `vaultId` - Top-level field
+- `vault.name` - Nested field
+- `vault.*` - Wildcard: matches all fields under `vault`
+
+### PII Stripping
+
+When `stripPii` is `true` (the default), the following fields are automatically masked using a deterministic SHA-256 hash (first 8 hex characters):
+
+- `creator`
+- `creatoraddress`
+- `email`
+- `failuredestination`
+- `requesteruserid`
+- `successdestination`
+- `targetuserid`
+- `userid`
+
+Additionally, email addresses and Stellar account IDs found anywhere in string values are masked.
+
+### Examples
+
+#### Default Policy (PII Stripping Enabled)
+
+```json
+{
+  "mode": "default",
+  "fields": [],
+  "stripPii": true
+}
+```
+
+Input:
+```json
+{
+  "vaultId": "123",
+  "creator": "user@example.com",
+  "amount": 1000
+}
+```
+
+Output:
+```json
+{
+  "vaultId": "123",
+  "creator": "a4d8f3c2",
+  "amount": 1000
+}
+```
+
+#### Allowlist Mode
+
+```json
+{
+  "mode": "allowlist",
+  "fields": ["vaultId", "amount"],
+  "stripPii": false
+}
+```
+
+Input:
+```json
+{
+  "vaultId": "123",
+  "creator": "user@example.com",
+  "amount": 1000,
+  "secret": "sensitive"
+}
+```
+
+Output:
+```json
+{
+  "vaultId": "123",
+  "amount": 1000
+}
+```
+
+#### Denylist Mode
+
+```json
+{
+  "mode": "denylist",
+  "fields": ["internalId", "debugInfo.*"],
+  "stripPii": true
+}
+```
+
+### Admin API
+
+#### `PATCH /api/admin/webhooks/subscribers/:id/field-policy`
+
+Updates the field policy for a subscriber.
+
+**Body:**
+```json
+{
+  "organization_id": "org-123",
+  "field_policy": {
+    "mode": "allowlist",
+    "fields": ["vaultId", "status", "amount"],
+    "stripPii": true
+  }
+}
+```
+
+**Response 200:**
+```json
+{
+  "id": "uuid",
+  "field_policy": {
+    "mode": "allowlist",
+    "fields": ["vaultId", "status", "amount"],
+    "stripPii": true
+  }
+}
+```
+
+### Database Schema
+
+The `webhook_subscribers` table includes a `field_policy` JSONB column:
+
+| Column | Type | Default | Description |
+|--------|------|---------|-------------|
+| `field_policy` | `jsonb` | `{"mode": "default", "fields": [], "stripPii": true}` | Per-subscriber field masking configuration |
+
+### Signature Implications
+
+The HMAC signature is computed **after** field masking is applied. This means:
+
+1. Different subscribers may receive different payloads for the same event (based on their field policies).
+2. Each subscriber's signature is computed over their specific masked payload.
+3. Subscribers can verify the signature using the masked payload they receive.
+
+This design ensures that the signature always matches the delivered body, regardless of masking configuration.
 
 ---
 

--- a/src/jobs/handlers.ts
+++ b/src/jobs/handlers.ts
@@ -83,7 +83,7 @@ export const createDefaultJobHandlers = (
       `exportJobId=${payload.exportJobId} attempt=${context.attempt}`,
     )
   },
-`  'vault.reconcile': async (payload, context) => {
+  'vault.reconcile': async (payload, context) => {
     const etlConfig = {
       horizonUrl: process.env.HORIZON_URL || 'https://horizon-testnet.stellar.org',
       networkPassphrase: process.env.STELLAR_NETWORK_PASSPHRASE || 'Test SDF Network ; September 2015',
@@ -100,7 +100,6 @@ export const createDefaultJobHandlers = (
       `vaultIds=${payload.vaultIds?.length || 'all'} batchSize=${payload.batchSize || 50} checked=${result.checked}/${result.totalVaults} drift=${result.driftDetected} missing=${result.missingOnChain} errors=${result.errors} attempt=${context.attempt}`,
     )
   },
-}
   'sessions.cleanup': async (payload, context) => {
     const batchSize = payload.batchSize ?? 1000
     const deleted = await cleanupExpiredSessions(batchSize)

--- a/src/jobs/types.ts
+++ b/src/jobs/types.ts
@@ -137,6 +137,7 @@ export const isPayloadForJobType = (
       return (
         (payload.vaultIds === undefined || Array.isArray(payload.vaultIds)) &&
         (payload.batchSize === undefined || typeof payload.batchSize === 'number')
+      )
     case 'sessions.cleanup':
       return payload.batchSize === undefined || (typeof payload.batchSize === 'number' && payload.batchSize > 0)
     case 'outbox.relay':

--- a/src/repositories/webhookSubscriberRepository.ts
+++ b/src/repositories/webhookSubscriberRepository.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex'
 import type { WebhookSubscriber, BreakerState, BreakerStateValue } from '../services/webhooks.js'
+import { FieldPolicy, parseFieldPolicy, DEFAULT_FIELD_POLICY } from '../utils/webhookFieldMasking.js'
 
 interface SubscriberRow {
   id: string
@@ -11,6 +12,7 @@ interface SubscriberRow {
   events: string[]
   active: boolean
   schema_version: number
+  field_policy: unknown
   created_at: Date
   updated_at: Date
 }
@@ -50,6 +52,7 @@ function toSubscriber(row: SubscriberRow): WebhookSubscriber {
     events: row.events ?? [],
     active: row.active,
     schemaVersion: row.schema_version ?? 1,
+    fieldPolicy: parseFieldPolicy(row.field_policy),
     createdAt: row.created_at instanceof Date
       ? row.created_at.toISOString()
       : String(row.created_at),
@@ -112,6 +115,7 @@ export class WebhookSubscriberRepository {
     secret: string
     events: string[]
     schemaVersion?: number
+    fieldPolicy?: FieldPolicy
   }): Promise<WebhookSubscriber> {
     const [row] = await this.db<SubscriberRow>('webhook_subscribers')
       .insert({
@@ -120,6 +124,7 @@ export class WebhookSubscriberRepository {
         secret: data.secret,
         events: JSON.stringify(data.events) as any,
         schema_version: data.schemaVersion ?? 1,
+        field_policy: JSON.stringify(data.fieldPolicy ?? DEFAULT_FIELD_POLICY) as any,
       })
       .returning('*')
     return toSubscriber(row)
@@ -143,18 +148,21 @@ export class WebhookSubscriberRepository {
     url: string
     secret: string
     events: string[]
+    fieldPolicy?: FieldPolicy
   }): Promise<WebhookSubscriber> {
+    const fieldPolicyJson = JSON.stringify(data.fieldPolicy ?? DEFAULT_FIELD_POLICY)
     const [row] = await this.db
       .raw<{ rows: SubscriberRow[] }>(
         `
-        INSERT INTO webhook_subscribers (organization_id, url, secret, events, active)
-        VALUES (:organizationId, :url, :secret, :events::jsonb, true)
+        INSERT INTO webhook_subscribers (organization_id, url, secret, events, active, field_policy)
+        VALUES (:organizationId, :url, :secret, :events::jsonb, true, :fieldPolicy::jsonb)
         ON CONFLICT (organization_id, url)
         DO UPDATE SET
-          secret     = EXCLUDED.secret,
-          events     = EXCLUDED.events,
-          active     = true,
-          updated_at = now()
+          secret       = EXCLUDED.secret,
+          events       = EXCLUDED.events,
+          field_policy = EXCLUDED.field_policy,
+          active       = true,
+          updated_at   = now()
         WHERE webhook_subscribers.organization_id = :organizationId
         RETURNING *
         `,
@@ -163,11 +171,33 @@ export class WebhookSubscriberRepository {
           url: data.url,
           secret: data.secret,
           events: JSON.stringify(data.events),
+          fieldPolicy: fieldPolicyJson,
         },
       )
       .then((result) => result.rows)
 
     return toSubscriber(row)
+  }
+
+  /**
+   * Updates the field policy for a subscriber.
+   * Returns null if the subscriber does not exist or belongs to a different org.
+   */
+  async updateFieldPolicy(
+    id: string,
+    organizationId: string,
+    fieldPolicy: FieldPolicy,
+  ): Promise<WebhookSubscriber | null> {
+    const rows = await this.db<SubscriberRow>('webhook_subscribers')
+      .where({ id, organization_id: organizationId })
+      .update({
+        field_policy: JSON.stringify(fieldPolicy) as any,
+        updated_at: this.db.fn.now(),
+      })
+      .returning('*')
+
+    if (rows.length === 0) return null
+    return toSubscriber(rows[0])
   }
 
   /**

--- a/src/routes/adminWebhooks.ts
+++ b/src/routes/adminWebhooks.ts
@@ -9,7 +9,9 @@ import {
   upsertSubscriber,
   rotateSubscriberSecret,
   listSubscribers,
+  updateSubscriberFieldPolicy,
 } from '../services/webhooks.js'
+import { isValidFieldPolicy, FieldPolicy } from '../utils/webhookFieldMasking.js'
 
 export const adminWebhooksRouter = Router()
 
@@ -156,6 +158,7 @@ adminWebhooksRouter.get('/subscribers', async (req: Request, res: Response) => {
         active: s.active,
         created_at: s.createdAt,
         rotated_at: s.rotatedAt,
+        field_policy: s.fieldPolicy,
       })),
     })
   } catch (error) {
@@ -214,6 +217,62 @@ adminWebhooksRouter.post(
     } catch (error) {
       console.error('Error rotating webhook subscriber secret:', error)
       res.status(500).json({ error: 'Failed to rotate secret' })
+    }
+  },
+)
+
+/**
+ * PATCH /api/admin/webhooks/subscribers/:id/field-policy
+ *
+ * Updates the field masking policy for a subscriber. The policy controls
+ * which fields are included in webhook payloads and whether PII is stripped.
+ *
+ * Body: { organization_id, field_policy: { mode, fields, stripPii } }
+ * Response 200: { id, field_policy }
+ */
+adminWebhooksRouter.patch(
+  '/subscribers/:id/field-policy',
+  async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params
+      const { organization_id, field_policy } = req.body ?? {}
+
+      if (!organization_id || typeof organization_id !== 'string') {
+        res.status(400).json({ error: 'organization_id is required' })
+        return
+      }
+      if (!field_policy || !isValidFieldPolicy(field_policy)) {
+        res.status(400).json({
+          error: 'field_policy must be an object with mode ("default", "allowlist", or "denylist"), fields (string array), and stripPii (boolean)',
+        })
+        return
+      }
+
+      const updated = await updateSubscriberFieldPolicy(id, organization_id, field_policy)
+
+      if (!updated) {
+        res.status(404).json({ error: 'Subscriber not found' })
+        return
+      }
+
+      createAuditLog({
+        actor_user_id: req.user!.userId,
+        action: 'webhook.subscriber.update_field_policy',
+        target_type: 'webhook_subscriber',
+        target_id: id,
+        metadata: {
+          organizationId: organization_id,
+          fieldPolicy: field_policy,
+        },
+      })
+
+      res.status(200).json({
+        id: updated.id,
+        field_policy: updated.fieldPolicy,
+      })
+    } catch (error) {
+      console.error('Error updating webhook subscriber field policy:', error)
+      res.status(500).json({ error: 'Failed to update field policy' })
     }
   },
 )

--- a/src/services/featureFlags.ts
+++ b/src/services/featureFlags.ts
@@ -223,6 +223,8 @@ export async function getFlag(
         cache.set(cacheKey, value)
         return value
       }
+    } catch (error) {
+      console.error(`Error fetching org-specific flag ${name} for ${orgId}:`, error)
     }
   }
 

--- a/src/services/soroban.ts
+++ b/src/services/soroban.ts
@@ -652,7 +652,6 @@ export const createDefaultSorobanClient = (
       return null
     }
   },
-}
 })
 
 export const defaultSorobanClient: SorobanClient = createDefaultSorobanClient()

--- a/src/services/webhooks.ts
+++ b/src/services/webhooks.ts
@@ -3,6 +3,7 @@ import { isIP } from 'node:net'
 import { WebhookSubscriberRepository } from '../repositories/webhookSubscriberRepository.js'
 import { retryWithBackoff } from '../utils/retry.js'
 import { db } from '../db/index.js'
+import { applyFieldMasking, FieldPolicy, DEFAULT_FIELD_POLICY, parseFieldPolicy } from '../utils/webhookFieldMasking.js'
 
 export interface WebhookDeadLetter {
   id: string
@@ -37,6 +38,11 @@ export interface WebhookSubscriber {
   active: boolean
   createdAt: string
   schemaVersion: number
+  /**
+   * Per-subscriber field masking policy. Controls which fields are included
+   * in webhook payloads and whether PII is stripped. Applied before signing.
+   */
+  fieldPolicy: FieldPolicy
 }
 
 export const LATEST_SCHEMA_VERSION = 2
@@ -86,6 +92,10 @@ export interface CircuitBreakerConfig {
  * Builds the HTTP request body for a webhook delivery according to the
  * subscriber's preferred schema version.
  *
+ * Field masking is applied BEFORE serialization, so the signature is computed
+ * on the masked payload. This ensures subscribers can verify the signature
+ * even when fields are filtered or PII is stripped.
+ *
  * v1 – Original shape with schema_version appended:
  *   { eventId, eventType, timestamp, data, organizationId, schema_version: 1 }
  *
@@ -96,13 +106,17 @@ export const buildVersionedPayload = (
   subscriber: WebhookSubscriber,
   payload: WebhookDeliveryPayload,
 ): string => {
+  // Apply field masking policy to the data before serialization
+  const fieldPolicy = subscriber.fieldPolicy ?? DEFAULT_FIELD_POLICY
+  const maskedData = applyFieldMasking(payload.data, fieldPolicy)
+
   switch (subscriber.schemaVersion) {
     case 1:
       return JSON.stringify({
         eventId: payload.eventId,
         eventType: payload.eventType,
         timestamp: payload.timestamp,
-        data: payload.data,
+        data: maskedData,
         organizationId: payload.organizationId,
         schema_version: 1,
       })
@@ -110,7 +124,7 @@ export const buildVersionedPayload = (
       return JSON.stringify({
         schema_version: 2,
         event_type: payload.eventType,
-        data: payload.data,
+        data: maskedData,
       })
     default:
       throw new Error(
@@ -533,6 +547,18 @@ export const isPreviousSecretInGrace = (subscriber: WebhookSubscriber): boolean 
 
 export const listSubscribers = async (organizationId: string): Promise<WebhookSubscriber[]> =>
   repo.findByOrg(organizationId)
+
+/**
+ * Updates the field masking policy for a subscriber.
+ * Returns null when the subscriber does not exist or belongs to a different org.
+ */
+export const updateSubscriberFieldPolicy = async (
+  id: string,
+  organizationId: string,
+  fieldPolicy: FieldPolicy,
+): Promise<WebhookSubscriber | null> => {
+  return repo.updateFieldPolicy(id, organizationId, fieldPolicy)
+}
 
 /** Test helper – clears all subscribers from the database. */
 export const resetSubscribers = async (): Promise<void> => {

--- a/src/tests/webhooks.fieldMasking.test.ts
+++ b/src/tests/webhooks.fieldMasking.test.ts
@@ -1,0 +1,401 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { randomUUID } from 'node:crypto'
+import type { WebhookSubscriber } from '../services/webhooks.js'
+import {
+  applyFieldMasking,
+  isValidFieldPolicy,
+  parseFieldPolicy,
+  DEFAULT_FIELD_POLICY,
+  FieldPolicy,
+} from '../utils/webhookFieldMasking.js'
+
+const mockSubscribers: WebhookSubscriber[] = []
+
+jest.unstable_mockModule('../db/knex.js', () => ({
+  db: {} as any,
+  closeDatabase: jest.fn(),
+}))
+
+jest.unstable_mockModule('../repositories/webhookSubscriberRepository.js', () => ({
+  WebhookSubscriberRepository: jest.fn().mockImplementation(() => ({
+    findByOrg: jest.fn(async (orgId: string) =>
+      mockSubscribers.filter((s) => s.organizationId === orgId),
+    ),
+    findById: jest.fn(async (id: string) =>
+      mockSubscribers.find((s) => s.id === id) ?? null,
+    ),
+    findByEvent: jest.fn(async (orgId: string, event: string) =>
+      mockSubscribers.filter(
+        (s) => s.organizationId === orgId && (s.events.length === 0 || s.events.includes(event)) && s.active,
+      ),
+    ),
+    create: jest.fn(async (data: any) => {
+      const sub: WebhookSubscriber = {
+        id: randomUUID(),
+        organizationId: data.organizationId,
+        url: data.url,
+        secret: data.secret,
+        previousSecret: null,
+        rotatedAt: null,
+        events: [...data.events],
+        active: true,
+        schemaVersion: data.schemaVersion ?? 1,
+        fieldPolicy: data.fieldPolicy ?? DEFAULT_FIELD_POLICY,
+        createdAt: new Date().toISOString(),
+      }
+      mockSubscribers.push(sub)
+      return sub
+    }),
+    remove: jest.fn(async (id: string) => {
+      const idx = mockSubscribers.findIndex((s) => s.id === id)
+      if (idx !== -1) mockSubscribers.splice(idx, 1)
+    }),
+    getBreakerState: jest.fn(async () => null),
+    upsertBreakerState: jest.fn(async () => {}),
+    tryTransitionToHalfOpen: jest.fn(async () => false),
+    removeBreakerState: jest.fn(async () => true),
+    getAllBreakerStates: jest.fn(async () => []),
+    updateFieldPolicy: jest.fn(async (id: string, orgId: string, fieldPolicy: FieldPolicy) => {
+      const sub = mockSubscribers.find((s) => s.id === id && s.organizationId === orgId)
+      if (!sub) return null
+      sub.fieldPolicy = fieldPolicy
+      return sub
+    }),
+  })),
+}))
+
+const { buildVersionedPayload, dispatchWebhookEvent } = await import('../services/webhooks.js')
+
+const TEST_ORG = 'test-org-id'
+
+const makePayload = (overrides: Record<string, any> = {}) => ({
+  eventId: randomUUID(),
+  eventType: 'vault_created',
+  timestamp: new Date().toISOString(),
+  data: {
+    vaultId: randomUUID(),
+    name: 'test-vault',
+    creator: 'user123',
+    userId: 'user-abc',
+    email: 'user@example.com',
+    amount: 1000,
+    nested: {
+      sensitiveField: 'secret-value',
+      normalField: 'visible-value',
+    },
+  },
+  organizationId: TEST_ORG,
+  ...overrides,
+})
+
+const makeSubscriber = (overrides: Record<string, any> = {}): WebhookSubscriber => ({
+  id: randomUUID(),
+  organizationId: TEST_ORG,
+  url: 'https://hooks.example.com/webhook',
+  secret: 'test-secret',
+  previousSecret: null,
+  rotatedAt: null,
+  events: ['vault_created'],
+  active: true,
+  schemaVersion: 1,
+  fieldPolicy: DEFAULT_FIELD_POLICY,
+  createdAt: new Date().toISOString(),
+  ...overrides,
+})
+
+beforeEach(() => {
+  mockSubscribers.length = 0
+})
+
+// ── isValidFieldPolicy ─────────────────────────────────────────────────────────
+
+describe('isValidFieldPolicy', () => {
+  it('returns true for valid default policy', () => {
+    expect(isValidFieldPolicy({ mode: 'default', fields: [], stripPii: true })).toBe(true)
+  })
+
+  it('returns true for valid allowlist policy', () => {
+    expect(isValidFieldPolicy({ mode: 'allowlist', fields: ['id', 'name'], stripPii: true })).toBe(true)
+  })
+
+  it('returns true for valid denylist policy', () => {
+    expect(isValidFieldPolicy({ mode: 'denylist', fields: ['secret'], stripPii: false })).toBe(true)
+  })
+
+  it('returns false for null', () => {
+    expect(isValidFieldPolicy(null)).toBe(false)
+  })
+
+  it('returns false for invalid mode', () => {
+    expect(isValidFieldPolicy({ mode: 'invalid', fields: [], stripPii: true })).toBe(false)
+  })
+
+  it('returns false for non-array fields', () => {
+    expect(isValidFieldPolicy({ mode: 'default', fields: 'id', stripPii: true })).toBe(false)
+  })
+
+  it('returns false for non-boolean stripPii', () => {
+    expect(isValidFieldPolicy({ mode: 'default', fields: [], stripPii: 'yes' })).toBe(false)
+  })
+})
+
+// ── parseFieldPolicy ───────────────────────────────────────────────────────────
+
+describe('parseFieldPolicy', () => {
+  it('returns valid policy as-is', () => {
+    const policy = { mode: 'allowlist' as const, fields: ['id'], stripPii: true }
+    expect(parseFieldPolicy(policy)).toEqual(policy)
+  })
+
+  it('returns default policy for null', () => {
+    expect(parseFieldPolicy(null)).toEqual(DEFAULT_FIELD_POLICY)
+  })
+
+  it('returns default policy for invalid input', () => {
+    expect(parseFieldPolicy({ mode: 'invalid' })).toEqual(DEFAULT_FIELD_POLICY)
+  })
+})
+
+// ── applyFieldMasking ──────────────────────────────────────────────────────────
+
+describe('applyFieldMasking', () => {
+  describe('default mode', () => {
+    it('passes through all fields when stripPii is false', () => {
+      const data = { id: '123', name: 'Test', creator: 'user1' }
+      const result = applyFieldMasking(data, { mode: 'default', fields: [], stripPii: false })
+      expect(result).toEqual(data)
+    })
+
+    it('masks PII fields when stripPii is true', () => {
+      const data = { id: '123', name: 'Test', creator: 'user1', email: 'test@example.com' }
+      const result = applyFieldMasking(data, { mode: 'default', fields: [], stripPii: true })
+      expect(result.id).toBe('123')
+      expect(result.name).toBe('Test')
+      expect(result.creator).not.toBe('user1')
+      expect(result.email).not.toBe('test@example.com')
+      // Verify it's masked (should be 8-char hex)
+      expect(typeof result.creator).toBe('string')
+      expect((result.creator as string).length).toBe(8)
+    })
+  })
+
+  describe('allowlist mode', () => {
+    it('only includes specified fields', () => {
+      const data = { id: '123', name: 'Test', secret: 'hidden' }
+      const result = applyFieldMasking(data, { mode: 'allowlist', fields: ['id', 'name'], stripPii: false })
+      expect(result).toEqual({ id: '123', name: 'Test' })
+    })
+
+    it('supports nested field paths', () => {
+      const data = { id: '123', nested: { allowed: 'yes', denied: 'no' } }
+      const result = applyFieldMasking(data, {
+        mode: 'allowlist',
+        fields: ['id', 'nested.allowed'],
+        stripPii: false,
+      })
+      expect(result).toEqual({ id: '123', nested: { allowed: 'yes' } })
+    })
+
+    it('supports wildcard patterns', () => {
+      const data = { id: '123', vault: { name: 'Test', status: 'active' }, other: 'excluded' }
+      const result = applyFieldMasking(data, {
+        mode: 'allowlist',
+        fields: ['id', 'vault.*'],
+        stripPii: false,
+      })
+      expect(result).toEqual({ id: '123', vault: { name: 'Test', status: 'active' } })
+    })
+
+    it('still applies PII masking when stripPii is true', () => {
+      const data = { id: '123', creator: 'user1' }
+      const result = applyFieldMasking(data, {
+        mode: 'allowlist',
+        fields: ['id', 'creator'],
+        stripPii: true,
+      })
+      expect(result.id).toBe('123')
+      expect(result.creator).not.toBe('user1')
+    })
+  })
+
+  describe('denylist mode', () => {
+    it('excludes specified fields', () => {
+      const data = { id: '123', name: 'Test', secret: 'hidden' }
+      const result = applyFieldMasking(data, { mode: 'denylist', fields: ['secret'], stripPii: false })
+      expect(result).toEqual({ id: '123', name: 'Test' })
+    })
+
+    it('supports nested field paths', () => {
+      const data = { id: '123', nested: { public: 'yes', private: 'no' } }
+      const result = applyFieldMasking(data, {
+        mode: 'denylist',
+        fields: ['nested.private'],
+        stripPii: false,
+      })
+      expect(result).toEqual({ id: '123', nested: { public: 'yes' } })
+    })
+
+    it('supports wildcard patterns', () => {
+      const data = { id: '123', internal: { a: '1', b: '2' }, public: 'visible' }
+      const result = applyFieldMasking(data, {
+        mode: 'denylist',
+        fields: ['internal.*'],
+        stripPii: false,
+      })
+      expect(result).toEqual({ id: '123', public: 'visible' })
+    })
+  })
+})
+
+// ── buildVersionedPayload with field masking ───────────────────────────────────
+
+describe('buildVersionedPayload with field masking', () => {
+  const payload = makePayload()
+
+  it('applies default PII stripping by default', () => {
+    const subscriber = makeSubscriber({ fieldPolicy: DEFAULT_FIELD_POLICY })
+    const json = JSON.parse(buildVersionedPayload(subscriber, payload))
+
+    // PII fields should be masked
+    expect(json.data.creator).not.toBe(payload.data.creator)
+    expect(json.data.userId).not.toBe(payload.data.userId)
+    expect(json.data.email).not.toBe(payload.data.email)
+
+    // Non-PII fields should be preserved
+    expect(json.data.vaultId).toBe(payload.data.vaultId)
+    expect(json.data.name).toBe(payload.data.name)
+    expect(json.data.amount).toBe(payload.data.amount)
+  })
+
+  it('respects stripPii: false in field policy', () => {
+    const subscriber = makeSubscriber({
+      fieldPolicy: { mode: 'default', fields: [], stripPii: false },
+    })
+    const json = JSON.parse(buildVersionedPayload(subscriber, payload))
+
+    // All fields should be preserved including PII
+    expect(json.data.creator).toBe(payload.data.creator)
+    expect(json.data.userId).toBe(payload.data.userId)
+    expect(json.data.email).toBe(payload.data.email)
+  })
+
+  it('applies allowlist filtering', () => {
+    const subscriber = makeSubscriber({
+      fieldPolicy: { mode: 'allowlist', fields: ['vaultId', 'name', 'amount'], stripPii: false },
+    })
+    const json = JSON.parse(buildVersionedPayload(subscriber, payload))
+
+    expect(json.data.vaultId).toBe(payload.data.vaultId)
+    expect(json.data.name).toBe(payload.data.name)
+    expect(json.data.amount).toBe(payload.data.amount)
+    expect(json.data.creator).toBeUndefined()
+    expect(json.data.userId).toBeUndefined()
+    expect(json.data.email).toBeUndefined()
+  })
+
+  it('applies denylist filtering', () => {
+    const subscriber = makeSubscriber({
+      fieldPolicy: { mode: 'denylist', fields: ['creator', 'userId', 'email'], stripPii: false },
+    })
+    const json = JSON.parse(buildVersionedPayload(subscriber, payload))
+
+    expect(json.data.vaultId).toBe(payload.data.vaultId)
+    expect(json.data.name).toBe(payload.data.name)
+    expect(json.data.amount).toBe(payload.data.amount)
+    expect(json.data.creator).toBeUndefined()
+    expect(json.data.userId).toBeUndefined()
+    expect(json.data.email).toBeUndefined()
+  })
+
+  it('signature is computed on masked payload', () => {
+    const subscriber1 = makeSubscriber({
+      fieldPolicy: { mode: 'default', fields: [], stripPii: true },
+    })
+    const subscriber2 = makeSubscriber({
+      fieldPolicy: { mode: 'default', fields: [], stripPii: false },
+    })
+
+    const body1 = buildVersionedPayload(subscriber1, payload)
+    const body2 = buildVersionedPayload(subscriber2, payload)
+
+    // Bodies should be different due to masking
+    expect(body1).not.toBe(body2)
+  })
+})
+
+// ── dispatchWebhookEvent with field masking ────────────────────────────────────
+
+describe('dispatchWebhookEvent with field masking', () => {
+  let fetchMock: jest.MockedFunction<typeof fetch>
+
+  beforeEach(() => {
+    mockSubscribers.length = 0
+    fetchMock = jest.fn<typeof fetch>()
+    global.fetch = fetchMock as any
+  })
+
+  afterEach(() => {
+    mockSubscribers.length = 0
+    jest.restoreAllMocks()
+  })
+
+  it('delivers masked payload to subscriber with PII stripping', async () => {
+    fetchMock.mockResolvedValue({ status: 200 } as Response)
+
+    mockSubscribers.push(makeSubscriber({
+      fieldPolicy: { mode: 'default', fields: [], stripPii: true },
+    }))
+
+    const payload = makePayload()
+    await dispatchWebhookEvent(payload)
+
+    const call = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(call[1].body as string)
+
+    // PII should be masked
+    expect(body.data.creator).not.toBe(payload.data.creator)
+  })
+
+  it('delivers unmasked payload when stripPii is false', async () => {
+    fetchMock.mockResolvedValue({ status: 200 } as Response)
+
+    mockSubscribers.push(makeSubscriber({
+      fieldPolicy: { mode: 'default', fields: [], stripPii: false },
+    }))
+
+    const payload = makePayload()
+    await dispatchWebhookEvent(payload)
+
+    const call = (global.fetch as jest.Mock).mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(call[1].body as string)
+
+    expect(body.data.creator).toBe(payload.data.creator)
+    expect(body.data.email).toBe(payload.data.email)
+  })
+
+  it('different subscribers receive differently masked payloads', async () => {
+    fetchMock.mockResolvedValue({ status: 200 } as Response)
+
+    mockSubscribers.push(makeSubscriber({
+      url: 'https://hooks.example.com/masked',
+      fieldPolicy: { mode: 'default', fields: [], stripPii: true },
+    }))
+    mockSubscribers.push(makeSubscriber({
+      url: 'https://hooks.example.com/unmasked',
+      fieldPolicy: { mode: 'default', fields: [], stripPii: false },
+    }))
+
+    const payload = makePayload()
+    await dispatchWebhookEvent(payload)
+
+    const calls = (global.fetch as jest.Mock).mock.calls as [string, RequestInit][]
+    const maskedCall = calls.find(([url]) => url === 'https://hooks.example.com/masked')!
+    const unmaskedCall = calls.find(([url]) => url === 'https://hooks.example.com/unmasked')!
+
+    const maskedBody = JSON.parse(maskedCall[1].body as string)
+    const unmaskedBody = JSON.parse(unmaskedCall[1].body as string)
+
+    expect(maskedBody.data.creator).not.toBe(payload.data.creator)
+    expect(unmaskedBody.data.creator).toBe(payload.data.creator)
+  })
+})

--- a/src/utils/webhookFieldMasking.ts
+++ b/src/utils/webhookFieldMasking.ts
@@ -1,0 +1,224 @@
+import { maskPii, isPrivacySensitiveField, sanitizePrivacyPayload } from './privacy.js'
+
+export type FieldPolicyMode = 'default' | 'allowlist' | 'denylist'
+
+export interface FieldPolicy {
+  mode: FieldPolicyMode
+  fields: string[]
+  stripPii: boolean
+}
+
+export const DEFAULT_FIELD_POLICY: FieldPolicy = {
+  mode: 'default',
+  fields: [],
+  stripPii: true,
+}
+
+/**
+ * Validates a FieldPolicy object structure.
+ */
+export function isValidFieldPolicy(value: unknown): value is FieldPolicy {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const policy = value as Record<string, unknown>
+
+  if (!['default', 'allowlist', 'denylist'].includes(policy.mode as string)) {
+    return false
+  }
+
+  if (!Array.isArray(policy.fields)) {
+    return false
+  }
+
+  if (!policy.fields.every((f) => typeof f === 'string')) {
+    return false
+  }
+
+  if (typeof policy.stripPii !== 'boolean') {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Parses a FieldPolicy from JSONB, returning defaults for invalid/null input.
+ */
+export function parseFieldPolicy(value: unknown): FieldPolicy {
+  if (isValidFieldPolicy(value)) {
+    return value
+  }
+  return { ...DEFAULT_FIELD_POLICY }
+}
+
+/**
+ * Gets a nested value from an object using dot notation.
+ * Example: getNestedValue({ vault: { id: '123' } }, 'vault.id') => '123'
+ */
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.')
+  let current: unknown = obj
+
+  for (const part of parts) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      return undefined
+    }
+    current = (current as Record<string, unknown>)[part]
+  }
+
+  return current
+}
+
+/**
+ * Sets a nested value in an object using dot notation.
+ * Creates intermediate objects as needed.
+ */
+function setNestedValue(obj: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split('.')
+  let current = obj
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i]
+    if (!(part in current) || typeof current[part] !== 'object' || current[part] === null) {
+      current[part] = {}
+    }
+    current = current[part] as Record<string, unknown>
+  }
+
+  current[parts[parts.length - 1]] = value
+}
+
+/**
+ * Checks if a field path matches an allowlist/denylist pattern.
+ * Supports exact matches and prefix matching with wildcards.
+ * Example: 'vault.*' matches 'vault.id', 'vault.name', etc.
+ */
+function fieldMatchesPattern(field: string, pattern: string): boolean {
+  if (pattern.endsWith('.*')) {
+    const prefix = pattern.slice(0, -2)
+    return field === prefix || field.startsWith(prefix + '.')
+  }
+  return field === pattern
+}
+
+/**
+ * Checks if a field should be included based on the policy.
+ */
+function shouldIncludeField(field: string, policy: FieldPolicy): boolean {
+  switch (policy.mode) {
+    case 'allowlist':
+      return policy.fields.some((pattern) => fieldMatchesPattern(field, pattern))
+    case 'denylist':
+      return !policy.fields.some((pattern) => fieldMatchesPattern(field, pattern))
+    case 'default':
+    default:
+      return true
+  }
+}
+
+/**
+ * Recursively collects all field paths from an object.
+ */
+function collectFieldPaths(obj: unknown, prefix = ''): string[] {
+  const paths: string[] = []
+
+  if (obj === null || obj === undefined || typeof obj !== 'object') {
+    return paths
+  }
+
+  if (Array.isArray(obj)) {
+    // For arrays, we include the array field but don't recurse into indexed items for filtering
+    return paths
+  }
+
+  for (const key of Object.keys(obj)) {
+    const fullPath = prefix ? `${prefix}.${key}` : key
+    paths.push(fullPath)
+
+    const value = (obj as Record<string, unknown>)[key]
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      paths.push(...collectFieldPaths(value, fullPath))
+    }
+  }
+
+  return paths
+}
+
+/**
+ * Filters an object based on allowlist/denylist field policy.
+ */
+function filterByFieldPolicy(payload: Record<string, unknown>, policy: FieldPolicy): Record<string, unknown> {
+  if (policy.mode === 'default') {
+    return payload
+  }
+
+  const allPaths = collectFieldPaths(payload)
+  const result: Record<string, unknown> = {}
+
+  for (const path of allPaths) {
+    if (shouldIncludeField(path, policy)) {
+      const value = getNestedValue(payload, path)
+      // Only set leaf values (non-object or arrays)
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        setNestedValue(result, path, value)
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * Masks PII fields in the payload using deterministic hashing.
+ */
+function maskPiiFields(payload: Record<string, unknown>): Record<string, unknown> {
+  return sanitizePrivacyPayload(payload) as Record<string, unknown>
+}
+
+/**
+ * Applies field masking policy to a webhook payload.
+ * This should be called BEFORE signing the payload.
+ *
+ * @param payload - The original webhook payload
+ * @param policy - The field policy to apply
+ * @returns The masked/filtered payload
+ */
+export function applyFieldMasking(
+  payload: Record<string, unknown>,
+  policy: FieldPolicy = DEFAULT_FIELD_POLICY
+): Record<string, unknown> {
+  // First apply allowlist/denylist filtering
+  let result = filterByFieldPolicy(payload, policy)
+
+  // Then apply PII stripping if enabled
+  if (policy.stripPii) {
+    result = maskPiiFields(result)
+  }
+
+  return result
+}
+
+/**
+ * Creates a human-readable description of a field policy for documentation.
+ */
+export function describeFieldPolicy(policy: FieldPolicy): string {
+  const parts: string[] = []
+
+  switch (policy.mode) {
+    case 'allowlist':
+      parts.push(`Allowlist: ${policy.fields.length > 0 ? policy.fields.join(', ') : '(none)'}`)
+      break
+    case 'denylist':
+      parts.push(`Denylist: ${policy.fields.length > 0 ? policy.fields.join(', ') : '(none)'}`)
+      break
+    case 'default':
+      parts.push('Default policy')
+      break
+  }
+
+  parts.push(`PII stripping: ${policy.stripPii ? 'enabled' : 'disabled'}`)
+
+  return parts.join('; ')
+}


### PR DESCRIPTION
## Summary

  Adds configurable webhook payload field masking and PII stripping per Issue #847.

  - **Per-subscriber field policy**: Each webhook subscriber can now have a `field_policy` that controls which fields are included in payloads
  - **Three modes**: `default` (all fields, PII stripped), `allowlist` (only specified fields), `denylist` (all except specified)
  - **PII stripping**: Uses existing `privacy.ts` utilities to mask known PII fields with deterministic SHA-256 hashes
  - **Nested field support**: Dot notation (`vault.name`) and wildcards (`vault.*`) for precise control
  - **Pre-signing masking**: Field masking is applied BEFORE HMAC signature computation, ensuring verifiable payloads

  ### Changes

  - `db/migrations/20260628150000_add_webhook_field_policy.cjs` - Adds `field_policy` JSONB column
  - `src/utils/webhookFieldMasking.ts` - Field masking utilities with allowlist/denylist support
  - `src/services/webhooks.ts` - Integrates masking into `buildVersionedPayload()`
  - `src/repositories/webhookSubscriberRepository.ts` - Repository updates for field_policy
  - `src/routes/adminWebhooks.ts` - New `PATCH /api/admin/webhooks/subscribers/:id/field-policy` endpoint
  - `docs/webhooks.md` - Comprehensive documentation for field masking

  ### Bonus fixes

  Fixed pre-existing syntax errors in `handlers.ts`, `types.ts`, `featureFlags.ts`, and `soroban.ts` that blocked TypeScript compilation.

  ## Test plan

  - [x] 27 new field masking tests pass
  - [x] Existing webhook schema versioning tests pass (11 tests)
  - [ ] Run full test suite
  - [ ] Run database migration on staging
  - [ ] Test API endpoint with sample field policies

  Closes #847