### PR TITLE
feat: tail-based log sampling with admin debug override

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -298,6 +298,48 @@ If `REDIS_URL` is not provided (e.g., during tests or local development), the ca
 
 To prevent stale-shaped objects from causing schema mismatch issues, all cached payloads are explicitly version-tagged (e.g., `{"version":"v1","data":...}`). Any version change triggers an automatic cache miss, ensuring that updated structures are always loaded fresh from the database.
 
+## Log Sampling
+
+The `requestLogger` middleware in `src/middleware/requestLogger.ts` supports tail-based log sampling to reduce log volume while preserving signal.
+
+### Sampling Rules
+
+| Condition | Always Logged? |
+|---|---|
+| Response status ≥ 500 | Yes (bypasses sampling) |
+| Duration ≥ `LOG_SLOW_THRESHOLD_MS` | Yes (bypasses sampling) |
+| Status in `LOG_ALWAYS_LOG_STATUS` | Yes (bypasses sampling) |
+| All other requests | Sampled at `LOG_SAMPLE_RATE` (0.0–1.0) |
+
+### Configuration (Env Vars)
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `LOG_SAMPLE_RATE` | float (0–1) | `1.0` | Fraction of non-error, non-slow requests to log |
+| `LOG_SLOW_THRESHOLD_MS` | int | `1000` | Requests exceeding this duration (ms) are always logged |
+| `LOG_ALWAYS_LOG_STATUS` | string (csv) | `500,502,503` | Status codes that bypass sampling |
+| `ADMIN_API_KEY` | string | `""` (disabled) | Shared secret for admin debug headers |
+
+### Admin Debug Overrides
+
+When `ADMIN_API_KEY` is set, two headers provide per-request log-level control:
+
+- **`x-debug-trace`**: Set to `ADMIN_API_KEY` to force debug-level logging for that request (also bypasses sampling).
+- **`x-log-level`**: Set to `debug`/`info`/`warn`/`error` to override the log level. Requires a matching `x-admin-key: <ADMIN_API_KEY>` header.
+
+All admin header comparisons use constant-time (`crypto.timingSafeEqual`) to resist timing attacks.
+
+### Example
+
+```env
+LOG_SAMPLE_RATE=0.1
+LOG_SLOW_THRESHOLD_MS=500
+LOG_ALWAYS_LOG_STATUS=500,502,503,504
+ADMIN_API_KEY=some-secret-value
+```
+
+This samples 10% of healthy, fast requests but always logs 5xx errors, 504 responses, and any request taking over 500ms.
+
 ## Runbooks
 
 | Scenario | Runbook |

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -219,6 +219,20 @@ export const envSchema = z
     HTTP_KEEPALIVE_TIMEOUT_MS: positiveInt(45_000),
     HTTP_HEADERS_TIMEOUT_MS: positiveInt(61_000),
     HTTP_REQUEST_TIMEOUT_MS: positiveInt(120_000),
+
+    // ── Admin / Debug ──────────────────────────────────────────────
+    ADMIN_API_KEY: z.string().default(""),
+
+    // ── Log sampling ───────────────────────────────────────────────
+    LOG_SAMPLE_RATE: z
+      .string()
+      .default("1")
+      .transform((v) => {
+        const n = Number.parseFloat(v);
+        return Number.isFinite(n) && n >= 0 && n <= 1 ? n : 1;
+      }),
+    LOG_SLOW_THRESHOLD_MS: positiveInt(1000),
+    LOG_ALWAYS_LOG_STATUS: z.string().default("500,502,503"),
   })
   .superRefine((data, ctx) => {
     // Existing CORS warning

--- a/src/middleware/requestLogger.ts
+++ b/src/middleware/requestLogger.ts
@@ -1,5 +1,28 @@
 import type { NextFunction, Request, Response } from 'express'
+import { timingSafeEqual } from 'crypto'
 import { logger, withCorrelationId, getOrGenerateCorrelationId } from './logger.js'
+import { getEnv } from '../config/env.js'
+
+const LOG_LEVELS = ['debug', 'info', 'warn', 'error'] as const
+type LogLevel = typeof LOG_LEVELS[number]
+
+function isLogLevel(v: string): v is LogLevel {
+  return LOG_LEVELS.includes(v as LogLevel)
+}
+
+function constantTimeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b))
+}
+
+function parseStatusSet(raw: string): Set<number> {
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => parseInt(s.trim(), 10))
+      .filter((n) => !isNaN(n)),
+  )
+}
 
 /**
  * Request logging middleware using Pino for structured JSON output.
@@ -11,6 +34,16 @@ import { logger, withCorrelationId, getOrGenerateCorrelationId } from './logger.
  * - Request size (if available)
  * - User ID (if available from headers)
  *
+ * Supports tail-based log sampling:
+ * - Errors (>=500), slow requests (>LOG_SLOW_THRESHOLD_MS), and
+ *   statuses in LOG_ALWAYS_LOG_STATUS are always logged.
+ * - All other requests are logged at LOG_SAMPLE_RATE (0.0–1.0).
+ *
+ * Admin debug overrides (requires ADMIN_API_KEY to be set):
+ * - x-debug-trace: <ADMIN_API_KEY> forces debug-level logging.
+ * - x-log-level: <level> overrides the log level when x-admin-key
+ *   matches ADMIN_API_KEY.
+ *
  * All sensitive fields are automatically redacted by Pino's redact configuration.
  */
 export const requestLogger = (req: Request, res: Response, next: NextFunction) => {
@@ -18,7 +51,6 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction) =
   const correlationId = getOrGenerateCorrelationId(req)
   const requestLogger = withCorrelationId(logger, correlationId)
 
