### PR TITLE
feat: slow-query ring buffer with admin inspection endpoint

### DIFF
--- a/docs/operations-metrics.md
+++ b/docs/operations-metrics.md
@@ -469,3 +469,72 @@ export const metricsRateLimiter = createRateLimiter({
 - **Query Execution Plans:** Optional EXPLAIN ANALYZE integration
 - **Performance Baselines:** Track metrics against expected SLAs
 - **Alerting Integration:** Send warnings to PagerDuty/Slack when thresholds exceeded
+
+---
+
+## Slow-Query Ring Buffer
+
+### Overview
+
+In addition to the aggregated `SlowQueryTracker`, the service maintains an in-process **ring buffer** that records every individual slow query as it happens. Entries are fingerprints only — raw parameter values are never stored.
+
+**Endpoint:** `GET /api/admin/db/slow-queries`
+**Authentication:** Required (Bearer token)
+**Authorization:** Admin only
+**Response:** Entries ordered oldest → newest
+
+### Configuration
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `SLOW_QUERY_THRESHOLD_MS` | `200` | Minimum duration (ms) before a query is captured |
+| `SLOW_QUERY_BUFFER_SIZE` | `100` | Maximum entries in the ring buffer (oldest evicted on overflow) |
+
+### Response Format
+
+```json
+{
+  "data": {
+    "count": 2,
+    "thresholdMs": 200,
+    "bufferSize": 100,
+    "entries": [
+      {
+        "fingerprint": "select * from vaults where id = ?",
+        "durationMs": 312,
+        "capturedAt": "2026-06-28T00:00:01.000Z"
+      },
+      {
+        "fingerprint": "select * from transactions where user_id = ? and status = ?",
+        "durationMs": 485,
+        "capturedAt": "2026-06-28T00:00:05.000Z"
+      }
+    ]
+  }
+}
+```
+
+### Fingerprinting
+
+SQL strings are normalized before storage to strip all literal values:
+
+| Pattern | Replaced with |
+|---------|---------------|
+| Quoted strings `'value'` | `?` |
+| Integer literals `42` | `?` |
+| Float literals `3.14` | `?` |
+| Positional params `$1`, `$2` | `?` |
+
+Whitespace is collapsed and the fingerprint is capped at 200 characters.
+
+### Knex Integration
+
+`captureSlowQuery` is called automatically via Knex event hooks in `src/db/knex.ts`:
+
+- `query` — records start time keyed by `__knexQueryUid`
+- `query-response` — computes elapsed time and calls `captureSlowQuery`
+- `query-error` — same as above, so failed slow queries are also captured
+
+### Memory Footprint
+
+Each entry holds a fingerprint string (≤200 chars), a number, and an ISO timestamp string. At the default buffer size of 100 entries this is well under 100 KB.

--- a/src/db/knex.ts
+++ b/src/db/knex.ts
@@ -1,10 +1,33 @@
 import { createRequire } from 'module'
 import knex, { Knex } from 'knex'
+import { captureSlowQuery } from '../services/dbMetrics.js'
 
 const nodeRequire = createRequire(import.meta.url)
 const config = nodeRequire('../../knexfile.cjs')
 
 export const db: Knex = knex(config)
+
+// Track query start times keyed by Knex's internal __knexQueryUid
+const queryStart = new Map<string, number>()
+
+db.on('query', (q: { __knexQueryUid: string }) => {
+  queryStart.set(q.__knexQueryUid, Date.now())
+})
+
+function finish(q: { __knexQueryUid: string; sql: string }): void {
+  const start = queryStart.get(q.__knexQueryUid)
+  if (start === undefined) return
+  queryStart.delete(q.__knexQueryUid)
+  captureSlowQuery(q.sql, Date.now() - start)
+}
+
+db.on('query-response', (_response: unknown, q: { __knexQueryUid: string; sql: string }) => {
+  finish(q)
+})
+
+db.on('query-error', (_error: unknown, q: { __knexQueryUid: string; sql: string }) => {
+  finish(q)
+})
 
 export async function closeDatabase(): Promise<void> {
   await db.destroy()

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from 'express'
+import { Router, Request, Response, NextFunction } from 'express'
 import { requireAdmin } from '../middleware/rbac.js'
 import { queryParser } from '../middleware/queryParser.js'
 import { authenticate } from '../middleware/auth.js'
@@ -14,7 +14,7 @@ import {
   verifyAuditLogChain,
 } from '../lib/audit-logs.js'
 import { cancelVaultById } from '../services/vaultStore.js'
-import { getDBHealthMetrics } from '../services/dbMetrics.js'
+import { getDBHealthMetrics, getSlowQueryBuffer } from '../services/dbMetrics.js'
 import {
   getFlag,
   setFlag,
@@ -25,6 +25,7 @@ import {
 import { pool } from '../db/index.js'
 import { db } from '../db/knex.js'
 import { getAbuseCategoryCounts } from '../security/abuse-monitor.js'
+import { metricsRateLimiter } from '../middleware/rateLimiter.js'
 import { CheckpointStore } from '../services/checkpointStore.js'
 import { getLatestListenerLag } from '../services/monitor.js'
 import { generateImpersonationToken } from '../lib/auth-utils.js'
@@ -760,6 +761,23 @@ adminRouter.get('/db/metrics', metricsRateLimiter, async (req: Request, res: Res
     console.error('Error retrieving DB metrics:', error)
     res.status(500).json({ error: 'Failed to retrieve database metrics' })
   }
+})
+
+/**
+ * GET /api/admin/db/slow-queries
+ * Returns the ring-buffered slow-query samples (admin only).
+ * Entries are ordered oldest → newest; fingerprints only, no raw parameters.
+ */
+adminRouter.get('/db/slow-queries', (req: Request, res: Response) => {
+  const entries = getSlowQueryBuffer()
+  res.status(200).json({
+    data: {
+      count: entries.length,
+      thresholdMs: (() => { const v = parseInt(process.env.SLOW_QUERY_THRESHOLD_MS ?? '200', 10); return Math.max(0, isNaN(v) ? 200 : v) })(),
+      bufferSize: (() => { const v = parseInt(process.env.SLOW_QUERY_BUFFER_SIZE ?? '100', 10); return Math.max(1, isNaN(v) ? 100 : v) })(),
+      entries,
+    },
+  })
 })
 
 /**

--- a/src/services/dbMetrics.ts
+++ b/src/services/dbMetrics.ts
@@ -257,3 +257,88 @@ export function resetEmbeddingReindexProgress(): void {
 }
 
 export { SlowQueryTracker, PoolMetrics, DBHealthMetrics, SlowQuerySample }
+
+// ── Slow-query ring buffer ────────────────────────────────────────────────────
+
+/** A single entry in the ring buffer – fingerprint only, never raw parameters. */
+export interface SlowQueryEntry {
+  /** Normalized SQL fingerprint with literals replaced by placeholders. */
+  fingerprint: string
+  /** Observed duration in milliseconds. */
+  durationMs: number
+  /** ISO 8601 capture timestamp. */
+  capturedAt: string
+}
+
+const getThresholdMs = (): number => {
+  const v = parseInt(process.env.SLOW_QUERY_THRESHOLD_MS ?? '200', 10)
+  return Math.max(0, isNaN(v) ? 200 : v)
+}
+
+const getBufferSize = (): number => {
+  const v = parseInt(process.env.SLOW_QUERY_BUFFER_SIZE ?? '100', 10)
+  return Math.max(1, isNaN(v) ? 100 : v)
+}
+
+/** Normalizes a SQL string into a parameter-free fingerprint. */
+export function fingerprintSql(sql: string): string {
+  return sql
+    .replace(/'[^']*'/g, '?')                              // quoted strings
+    .replace(/\$\d+/g, '?')                                // $1 $2 … positional params (before int regex)
+    .replace(/\b\d+\.\d+\b/g, '?')                         // float literals (before int regex)
+    .replace(/\b\d+\b/g, '?')                              // integer literals
+    .replace(/\s+/g, ' ')
+    .trim()
+    .substring(0, 200)
+}
+
+class SlowQueryRingBuffer {
+  private buf: SlowQueryEntry[] = []
+  private head = 0   // next write slot
+
+  private get size(): number { return getBufferSize() }
+
+  record(sql: string, durationMs: number): void {
+    if (durationMs < getThresholdMs()) return
+    const entry: SlowQueryEntry = {
+      fingerprint: fingerprintSql(sql),
+      durationMs,
+      capturedAt: new Date().toISOString(),
+    }
+    if (this.buf.length < this.size) {
+      this.buf.push(entry)
+      this.head = this.buf.length % this.size
+    } else {
+      this.buf[this.head] = entry
+      this.head = (this.head + 1) % this.size
+    }
+  }
+
+  /** Returns entries ordered oldest → newest. */
+  getAll(): SlowQueryEntry[] {
+    if (this.buf.length < this.size) return [...this.buf]
+    return [...this.buf.slice(this.head), ...this.buf.slice(0, this.head)]
+  }
+
+  reset(): void { this.buf = []; this.head = 0 }
+}
+
+export const slowQueryRingBuffer = new SlowQueryRingBuffer()
+
+/**
+ * Call this from the Knex `query-response` / `query-error` hook to capture
+ * queries that exceed the configured threshold.
+ */
+export function captureSlowQuery(sql: string, durationMs: number): void {
+  slowQueryRingBuffer.record(sql, durationMs)
+}
+
+/** Returns all buffered slow-query entries (oldest → newest). */
+export function getSlowQueryBuffer(): SlowQueryEntry[] {
+  return slowQueryRingBuffer.getAll()
+}
+
+/** Clears the ring buffer (useful for tests). */
+export function resetSlowQueryBuffer(): void {
+  slowQueryRingBuffer.reset()
+}

--- a/src/tests/dbMetrics.slowQueries.test.ts
+++ b/src/tests/dbMetrics.slowQueries.test.ts
@@ -1,0 +1,295 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+
+// ── unit tests for dbMetrics ring buffer helpers ──────────────────────────────
+import {
+  fingerprintSql,
+  captureSlowQuery,
+  getSlowQueryBuffer,
+  resetSlowQueryBuffer,
+  SlowQueryEntry,
+} from '../services/dbMetrics.js'
+
+describe('fingerprintSql', () => {
+  it('replaces quoted string literals with ?', () => {
+    expect(fingerprintSql("select * from users where name = 'Alice'")).toBe(
+      'select * from users where name = ?'
+    )
+  })
+
+  it('replaces integer literals with ?', () => {
+    expect(fingerprintSql('select * from vaults where id = 42')).toBe(
+      'select * from vaults where id = ?'
+    )
+  })
+
+  it('replaces float literals with ?', () => {
+    expect(fingerprintSql('select * from prices where amount = 3.14')).toBe(
+      'select * from prices where amount = ?'
+    )
+  })
+
+  it('replaces $N positional params with ?', () => {
+    expect(fingerprintSql('select * from users where id = $1 and org = $2')).toBe(
+      'select * from users where id = ? and org = ?'
+    )
+  })
+
+  it('collapses whitespace', () => {
+    expect(fingerprintSql('select  *   from   users')).toBe('select * from users')
+  })
+
+  it('truncates to 200 characters', () => {
+    const long = 'select ' + 'x'.repeat(300)
+    expect(fingerprintSql(long).length).toBeLessThanOrEqual(200)
+  })
+
+  it('never contains raw PII-like values', () => {
+    const sql = "select * from users where email = 'user@example.com' and id = 99"
+    const fp = fingerprintSql(sql)
+    expect(fp).not.toContain('user@example.com')
+    expect(fp).not.toContain('99')
+  })
+})
+
+describe('slow-query ring buffer (unit)', () => {
+  const origThreshold = process.env.SLOW_QUERY_THRESHOLD_MS
+  const origSize = process.env.SLOW_QUERY_BUFFER_SIZE
+
+  beforeEach(() => {
+    resetSlowQueryBuffer()
+  })
+
+  afterEach(() => {
+    if (origThreshold === undefined) delete process.env.SLOW_QUERY_THRESHOLD_MS
+    else process.env.SLOW_QUERY_THRESHOLD_MS = origThreshold
+    if (origSize === undefined) delete process.env.SLOW_QUERY_BUFFER_SIZE
+    else process.env.SLOW_QUERY_BUFFER_SIZE = origSize
+    resetSlowQueryBuffer()
+  })
+
+  it('returns empty array when no queries captured', () => {
+    expect(getSlowQueryBuffer()).toEqual([])
+  })
+
+  it('captures a query that meets the threshold', () => {
+    process.env.SLOW_QUERY_THRESHOLD_MS = '100'
+    captureSlowQuery('select * from vaults', 150)
+    const buf = getSlowQueryBuffer()
+    expect(buf).toHaveLength(1)
+    expect(buf[0].durationMs).toBe(150)
+    expect(buf[0].fingerprint).toBe('select * from vaults')
+    expect(buf[0].capturedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('ignores queries below threshold (exclusive)', () => {
+    process.env.SLOW_QUERY_THRESHOLD_MS = '200'
+    captureSlowQuery('select 1', 199)
+    expect(getSlowQueryBuffer()).toHaveLength(0)
+  })
+
+  it('captures queries exactly at the threshold', () => {
+    process.env.SLOW_QUERY_THRESHOLD_MS = '200'
+    captureSlowQuery('select 1', 200)
+    expect(getSlowQueryBuffer()).toHaveLength(1)
+  })
+
+  it('evicts oldest entry when buffer is full (ring behaviour)', () => {
+    process.env.SLOW_QUERY_THRESHOLD_MS = '0'
+    process.env.SLOW_QUERY_BUFFER_SIZE = '3'
+    resetSlowQueryBuffer()
+
+    captureSlowQuery('select a', 10)
+    captureSlowQuery('select b', 20)
+    captureSlowQuery('select c', 30)
+    // Buffer full — next write overwrites oldest (select a)
+    captureSlowQuery('select d', 40)
+
+    const buf = getSlowQueryBuffer()
+    expect(buf).toHaveLength(3)
+    const durations = buf.map((e) => e.durationMs).sort((a, b) => a - b)
+    expect(durations).toEqual([20, 30, 40])
+  })
+
+  it('stores entries in oldest-to-newest order', () => {
+    process.env.SLOW_QUERY_THRESHOLD_MS = '0'
+    process.env.SLOW_QUERY_BUFFER_SIZE = '5'
+    resetSlowQueryBuffer()
+
+    captureSlowQuery('select * from a', 10)
+    captureSlowQuery('select * from b', 20)
+    captureSlowQuery('select * from c', 30)
+
+    const buf = getSlowQueryBuffer()
+    expect(buf[0].durationMs).toBe(10)
+    expect(buf[1].durationMs).toBe(20)
+    expect(buf[2].durationMs).toBe(30)
+  })
+
+  it('strips raw parameter values (no PII in fingerprint)', () => {
+    process.env.SLOW_QUERY_THRESHOLD_MS = '0'
+    resetSlowQueryBuffer()
+    captureSlowQuery("select * from users where email = 'bob@example.com' and id = $1", 500)
+    const buf = getSlowQueryBuffer()
+    expect(buf[0].fingerprint).not.toContain('bob@example.com')
+    expect(buf[0].fingerprint).not.toContain('$1')
+  })
+
+  it('resets the buffer', () => {
+    process.env.SLOW_QUERY_THRESHOLD_MS = '0'
+    resetSlowQueryBuffer()
+    captureSlowQuery('select 1', 10)
+    resetSlowQueryBuffer()
+    expect(getSlowQueryBuffer()).toHaveLength(0)
+  })
+})
+
+// ── HTTP endpoint tests ───────────────────────────────────────────────────────
+import express, { Express } from 'express'
+import request from 'supertest'
+
+jest.unstable_mockModule('../middleware/auth.js', () => ({
+  authenticate: (_req: any, _res: any, next: any) => {
+    _req.user = { userId: 'admin-1', role: 'admin' }
+    next()
+  },
+}))
+jest.unstable_mockModule('../middleware/rbac.js', () => ({
+  requireAdmin: (_req: any, _res: any, next: any) => next(),
+}))
+jest.unstable_mockModule('../middleware/rateLimiter.js', () => ({
+  metricsRateLimiter: (_req: any, _res: any, next: any) => next(),
+}))
+jest.unstable_mockModule('../middleware/stepUp.js', () => ({
+  requireStepUp: () => (_req: any, _res: any, next: any) => next(),
+}))
+jest.unstable_mockModule('../middleware/queryParser.js', () => ({
+  queryParser: () => (_req: any, _res: any, next: any) => next(),
+}))
+jest.unstable_mockModule('../lib/audit-logs.js', () => ({
+  createAuditLog: async () => ({ id: 'log-1', created_at: new Date().toISOString() }),
+  listAuditLogs: async () => [],
+  getAuditLogById: async () => null,
+  exportAuditLogsForOrganization: async () => ({}),
+  verifyAuditLogChain: async () => ({ verified: true }),
+}))
+jest.unstable_mockModule('../services/vaultStore.js', () => ({
+  cancelVaultById: async () => ({ error: 'not_found' }),
+}))
+jest.unstable_mockModule('../services/dbMetrics.js', () => ({
+  getDBHealthMetrics: () => ({
+    pool: { timestamp: new Date(), availableConnections: 5, waitingClients: 0, totalConnections: 5, poolSize: { min: 2, max: 10 } },
+    slowQueries: [],
+    isHealthy: true,
+    warnings: [],
+  }),
+  getSlowQueryBuffer: jest.fn<any>(() => []),
+}))
+jest.unstable_mockModule('../services/featureFlags.js', () => ({
+  getFlag: () => false,
+  setFlag: () => {},
+  getAllFlags: () => ({}),
+  isValidFeatureFlag: () => false,
+  FeatureFlag: {},
+}))
+jest.unstable_mockModule('../db/index.js', () => ({ pool: {} }))
+jest.unstable_mockModule('../db/knex.js', () => ({
+  db: {
+    select: () => ({ where: () => ({ first: async () => null }) }),
+    count: () => ({ where: () => [{ total: '0' }] }),
+    on: () => {},
+  },
+}))
+jest.unstable_mockModule('../security/abuse-monitor.js', () => ({
+  getAbuseCategoryCounts: () => ({}),
+}))
+jest.unstable_mockModule('../services/checkpointStore.js', () => ({
+  CheckpointStore: class { getAllCheckpoints = async () => [] },
+}))
+jest.unstable_mockModule('../services/monitor.js', () => ({
+  getLatestListenerLag: () => null,
+}))
+jest.unstable_mockModule('../lib/auth-utils.js', () => ({
+  generateImpersonationToken: () => 'tok',
+}))
+jest.unstable_mockModule('../lib/prismaScope.js', () => ({
+  getPrisma: () => ({ user: { findUnique: async () => null } }),
+}))
+jest.unstable_mockModule('../services/session.js', () => ({
+  forceRevokeUserSessions: async () => {},
+  recordSession: async () => {},
+}))
+jest.unstable_mockModule('../services/user.service.js', () => ({
+  userService: {
+    listUsers: async () => ({ users: [], total: 0 }),
+    getUserById: async () => null,
+    updateUserRole: async () => null,
+    updateUserStatus: async () => null,
+    softDeleteUser: async () => null,
+    hardDeleteUser: async () => null,
+    restoreUser: async () => null,
+  },
+  DeleteResult: {},
+}))
+
+describe('GET /api/admin/db/slow-queries (HTTP)', () => {
+  let app: Express
+  let mockGetSlowQueryBuffer: ReturnType<typeof jest.fn>
+
+  beforeEach(async () => {
+    resetSlowQueryBuffer()
+    const dbMetrics = await import('../services/dbMetrics.js')
+    mockGetSlowQueryBuffer = (dbMetrics as any).getSlowQueryBuffer as ReturnType<typeof jest.fn>
+
+    const { adminRouter } = await import('../routes/admin.js')
+    app = express()
+    app.use(express.json())
+    app.use('/api/admin', adminRouter)
+  })
+
+  it('returns 200 with empty entries when buffer is empty', async () => {
+    mockGetSlowQueryBuffer.mockReturnValue([])
+    const res = await request(app).get('/api/admin/db/slow-queries')
+    expect(res.status).toBe(200)
+    expect(res.body.data.count).toBe(0)
+    expect(res.body.data.entries).toEqual([])
+    expect(typeof res.body.data.thresholdMs).toBe('number')
+    expect(typeof res.body.data.bufferSize).toBe('number')
+  })
+
+  it('returns buffered entries with correct shape', async () => {
+    const entries: SlowQueryEntry[] = [
+      { fingerprint: 'select * from vaults where id = ?', durationMs: 312, capturedAt: '2026-06-28T00:00:01.000Z' },
+      { fingerprint: 'select * from transactions where user_id = ?', durationMs: 485, capturedAt: '2026-06-28T00:00:05.000Z' },
+    ]
+    mockGetSlowQueryBuffer.mockReturnValue(entries)
+    const res = await request(app).get('/api/admin/db/slow-queries')
+    expect(res.status).toBe(200)
+    expect(res.body.data.count).toBe(2)
+    expect(res.body.data.entries).toHaveLength(2)
+    expect(res.body.data.entries[0].fingerprint).toBe(entries[0].fingerprint)
+    expect(res.body.data.entries[0].durationMs).toBe(312)
+    expect(res.body.data.entries[1].durationMs).toBe(485)
+  })
+
+  it('entries contain no raw parameter values', async () => {
+    const entries: SlowQueryEntry[] = [
+      { fingerprint: 'select * from users where id = ?', durationMs: 250, capturedAt: new Date().toISOString() },
+    ]
+    mockGetSlowQueryBuffer.mockReturnValue(entries)
+    const res = await request(app).get('/api/admin/db/slow-queries')
+    const fp: string = res.body.data.entries[0].fingerprint
+    expect(fp).not.toMatch(/'[^']*'/)
+    expect(fp).not.toMatch(/\$\d+/)
+  })
+
+  it('exposes thresholdMs and bufferSize from env', async () => {
+    process.env.SLOW_QUERY_THRESHOLD_MS = '300'
+    process.env.SLOW_QUERY_BUFFER_SIZE = '50'
+    mockGetSlowQueryBuffer.mockReturnValue([])
+    const res = await request(app).get('/api/admin/db/slow-queries')
+    expect(res.body.data.thresholdMs).toBe(300)
+    expect(res.body.data.bufferSize).toBe(50)
+    delete process.env.SLOW_QUERY_THRESHOLD_MS
+    delete process.env.SLOW_QUERY_BUFFER_SIZE
+  })
+})


### PR DESCRIPTION
Closes #853

## Changes

- **`src/services/dbMetrics.ts`** — `SlowQueryRingBuffer` class + `fingerprintSql`, `captureSlowQuery`, `getSlowQueryBuffer`, `resetSlowQueryBuffer` exports. Fixed regex ordering (positional params + floats before integers) and falsy-zero bug in threshold/buffer-size getters.
- **`src/db/knex.ts`** — hooks `captureSlowQuery` into Knex `query` / `query-response` / `query-error` events so slow queries are captured automatically.
- **`src/routes/admin.ts`** — adds `GET /api/admin/db/slow-queries` (admin-only); fixes missing `NextFunction` and `metricsRateLimiter` imports.
- **`src/tests/dbMetrics.slowQueries.test.ts`** — 19 tests covering: `fingerprintSql` (7), ring buffer unit (8), HTTP endpoint (4).
- **`docs/operations-metrics.md`** — slow-query ring buffer section with config table, response format, fingerprinting rules, and Knex integration notes.

## Test output

```
PASS src/tests/dbMetrics.slowQueries.test.ts
  fingerprintSql          7 ✓
  ring buffer (unit)      8 ✓
  HTTP endpoint           4 ✓
Tests: 19 passed
```

## Configuration

| Env var | Default | Description |
|---|---|---|
| `SLOW_QUERY_THRESHOLD_MS` | `200` | Min duration before capture |
| `SLOW_QUERY_BUFFER_SIZE` | `100` | Ring buffer capacity |