-  // Extract useful request metadata
   const method = req.method
   const url = req.originalUrl
   const path = req.path
@@ -27,7 +59,6 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction) =
   const userRole = req.headers['x-user-role'] as string | undefined
   const contentLength = req.headers['content-length']
 
-  // Store correlation ID and logger on request for downstream handlers
   ;(req as any).correlationId = correlationId
   ;(req as any).logger = requestLogger
 
@@ -35,14 +66,43 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction) =
     const durationMs = Date.now() - start
     const statusCode = res.statusCode
 
-    // Determine log level based on status code
-    const logLevel =
+    let logLevel: LogLevel =
       statusCode >= 500 ? 'error' :
       statusCode >= 400 ? 'warn' :
       statusCode >= 200 ? 'info' :
       'debug'
 
-    // Emit structured JSON log
+    let forceLog = false
+    const env = getEnv()
+
+    if (env.ADMIN_API_KEY) {
+      const debugTrace = req.headers['x-debug-trace'] as string | undefined
+      if (debugTrace && constantTimeCompare(debugTrace, env.ADMIN_API_KEY)) {
+        logLevel = 'debug'
+        forceLog = true
+      }
+
+      const logLevelHeader = req.headers['x-log-level'] as string | undefined
+      const adminKeyHeader = req.headers['x-admin-key'] as string | undefined
+      if (
+        logLevelHeader &&
+        adminKeyHeader &&
+        constantTimeCompare(adminKeyHeader, env.ADMIN_API_KEY) &&
+        isLogLevel(logLevelHeader)
+      ) {
+        logLevel = logLevelHeader
+        forceLog = true
+      }
+    }
+
+    if (!forceLog) {
+      const isError = statusCode >= 500
+      const isSlow = durationMs >= env.LOG_SLOW_THRESHOLD_MS
+      const importantStatuses = parseStatusSet(env.LOG_ALWAYS_LOG_STATUS)
+      const sampled = isError || isSlow || importantStatuses.has(statusCode) || Math.random() < env.LOG_SAMPLE_RATE
+      if (!sampled) return
+    }
+
     requestLogger[logLevel](
       {
         event: 'http.request',
@@ -69,4 +129,3 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction) =
 
   next()
 }
-

--- a/src/tests/requestLogger.sampling.test.ts
+++ b/src/tests/requestLogger.sampling.test.ts
@@ -1,0 +1,309 @@
+import { jest } from '@jest/globals'
+import type { NextFunction, Request, Response } from 'express'
+
+const mockEnv: any = {
+  LOG_SAMPLE_RATE: 1,
+  LOG_SLOW_THRESHOLD_MS: 1000,
+  LOG_ALWAYS_LOG_STATUS: '500,502,503',
+  ADMIN_API_KEY: 'test-admin-key',
+}
+
+jest.unstable_mockModule('../config/env.js', () => ({
+  getEnv: jest.fn(() => mockEnv),
+}))
+
+const { requestLogger } = await import('../middleware/requestLogger.js')
+import * as loggerModule from '../middleware/logger.js'
+
+function mockRes() {
+  let finishHandler: () => void = () => {}
+  return {
+    statusCode: 200,
+    getHeaders: () => ({}),
+    on: ((event: string, handler: () => void) => {
+      if (event === 'finish') finishHandler = handler
+      return mockRes() as Response
+    }) as any,
+    emitFinish() {
+      finishHandler()
+    },
+  }
+}
+
+describe('requestLogger sampling', () => {
+  let req: Partial<Request>
+  let res: any
+  let next: NextFunction
+  let mockLogger: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockLogger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }
+
+    jest.spyOn(loggerModule.logger, 'child').mockReturnValue(mockLogger as any)
+
+    req = {
+      method: 'GET',
+      originalUrl: '/api/test',
+      path: '/api/test',
+      url: '/api/test',
+      headers: {},
+      body: {},
+      socket: {} as any,
+    }
+    res = mockRes()
+    next = jest.fn()
+
+    mockEnv.LOG_SAMPLE_RATE = 1
+    mockEnv.LOG_SLOW_THRESHOLD_MS = 1000
+    mockEnv.LOG_ALWAYS_LOG_STATUS = '500,502,503'
+    mockEnv.ADMIN_API_KEY = 'test-admin-key'
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('basic logging', () => {
+    it('logs at info level for 2xx responses', () => {
+      res.statusCode = 200
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.info).toHaveBeenCalled()
+    })
+
+    it('logs at warn level for 4xx responses', () => {
+      res.statusCode = 404
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.warn).toHaveBeenCalled()
+    })
+
+    it('logs at error level for 5xx responses', () => {
+      res.statusCode = 500
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.error).toHaveBeenCalled()
+    })
+
+    it('logs at debug level for other status codes', () => {
+      res.statusCode = 100
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.debug).toHaveBeenCalled()
+    })
+
+    it('always calls next()', () => {
+      requestLogger(req as Request, res as Response, next)
+      expect(next).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('tail-based sampling', () => {
+    it('logs when sampled in (Math.random < rate)', () => {
+      mockEnv.LOG_SAMPLE_RATE = 0.5
+      mockEnv.LOG_ALWAYS_LOG_STATUS = '999'
+      jest.spyOn(Math, 'random').mockReturnValue(0.3)
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.info).toHaveBeenCalledTimes(1)
+    })
+
+    it('skips logging when sampled out (Math.random >= rate)', () => {
+      mockEnv.LOG_SAMPLE_RATE = 0.5
+      mockEnv.LOG_ALWAYS_LOG_STATUS = '999'
+      jest.spyOn(Math, 'random').mockReturnValue(0.7)
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.info).not.toHaveBeenCalled()
+    })
+
+    it('always logs 5xx errors regardless of sample rate', () => {
+      mockEnv.LOG_SAMPLE_RATE = 0
+      jest.spyOn(Math, 'random').mockReturnValue(0.9)
+      res.statusCode = 500
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.error).toHaveBeenCalled()
+    })
+
+    it('always logs requests exceeding slow threshold', () => {
+      mockEnv.LOG_SAMPLE_RATE = 0
+      mockEnv.LOG_SLOW_THRESHOLD_MS = 10
+      mockEnv.LOG_ALWAYS_LOG_STATUS = '999'
+      jest.spyOn(Math, 'random').mockReturnValue(0.9)
+
+      const realNow = Date.now
+      let callCount = 0
+      Date.now = () => (callCount++ === 0 ? 0 : 100)
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      Date.now = realNow
+
+      expect(mockLogger.info).toHaveBeenCalled()
+    })
+
+    it('always logs statuses in LOG_ALWAYS_LOG_STATUS', () => {
+      mockEnv.LOG_SAMPLE_RATE = 0
+      mockEnv.LOG_ALWAYS_LOG_STATUS = '503,504'
+      jest.spyOn(Math, 'random').mockReturnValue(0.9)
+      res.statusCode = 503
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.error).toHaveBeenCalled()
+    })
+
+    it('logs everything when sample rate is 1', () => {
+      mockEnv.LOG_SAMPLE_RATE = 1
+      mockEnv.LOG_ALWAYS_LOG_STATUS = '999'
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.info).toHaveBeenCalled()
+    })
+
+    it('only logs important requests when sample rate is 0', () => {
+      mockEnv.LOG_SAMPLE_RATE = 0
+      mockEnv.LOG_ALWAYS_LOG_STATUS = '999'
+      jest.spyOn(Math, 'random').mockReturnValue(0.9)
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.info).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('admin debug overrides', () => {
+    it('forces debug level via x-debug-trace header', () => {
+      req.headers = { 'x-debug-trace': 'test-admin-key' }
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.debug).toHaveBeenCalled()
+      expect(mockLogger.info).not.toHaveBeenCalled()
+    })
+
+    it('ignores x-debug-trace with wrong key', () => {
+      req.headers = { 'x-debug-trace': 'wrong-key' }
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.info).toHaveBeenCalled()
+      expect(mockLogger.debug).not.toHaveBeenCalled()
+    })
+
+    it('overrides log level via x-log-level with x-admin-key auth', () => {
+      req.headers = {
+        'x-log-level': 'warn',
+        'x-admin-key': 'test-admin-key',
+      }
+      res.statusCode = 200
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.warn).toHaveBeenCalled()
+      expect(mockLogger.info).not.toHaveBeenCalled()
+    })
+
+    it('ignores x-log-level without matching x-admin-key', () => {
+      req.headers = {
+        'x-log-level': 'warn',
+        'x-admin-key': 'wrong-key',
+      }
+      res.statusCode = 200
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.info).toHaveBeenCalled()
+      expect(mockLogger.warn).not.toHaveBeenCalled()
+    })
+
+    it('ignores x-log-level with invalid level value', () => {
+      req.headers = {
+        'x-log-level': 'invalid-level',
+        'x-admin-key': 'test-admin-key',
+      }
+      res.statusCode = 200
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.info).toHaveBeenCalled()
+    })
+
+    it('disables admin overrides when ADMIN_API_KEY is empty', () => {
+      mockEnv.ADMIN_API_KEY = ''
+      req.headers = { 'x-debug-trace': '' }
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.info).toHaveBeenCalled()
+      expect(mockLogger.debug).not.toHaveBeenCalled()
+    })
+
+    it('x-debug-trace overrides sampling (force logs even when sampled out)', () => {
+      mockEnv.LOG_SAMPLE_RATE = 0
+      mockEnv.LOG_ALWAYS_LOG_STATUS = '999'
+      jest.spyOn(Math, 'random').mockReturnValue(0.9)
+      req.headers = { 'x-debug-trace': 'test-admin-key' }
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+      expect(mockLogger.debug).toHaveBeenCalled()
+    })
+  })
+
+  describe('correlation ID and regression', () => {
+    it('preserves correlation ID on request', () => {
+      req.headers = { 'x-correlation-id': 'test-corr-id' }
+
+      requestLogger(req as Request, res as Response, next)
+
+      expect((req as any).correlationId).toBe('test-corr-id')
+    })
+
+    it('generates correlation ID when header is missing', () => {
+      requestLogger(req as Request, res as Response, next)
+
+      expect((req as any).correlationId).toBeDefined()
+      expect(typeof (req as any).correlationId).toBe('string')
+    })
+
+    it('attaches logger to request for downstream handlers', () => {
+      requestLogger(req as Request, res as Response, next)
+
+      expect((req as any).logger).toBeDefined()
+    })
+  })
+
+  describe('structured log content', () => {
+    it('includes expected fields in the log object', () => {
+      req.method = 'POST'
+      req.path = '/api/vaults/123'
+      req.headers = { 'x-user-id': 'user-1', 'x-user-role': 'admin' }
+      req.body = { name: 'test' }
+
+      requestLogger(req as Request, res as Response, next)
+      res.emitFinish()
+
+      const logArg = mockLogger.info.mock.calls[0][0]
+      expect(logArg.event).toBe('http.request')
+      expect(logArg.req.method).toBe('POST')
+      expect(logArg.req.path).toBe('/api/vaults/123')
+      expect(logArg.req.userId).toBe('user-1')
+      expect(logArg.req.userRole).toBe('admin')
+      expect(logArg.res.statusCode).toBe(200)
+      expect(logArg.durationMs).toEqual(expect.any(Number))
+    })
+  })
+})


### PR DESCRIPTION
Tail-based log sampling with admin debug override for requestLogger.
- Adds LOG_SAMPLE_RATE, LOG_SLOW_THRESHOLD_MS, LOG_ALWAYS_LOG_STATUS, and ADMIN_API_KEY to validated env config
- Always logs error (≥500), slow (>threshold), and configurable status-code classes, sampling the rest at the configured rate
- x-debug-trace header (authenticated against ADMIN_API_KEY) forces debug-level logging
- x-log-level + x-admin-key headers override log level per-request with constant-time auth
- 23 tests covering sampling, bypasses, admin overrides, correlation-ID preservation, and regression
- Documented in docs/operations.md
Closes #839