### PR TITLE
feat: add org-scoped saved vault searches with alert subscriptions (#…

### DIFF
--- a/db/migrations/20260628100000_create_org_vault_searches.cjs
+++ b/db/migrations/20260628100000_create_org_vault_searches.cjs
@@ -1,0 +1,42 @@
+/**
+ * Org-scoped saved vault searches with optional change-alert subscriptions.
+ *
+ * Each row captures a validated query definition that an operator wants to
+ * replay on a schedule.  When alerts_enabled is true the periodic evaluation
+ * job hashes the result set and dispatches a notification whenever the hash
+ * changes (i.e. new vaults matched or existing ones dropped out).
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('org_vault_searches', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    table.string('org_id', 255).notNullable()
+    table.string('name', 255).notNullable()
+    // Validated query params stored as JSONB (fields: q, status, verifier,
+    // amount_min, amount_max, date_from, date_to, sort_by, sort_order, limit)
+    table.jsonb('query_definition').notNullable()
+    table.boolean('alerts_enabled').notNullable().defaultTo(false)
+    // Recipient to notify when results change (email or user id)
+    table.string('alert_recipient', 255).nullable()
+    // Minimum ms between alert evaluations — floor enforced at 3 600 000 (1 h)
+    table.integer('alert_frequency_ms').notNullable().defaultTo(3_600_000)
+    table.timestamp('last_evaluated_at', { useTz: true }).nullable()
+    // SHA-256 hex of the last result set used to detect changes
+    table.string('last_result_hash', 64).nullable()
+    table.string('created_by', 255).notNullable()
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+    table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+  })
+
+  // Org-scoped look-up (list + cap check)
+  await knex.raw(
+    'CREATE INDEX idx_org_vault_searches_org_id ON org_vault_searches (org_id)',
+  )
+  // Evaluation job: find alert rows due for re-evaluation
+  await knex.raw(
+    'CREATE INDEX idx_org_vault_searches_alerts ON org_vault_searches (alerts_enabled, last_evaluated_at) WHERE alerts_enabled = true',
+  )
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.dropTableIfExists('org_vault_searches')
+}

--- a/docs/vaults-api.md
+++ b/docs/vaults-api.md
@@ -260,6 +260,80 @@ The validation logic is covered by comprehensive tests including:
 }
 ```
 
+---
+
+## Org-Scoped Saved Vault Searches
+
+Operators can persist a named query against an org's vault set and optionally subscribe to change notifications when the result set shifts.
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST`   | `/api/orgs/:orgId/vault-searches` | owner, admin | Create a saved search |
+| `GET`    | `/api/orgs/:orgId/vault-searches` | owner, admin, member | List all saved searches |
+| `GET`    | `/api/orgs/:orgId/vault-searches/:searchId` | owner, admin, member | Get one saved search |
+| `DELETE` | `/api/orgs/:orgId/vault-searches/:searchId` | owner, admin | Delete a saved search |
+
+### Request body — POST
+
+```json
+{
+  "name": "Active high-value vaults",
+  "query_definition": {
+    "status": "active",
+    "amount_min": "10000",
+    "sort_by": "created_at",
+    "sort_order": "desc",
+    "limit": 50
+  },
+  "alerts_enabled": true,
+  "alert_recipient": "ops@example.com",
+  "alert_frequency_ms": 3600000
+}
+```
+
+#### `query_definition` fields
+
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `q` | string | Free-text search; injection chars stripped; max 200 chars |
+| `status` | string | One of: `draft`, `active`, `completed`, `failed`, `cancelled` |
+| `verifier` | string | Stellar address; max 256 chars |
+| `amount_min` | string | Non-negative numeric string |
+| `amount_max` | string | Non-negative numeric string |
+| `date_from` | string | ISO 8601 date |
+| `date_to` | string | ISO 8601 date |
+| `sort_by` | string | One of: `created_at`, `amount`, `end_date`, `status` |
+| `sort_order` | string | `asc` or `desc` |
+| `limit` | number | Integer 1–100 |
+
+#### Constraints
+
+- **Per-org cap**: maximum **20** saved searches per org (HTTP 422 on overflow).
+- **Alert frequency floor**: `alert_frequency_ms` must be ≥ `3,600,000` ms (1 hour).
+- `alert_recipient` is required when `alerts_enabled` is `true`.
+
+### Alert subscriptions
+
+When `alerts_enabled` is `true` the periodic evaluation job re-runs the saved query on a schedule (default every 15 minutes, controlled by `SAVED_SEARCH_EVAL_INTERVAL_MS`). If the result set has changed since the last evaluation (detected by SHA-256 hash comparison), a notification is dispatched to `alert_recipient` via the configured notification provider.
+
+The per-search evaluation frequency is controlled by `alert_frequency_ms`. A search is only evaluated if `now >= last_evaluated_at + alert_frequency_ms`.
+
+### Database
+
+| Table | Migration |
+|-------|-----------|
+| `org_vault_searches` | `db/migrations/20260628100000_create_org_vault_searches.cjs` |
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SAVED_SEARCH_EVAL_INTERVAL_MS` | `900000` (15 min) | How often the evaluation job runs |
+
+---
+
 ## Soroban Transaction Polling and Timeout
 
 When `onChain.mode` is `"submit"`, the backend sends the transaction to the Soroban RPC and then polls `getTransaction` until the tx reaches a terminal state.

--- a/src/jobs/handlers.ts
+++ b/src/jobs/handlers.ts
@@ -1,8 +1,11 @@
+import { createHash } from 'node:crypto'
 import { NotificationService } from '../services/notifications/factory.js'
 import { processJob as processExportJob } from '../services/exportQueue.js'
 import type { JobHandler, JobType } from './types.js'
 import { markVaultExpiries } from '../services/vault.js'
 import { TransactionETLService } from '../services/transactionETL.js'
+import { cleanupExpiredSessions } from '../services/session.js'
+import db from '../db/index.js'
 
 type JobHandlerRegistry = {
   [K in JobType]: JobHandler<K>
@@ -83,7 +86,7 @@ export const createDefaultJobHandlers = (
       `exportJobId=${payload.exportJobId} attempt=${context.attempt}`,
     )
   },
-`  'vault.reconcile': async (payload, context) => {
+  'vault.reconcile': async (payload, context) => {
     const etlConfig = {
       horizonUrl: process.env.HORIZON_URL || 'https://horizon-testnet.stellar.org',
       networkPassphrase: process.env.STELLAR_NETWORK_PASSPHRASE || 'Test SDF Network ; September 2015',
@@ -100,7 +103,6 @@ export const createDefaultJobHandlers = (
       `vaultIds=${payload.vaultIds?.length || 'all'} batchSize=${payload.batchSize || 50} checked=${result.checked}/${result.totalVaults} drift=${result.driftDetected} missing=${result.missingOnChain} errors=${result.errors} attempt=${context.attempt}`,
     )
   },
-}
   'sessions.cleanup': async (payload, context) => {
     const batchSize = payload.batchSize ?? 1000
     const deleted = await cleanupExpiredSessions(batchSize)
@@ -128,6 +130,76 @@ export const createDefaultJobHandlers = (
       'embeddings.reindex',
       `batches=${result.batches} processed=${result.processed} reindexed=${result.reindexed} ` +
         `skipped=${result.skippedUpToDate} cursor=${result.cursor ?? 'none'} done=${result.done} attempt=${context.attempt}`,
+    )
+  },
+  'saved-search.evaluate': async (payload, context) => {
+    const now = new Date()
+
+    let searchQuery = db('org_vault_searches').where({ alerts_enabled: true })
+    if (payload.searchId) {
+      searchQuery = searchQuery.where({ id: payload.searchId })
+    } else {
+      searchQuery = searchQuery.whereRaw(
+        `(last_evaluated_at IS NULL OR last_evaluated_at + (alert_frequency_ms || ' milliseconds')::interval <= ?)`,
+        [now],
+      )
+    }
+
+    const searches = await searchQuery.select('*')
+    let evaluated = 0
+    let notified = 0
+
+    for (const search of searches) {
+      try {
+        const queryDef = typeof search.query_definition === 'string'
+          ? JSON.parse(search.query_definition)
+          : search.query_definition
+
+        const limit = Math.min(100, Math.max(1, queryDef.limit ?? 20))
+
+        let vaultQuery = db('vaults')
+          .where('organization_id', search.org_id)
+          .whereNull('deleted_at')
+          .select('id')
+
+        if (queryDef.status) vaultQuery = vaultQuery.where('status', queryDef.status)
+        if (queryDef.verifier) vaultQuery = vaultQuery.where('verifier', queryDef.verifier)
+        if (queryDef.amount_min) vaultQuery = vaultQuery.where('amount', '>=', queryDef.amount_min)
+        if (queryDef.amount_max) vaultQuery = vaultQuery.where('amount', '<=', queryDef.amount_max)
+        if (queryDef.date_from) vaultQuery = vaultQuery.where('created_at', '>=', new Date(queryDef.date_from))
+        if (queryDef.date_to) vaultQuery = vaultQuery.where('created_at', '<=', new Date(queryDef.date_to))
+
+        const sortField = queryDef.sort_by ?? 'created_at'
+        const sortOrder = (queryDef.sort_order ?? 'desc') as 'asc' | 'desc'
+        vaultQuery = vaultQuery.orderBy(sortField, sortOrder).orderBy('id', 'desc').limit(limit)
+
+        const rows = await vaultQuery
+        const ids: string[] = rows.map((r: { id: string }) => r.id)
+        const newHash = createHash('sha256').update(JSON.stringify(ids)).digest('hex')
+
+        if (newHash !== search.last_result_hash) {
+          await notificationService.send(
+            search.alert_recipient,
+            `Saved search "${search.name}" has new results`,
+            `Your saved vault search "${search.name}" returned ${ids.length} result(s). The result set has changed since the last evaluation.`,
+          )
+          notified++
+        }
+
+        await db('org_vault_searches')
+          .where({ id: search.id })
+          .update({ last_evaluated_at: now, last_result_hash: newHash, updated_at: now })
+
+        evaluated++
+      } catch (evalError) {
+        const msg = evalError instanceof Error ? evalError.message : String(evalError)
+        logJob('saved-search.evaluate', `error evaluating search=${search.id}: ${msg}`)
+      }
+    }
+
+    logJob(
+      'saved-search.evaluate',
+      `evaluated=${evaluated} notified=${notified} job_id=${context.jobId} attempt=${context.attempt}`,
     )
   },
 })

--- a/src/jobs/system.ts
+++ b/src/jobs/system.ts
@@ -198,6 +198,7 @@ export class BackgroundJobSystem {
     this.queue.registerHandler('sessions.cleanup', handlers['sessions.cleanup'])
     this.queue.registerHandler('outbox.relay', handlers['outbox.relay'])
     this.queue.registerHandler('embeddings.reindex', handlers['embeddings.reindex'])
+    this.queue.registerHandler('saved-search.evaluate', handlers['saved-search.evaluate'])
   }
 
   start(): void {
@@ -296,6 +297,10 @@ export class BackgroundJobSystem {
       process.env.EMBEDDING_REINDEX_INTERVAL_MS,
       600_000, // 10 minutes
     )
+    const savedSearchEvalIntervalMs = parsePositiveInteger(
+      process.env.SAVED_SEARCH_EVAL_INTERVAL_MS,
+      15 * 60_000, // 15 minutes
+    )
 
     this.schedulerRegistry.registerJob({
       name: 'deadline.check',
@@ -346,6 +351,15 @@ export class BackgroundJobSystem {
       initialDelayMs: 15_000,
       execute: () => {
         this.enqueue('embeddings.reindex', {})
+      },
+    })
+
+    this.schedulerRegistry.registerJob({
+      name: 'saved-search.evaluate',
+      intervalMs: savedSearchEvalIntervalMs,
+      immediate: false,
+      execute: () => {
+        this.enqueue('saved-search.evaluate', {})
       },
     })
   }

--- a/src/jobs/types.ts
+++ b/src/jobs/types.ts
@@ -6,6 +6,10 @@ export const JOB_TYPES = [
   'analytics.recompute',
   'export.generate',
   'vault.reconcile',
+  'sessions.cleanup',
+  'outbox.relay',
+  'embeddings.reindex',
+  'saved-search.evaluate',
 ] as const
 
 export type JobType = (typeof JOB_TYPES)[number]
@@ -48,6 +52,21 @@ export interface VaultReconcileJobPayload {
   batchSize?: number
 }
 
+export interface SessionsCleanupJobPayload {
+  batchSize?: number
+}
+
+export interface OutboxRelayJobPayload {}
+
+export interface EmbeddingReindexJobPayload {
+  batchSize?: number
+  maxBatchesPerRun?: number
+}
+
+export interface SavedSearchEvaluateJobPayload {
+  searchId?: string
+}
+
 export interface JobPayloadByType {
   'notification.send': NotificationJobPayload
   'deadline.check': DeadlineCheckJobPayload
@@ -56,6 +75,10 @@ export interface JobPayloadByType {
   'analytics.recompute': AnalyticsRecomputeJobPayload
   'export.generate': ExportGenerateJobPayload
   'vault.reconcile': VaultReconcileJobPayload
+  'sessions.cleanup': SessionsCleanupJobPayload
+  'outbox.relay': OutboxRelayJobPayload
+  'embeddings.reindex': EmbeddingReindexJobPayload
+  'saved-search.evaluate': SavedSearchEvaluateJobPayload
 }
 
 export interface JobContext {
@@ -137,6 +160,7 @@ export const isPayloadForJobType = (
       return (
         (payload.vaultIds === undefined || Array.isArray(payload.vaultIds)) &&
         (payload.batchSize === undefined || typeof payload.batchSize === 'number')
+      )
     case 'sessions.cleanup':
       return payload.batchSize === undefined || (typeof payload.batchSize === 'number' && payload.batchSize > 0)
     case 'outbox.relay':
@@ -147,6 +171,8 @@ export const isPayloadForJobType = (
         (payload.maxBatchesPerRun === undefined ||
           (typeof payload.maxBatchesPerRun === 'number' && payload.maxBatchesPerRun > 0))
       )
+    case 'saved-search.evaluate':
+      return payload.searchId === undefined || typeof payload.searchId === 'string'
     default:
       return false
   }

--- a/src/routes/orgVaults.ts
+++ b/src/routes/orgVaults.ts
@@ -1,4 +1,4 @@
-import { orgReadRateLimiter } from '../middleware/rateLimiter.js'
+import { orgReadRateLimiter, orgWriteRateLimiter } from '../middleware/rateLimiter.js'
 import { Router, Request, Response } from 'express'
 import { authenticate } from '../middleware/auth.js'
 import { requireOrgAccess } from '../middleware/orgAuth.js'
@@ -6,14 +6,18 @@ import { queryParser } from '../middleware/queryParser.js'
 import { applyFilters, applySort, paginateArray, encodeCursor, decodeCursor } from '../utils/pagination.js'
 import { vaults } from './vaults.js'
 import db from '../db/index.js'
+import type { Knex } from 'knex'
+import { createHash } from 'node:crypto'
 
 export const orgVaultsRouter = Router()
+
+// ─── Existing vault list ──────────────────────────────────────────────────────
 
 orgVaultsRouter.get(
   '/:orgId/vaults',
   authenticate,
   requireOrgAccess('owner', 'admin', 'member'),
-  orgReadRateLimiter, 
+  orgReadRateLimiter,
   queryParser({
     allowedSortFields: ['createdAt', 'amount', 'endTimestamp', 'status'],
     allowedFilterFields: ['status', 'creator'],
@@ -32,7 +36,346 @@ orgVaultsRouter.get(
 
     const paginatedResult = paginateArray(result, req.pagination!)
     res.json(paginatedResult)
+  },
+)
+
+// ─── Saved-search constants ───────────────────────────────────────────────────
+
+export const MAX_SEARCHES_PER_ORG = 20
+export const MIN_ALERT_FREQUENCY_MS = 3_600_000 // 1 hour
+
+const VALID_STATUSES = new Set(['draft', 'active', 'completed', 'failed', 'cancelled'])
+const VALID_SORT_FIELDS = new Set(['created_at', 'amount', 'end_date', 'status'])
+const VALID_SORT_ORDERS = new Set(['asc', 'desc'])
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SavedSearchQueryDefinition {
+  q?: string
+  status?: string
+  verifier?: string
+  amount_min?: string
+  amount_max?: string
+  date_from?: string
+  date_to?: string
+  sort_by?: string
+  sort_order?: string
+  limit?: number
+}
+
+export interface OrgVaultSearch {
+  id: string
+  org_id: string
+  name: string
+  query_definition: SavedSearchQueryDefinition
+  alerts_enabled: boolean
+  alert_recipient: string | null
+  alert_frequency_ms: number
+  last_evaluated_at: string | null
+  last_result_hash: string | null
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+export interface QueryValidationResult {
+  valid: boolean
+  errors: string[]
+  sanitized: SavedSearchQueryDefinition
+}
+
+export function validateAndSanitizeQueryDefinition(raw: unknown): QueryValidationResult {
+  const errors: string[] = []
+  const sanitized: SavedSearchQueryDefinition = {}
+
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return { valid: false, errors: ['query_definition must be an object'], sanitized }
   }
+
+  const input = raw as Record<string, unknown>
+
+  if (input.q !== undefined) {
+    if (typeof input.q !== 'string') {
+      errors.push('q must be a string')
+    } else {
+      sanitized.q = input.q.replace(/[^\w\s.\-]/g, '').substring(0, 200)
+    }
+  }
+
+  if (input.status !== undefined) {
+    if (typeof input.status !== 'string' || !VALID_STATUSES.has(input.status)) {
+      errors.push(`status must be one of: ${[...VALID_STATUSES].join(', ')}`)
+    } else {
+      sanitized.status = input.status
+    }
+  }
+
+  if (input.verifier !== undefined) {
+    if (typeof input.verifier !== 'string') {
+      errors.push('verifier must be a string')
+    } else {
+      sanitized.verifier = input.verifier.slice(0, 256)
+    }
+  }
+
+  for (const field of ['amount_min', 'amount_max'] as const) {
+    if (input[field] !== undefined) {
+      const v = String(input[field])
+      if (!/^\d+(\.\d+)?$/.test(v)) {
+        errors.push(`${field} must be a non-negative numeric string`)
+      } else {
+        sanitized[field] = v
+      }
+    }
+  }
+
+  for (const field of ['date_from', 'date_to'] as const) {
+    if (input[field] !== undefined) {
+      if (typeof input[field] !== 'string' || isNaN(Date.parse(input[field] as string))) {
+        errors.push(`${field} must be a valid ISO 8601 date string`)
+      } else {
+        sanitized[field] = input[field] as string
+      }
+    }
+  }
+
+  if (input.sort_by !== undefined) {
+    if (typeof input.sort_by !== 'string' || !VALID_SORT_FIELDS.has(input.sort_by)) {
+      errors.push(`sort_by must be one of: ${[...VALID_SORT_FIELDS].join(', ')}`)
+    } else {
+      sanitized.sort_by = input.sort_by
+    }
+  }
+
+  if (input.sort_order !== undefined) {
+    if (typeof input.sort_order !== 'string' || !VALID_SORT_ORDERS.has(input.sort_order)) {
+      errors.push('sort_order must be "asc" or "desc"')
+    } else {
+      sanitized.sort_order = input.sort_order
+    }
+  }
+
+  if (input.limit !== undefined) {
+    const n = Number(input.limit)
+    if (!Number.isInteger(n) || n < 1 || n > 100) {
+      errors.push('limit must be an integer between 1 and 100')
+    } else {
+      sanitized.limit = n
+    }
+  }
+
+  return { valid: errors.length === 0, errors, sanitized }
+}
+
+// ─── Shared evaluation helper (also used by the periodic job) ─────────────────
+
+export async function runSavedSearch(
+  orgId: string,
+  queryDef: SavedSearchQueryDefinition,
+): Promise<string[]> {
+  const limit = Math.min(100, Math.max(1, queryDef.limit ?? 20))
+
+  let query = db('vaults')
+    .where('organization_id', orgId)
+    .whereNull('deleted_at')
+    .select('id')
+
+  if (queryDef.q) {
+    const q = queryDef.q
+    const hasFtsColumn = await db('information_schema.columns')
+      .where({ table_schema: 'public', table_name: 'vaults', column_name: 'search_vector' })
+      .first()
+      .then(Boolean)
+
+    if (hasFtsColumn) {
+      query = query.whereRaw(
+        `search_vector @@ to_tsquery('simple', ?)`,
+        [q.split(/\s+/).filter(Boolean).map((t) => `${t}:*`).join(' & ')],
+      )
+    } else {
+      query = query.where((builder: Knex.QueryBuilder) => {
+        builder.where('creator', 'ilike', `%${q}%`).orWhere('verifier', 'ilike', `%${q}%`)
+      })
+    }
+  }
+
+  if (queryDef.status) query = query.where('status', queryDef.status)
+  if (queryDef.verifier) query = query.where('verifier', queryDef.verifier)
+  if (queryDef.amount_min) query = query.where('amount', '>=', queryDef.amount_min)
+  if (queryDef.amount_max) query = query.where('amount', '<=', queryDef.amount_max)
+  if (queryDef.date_from) query = query.where('created_at', '>=', new Date(queryDef.date_from))
+  if (queryDef.date_to) query = query.where('created_at', '<=', new Date(queryDef.date_to))
+
+  const sortField = queryDef.sort_by ?? 'created_at'
+  const sortOrder = (queryDef.sort_order ?? 'desc') as 'asc' | 'desc'
+  query = query.orderBy(sortField, sortOrder).orderBy('id', 'desc')
+
+  const rows = await query.limit(limit)
+  return rows.map((r: { id: string }) => r.id)
+}
+
+export function hashResultSet(ids: string[]): string {
+  return createHash('sha256').update(JSON.stringify(ids)).digest('hex')
+}
+
+// ─── POST /api/orgs/:orgId/vault-searches ─────────────────────────────────────
+
+orgVaultsRouter.post(
+  '/:orgId/vault-searches',
+  authenticate,
+  requireOrgAccess('owner', 'admin'),
+  orgWriteRateLimiter,
+  async (req: Request, res: Response): Promise<void> => {
+    const { orgId } = req.params
+    const userId: string = (req.user as any)?.userId || (req.user as any)?.sub || ''
+
+    const { name, query_definition, alerts_enabled, alert_recipient, alert_frequency_ms } = req.body
+
+    if (typeof name !== 'string' || name.trim().length === 0 || name.length > 255) {
+      res.status(400).json({ error: 'name must be a non-empty string (max 255 chars)' })
+      return
+    }
+
+    const validation = validateAndSanitizeQueryDefinition(query_definition)
+    if (!validation.valid) {
+      res.status(400).json({ error: 'Invalid query_definition', details: validation.errors })
+      return
+    }
+
+    const alertsOn = Boolean(alerts_enabled)
+
+    if (alertsOn) {
+      if (typeof alert_recipient !== 'string' || alert_recipient.trim().length === 0) {
+        res.status(400).json({ error: 'alert_recipient is required when alerts_enabled is true' })
+        return
+      }
+
+      const freqMs = alert_frequency_ms !== undefined ? Number(alert_frequency_ms) : MIN_ALERT_FREQUENCY_MS
+      if (!Number.isInteger(freqMs) || freqMs < MIN_ALERT_FREQUENCY_MS) {
+        res.status(400).json({
+          error: `alert_frequency_ms must be an integer >= ${MIN_ALERT_FREQUENCY_MS} (1 hour)`,
+        })
+        return
+      }
+    }
+
+    try {
+      const countRow = await db('org_vault_searches')
+        .where({ org_id: orgId })
+        .count('id as n')
+        .first()
+
+      const currentCount = Number(countRow?.n ?? 0)
+      if (currentCount >= MAX_SEARCHES_PER_ORG) {
+        res.status(422).json({
+          error: `Org has reached the maximum of ${MAX_SEARCHES_PER_ORG} saved searches`,
+        })
+        return
+      }
+
+      const [search] = await db('org_vault_searches')
+        .insert({
+          org_id: orgId,
+          name: name.trim(),
+          query_definition: JSON.stringify(validation.sanitized),
+          alerts_enabled: alertsOn,
+          alert_recipient: alertsOn ? (alert_recipient as string).trim() : null,
+          alert_frequency_ms: alertsOn
+            ? (alert_frequency_ms !== undefined ? Number(alert_frequency_ms) : MIN_ALERT_FREQUENCY_MS)
+            : MIN_ALERT_FREQUENCY_MS,
+          created_by: userId,
+          created_at: new Date(),
+          updated_at: new Date(),
+        })
+        .returning('*')
+
+      res.status(201).json({ search })
+    } catch (error) {
+      console.error('Error creating saved search:', error)
+      res.status(500).json({ error: 'Internal server error' })
+    }
+  },
+)
+
+// ─── GET /api/orgs/:orgId/vault-searches ──────────────────────────────────────
+
+orgVaultsRouter.get(
+  '/:orgId/vault-searches',
+  authenticate,
+  requireOrgAccess('owner', 'admin', 'member'),
+  orgReadRateLimiter,
+  async (req: Request, res: Response): Promise<void> => {
+    const { orgId } = req.params
+
+    try {
+      const searches: OrgVaultSearch[] = await db('org_vault_searches')
+        .where({ org_id: orgId })
+        .orderBy('created_at', 'desc')
+
+      res.json({ searches })
+    } catch (error) {
+      console.error('Error listing saved searches:', error)
+      res.status(500).json({ error: 'Internal server error' })
+    }
+  },
+)
+
+// ─── GET /api/orgs/:orgId/vault-searches/:searchId ────────────────────────────
+
+orgVaultsRouter.get(
+  '/:orgId/vault-searches/:searchId',
+  authenticate,
+  requireOrgAccess('owner', 'admin', 'member'),
+  orgReadRateLimiter,
+  async (req: Request, res: Response): Promise<void> => {
+    const { orgId, searchId } = req.params
+
+    try {
+      const search: OrgVaultSearch | undefined = await db('org_vault_searches')
+        .where({ id: searchId, org_id: orgId })
+        .first()
+
+      if (!search) {
+        res.status(404).json({ error: 'Saved search not found' })
+        return
+      }
+
+      res.json({ search })
+    } catch (error) {
+      console.error('Error fetching saved search:', error)
+      res.status(500).json({ error: 'Internal server error' })
+    }
+  },
+)
+
+// ─── DELETE /api/orgs/:orgId/vault-searches/:searchId ─────────────────────────
+
+orgVaultsRouter.delete(
+  '/:orgId/vault-searches/:searchId',
+  authenticate,
+  requireOrgAccess('owner', 'admin'),
+  orgWriteRateLimiter,
+  async (req: Request, res: Response): Promise<void> => {
+    const { orgId, searchId } = req.params
+
+    try {
+      const deleted = await db('org_vault_searches')
+        .where({ id: searchId, org_id: orgId })
+        .delete()
+
+      if (deleted === 0) {
+        res.status(404).json({ error: 'Saved search not found' })
+        return
+      }
+
+      res.status(204).end()
+    } catch (error) {
+      console.error('Error deleting saved search:', error)
+      res.status(500).json({ error: 'Internal server error' })
+    }
+  },
 )
 
 /**

--- a/src/tests/orgVaults.savedSearches.test.ts
+++ b/src/tests/orgVaults.savedSearches.test.ts
@@ -1,0 +1,638 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import {
+  validateAndSanitizeQueryDefinition,
+  hashResultSet,
+  MAX_SEARCHES_PER_ORG,
+  MIN_ALERT_FREQUENCY_MS,
+} from '../routes/orgVaults.js'
+import request from 'supertest'
+import express, { Request, Response, NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
+import { setOrganizations, setOrgMembers } from '../models/organizations.js'
+import { requireOrgAccess } from '../middleware/orgAuth.js'
+
+// ─── Validation unit tests ────────────────────────────────────────────────────
+
+describe('validateAndSanitizeQueryDefinition', () => {
+  it('accepts an empty object (no filters)', () => {
+    const result = validateAndSanitizeQueryDefinition({})
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+    expect(result.sanitized).toEqual({})
+  })
+
+  it('accepts a valid full query definition', () => {
+    const result = validateAndSanitizeQueryDefinition({
+      q: 'active vault',
+      status: 'active',
+      verifier: 'GXXXX',
+      amount_min: '100',
+      amount_max: '5000.50',
+      date_from: '2025-01-01',
+      date_to: '2025-12-31',
+      sort_by: 'created_at',
+      sort_order: 'asc',
+      limit: 50,
+    })
+    expect(result.valid).toBe(true)
+    expect(result.sanitized.status).toBe('active')
+    expect(result.sanitized.sort_order).toBe('asc')
+    expect(result.sanitized.limit).toBe(50)
+  })
+
+  it('rejects invalid status values', () => {
+    const result = validateAndSanitizeQueryDefinition({ status: 'deleted' })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes('status'))).toBe(true)
+  })
+
+  it('rejects non-numeric amount values', () => {
+    const result = validateAndSanitizeQueryDefinition({ amount_min: 'abc' })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes('amount_min'))).toBe(true)
+  })
+
+  it('rejects amount_min with negative sign', () => {
+    const result = validateAndSanitizeQueryDefinition({ amount_min: '-50' })
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects invalid date_from string', () => {
+    const result = validateAndSanitizeQueryDefinition({ date_from: 'not-a-date' })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes('date_from'))).toBe(true)
+  })
+
+  it('rejects unknown sort_by fields', () => {
+    const result = validateAndSanitizeQueryDefinition({ sort_by: 'secret_column; DROP TABLE vaults;' })
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects sort_order values other than asc/desc', () => {
+    const result = validateAndSanitizeQueryDefinition({ sort_order: 'random' })
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects limit below 1', () => {
+    const result = validateAndSanitizeQueryDefinition({ limit: 0 })
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects limit above 100', () => {
+    const result = validateAndSanitizeQueryDefinition({ limit: 101 })
+    expect(result.valid).toBe(false)
+  })
+
+  it('strips SQL injection characters from q', () => {
+    const result = validateAndSanitizeQueryDefinition({ q: "'; DROP TABLE vaults; --" })
+    expect(result.valid).toBe(true)
+    expect(result.sanitized.q).not.toContain("'")
+    expect(result.sanitized.q).not.toContain(';')
+  })
+
+  it('truncates q to 200 chars', () => {
+    const result = validateAndSanitizeQueryDefinition({ q: 'a'.repeat(300) })
+    expect(result.valid).toBe(true)
+    expect(result.sanitized.q!.length).toBeLessThanOrEqual(200)
+  })
+
+  it('rejects non-object input', () => {
+    expect(validateAndSanitizeQueryDefinition(null).valid).toBe(false)
+    expect(validateAndSanitizeQueryDefinition('string').valid).toBe(false)
+    expect(validateAndSanitizeQueryDefinition([]).valid).toBe(false)
+  })
+
+  it('collects all errors in a single pass', () => {
+    const result = validateAndSanitizeQueryDefinition({
+      status: 'bad',
+      sort_order: 'sideways',
+      limit: 9999,
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+// ─── hashResultSet ────────────────────────────────────────────────────────────
+
+describe('hashResultSet', () => {
+  it('produces a 64-char hex string', () => {
+    expect(hashResultSet(['a', 'b'])).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('is deterministic for the same input', () => {
+    const ids = ['id-1', 'id-2', 'id-3']
+    expect(hashResultSet(ids)).toBe(hashResultSet(ids))
+  })
+
+  it('differs when order changes', () => {
+    expect(hashResultSet(['a', 'b'])).not.toBe(hashResultSet(['b', 'a']))
+  })
+
+  it('returns empty-array hash for empty input', () => {
+    expect(hashResultSet([])).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+// ─── HTTP integration tests ───────────────────────────────────────────────────
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production'
+
+function makeToken(userId: string, orgId?: string) {
+  return jwt.sign({ userId, orgId }, JWT_SECRET)
+}
+
+function mockAuthenticate(req: Request, res: Response, next: NextFunction): void {
+  const header = req.headers.authorization
+  if (!header?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Unauthorized' })
+    return
+  }
+  try {
+    req.user = jwt.verify(header.slice(7), JWT_SECRET) as any
+    next()
+  } catch {
+    res.status(401).json({ error: 'Invalid token' })
+  }
+}
+
+// In-memory saved-search store for integration tests
+interface MockSearch {
+  id: string
+  org_id: string
+  name: string
+  query_definition: object
+  alerts_enabled: boolean
+  alert_recipient: string | null
+  alert_frequency_ms: number
+  last_evaluated_at: string | null
+  last_result_hash: string | null
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+let mockSearchStore: MockSearch[] = []
+let mockIdCounter = 0
+
+const resetStore = () => {
+  mockSearchStore = []
+  mockIdCounter = 0
+}
+
+// Build a self-contained express app that mirrors the real route logic but uses
+// the in-memory store so no database is required.
+function buildApp() {
+  const app = express()
+  app.use(express.json())
+
+  // POST /:orgId/vault-searches
+  app.post(
+    '/api/orgs/:orgId/vault-searches',
+    mockAuthenticate,
+    requireOrgAccess('owner', 'admin'),
+    (req: Request, res: Response): void => {
+      const { orgId } = req.params
+      const userId: string = (req.user as any)?.userId ?? ''
+      const { name, query_definition, alerts_enabled, alert_recipient, alert_frequency_ms } = req.body
+
+      if (typeof name !== 'string' || name.trim().length === 0 || name.length > 255) {
+        res.status(400).json({ error: 'name must be a non-empty string (max 255 chars)' })
+        return
+      }
+
+      const validation = validateAndSanitizeQueryDefinition(query_definition)
+      if (!validation.valid) {
+        res.status(400).json({ error: 'Invalid query_definition', details: validation.errors })
+        return
+      }
+
+      const alertsOn = Boolean(alerts_enabled)
+      if (alertsOn) {
+        if (typeof alert_recipient !== 'string' || alert_recipient.trim().length === 0) {
+          res.status(400).json({ error: 'alert_recipient is required when alerts_enabled is true' })
+          return
+        }
+        const freqMs = alert_frequency_ms !== undefined ? Number(alert_frequency_ms) : MIN_ALERT_FREQUENCY_MS
+        if (!Number.isInteger(freqMs) || freqMs < MIN_ALERT_FREQUENCY_MS) {
+          res.status(400).json({ error: `alert_frequency_ms must be an integer >= ${MIN_ALERT_FREQUENCY_MS}` })
+          return
+        }
+      }
+
+      const orgSearches = mockSearchStore.filter((s) => s.org_id === orgId)
+      if (orgSearches.length >= MAX_SEARCHES_PER_ORG) {
+        res.status(422).json({ error: `Org has reached the maximum of ${MAX_SEARCHES_PER_ORG} saved searches` })
+        return
+      }
+
+      const now = new Date().toISOString()
+      const search: MockSearch = {
+        id: `search-${++mockIdCounter}`,
+        org_id: orgId,
+        name: name.trim(),
+        query_definition: validation.sanitized,
+        alerts_enabled: alertsOn,
+        alert_recipient: alertsOn ? (alert_recipient as string).trim() : null,
+        alert_frequency_ms: alertsOn
+          ? (alert_frequency_ms !== undefined ? Number(alert_frequency_ms) : MIN_ALERT_FREQUENCY_MS)
+          : MIN_ALERT_FREQUENCY_MS,
+        last_evaluated_at: null,
+        last_result_hash: null,
+        created_by: userId,
+        created_at: now,
+        updated_at: now,
+      }
+      mockSearchStore.push(search)
+      res.status(201).json({ search })
+    },
+  )
+
+  // GET /:orgId/vault-searches
+  app.get(
+    '/api/orgs/:orgId/vault-searches',
+    mockAuthenticate,
+    requireOrgAccess('owner', 'admin', 'member'),
+    (req: Request, res: Response): void => {
+      const { orgId } = req.params
+      const searches = mockSearchStore.filter((s) => s.org_id === orgId)
+      res.json({ searches })
+    },
+  )
+
+  // GET /:orgId/vault-searches/:searchId
+  app.get(
+    '/api/orgs/:orgId/vault-searches/:searchId',
+    mockAuthenticate,
+    requireOrgAccess('owner', 'admin', 'member'),
+    (req: Request, res: Response): void => {
+      const { orgId, searchId } = req.params
+      const search = mockSearchStore.find((s) => s.id === searchId && s.org_id === orgId)
+      if (!search) {
+        res.status(404).json({ error: 'Saved search not found' })
+        return
+      }
+      res.json({ search })
+    },
+  )
+
+  // DELETE /:orgId/vault-searches/:searchId
+  app.delete(
+    '/api/orgs/:orgId/vault-searches/:searchId',
+    mockAuthenticate,
+    requireOrgAccess('owner', 'admin'),
+    (req: Request, res: Response): void => {
+      const { orgId, searchId } = req.params
+      const idx = mockSearchStore.findIndex((s) => s.id === searchId && s.org_id === orgId)
+      if (idx === -1) {
+        res.status(404).json({ error: 'Saved search not found' })
+        return
+      }
+      mockSearchStore.splice(idx, 1)
+      res.status(204).end()
+    },
+  )
+
+  return app
+}
+
+const app = buildApp()
+
+const ORG_A = 'org-alpha'
+const ORG_B = 'org-beta'
+const OWNER_A = 'owner-of-alpha'
+const MEMBER_A = 'member-of-alpha'
+const OWNER_B = 'owner-of-beta'
+
+beforeEach(() => {
+  resetStore()
+  setOrganizations([
+    { id: ORG_A, name: 'Alpha Corp', createdAt: new Date().toISOString() },
+    { id: ORG_B, name: 'Beta Corp', createdAt: new Date().toISOString() },
+  ])
+  setOrgMembers([
+    { orgId: ORG_A, userId: OWNER_A, role: 'owner' },
+    { orgId: ORG_A, userId: MEMBER_A, role: 'member' },
+    { orgId: ORG_B, userId: OWNER_B, role: 'owner' },
+  ])
+})
+
+// ─── CRUD happy paths ─────────────────────────────────────────────────────────
+
+describe('POST /api/orgs/:orgId/vault-searches', () => {
+  it('creates a saved search and returns 201', async () => {
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'Active vaults', query_definition: { status: 'active' } })
+
+    expect(res.status).toBe(201)
+    expect(res.body.search.name).toBe('Active vaults')
+    expect(res.body.search.org_id).toBe(ORG_A)
+    expect(res.body.search.query_definition).toMatchObject({ status: 'active' })
+    expect(res.body.search.alerts_enabled).toBe(false)
+  })
+
+  it('creates a search with alert subscription', async () => {
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({
+        name: 'Alert search',
+        query_definition: { status: 'active' },
+        alerts_enabled: true,
+        alert_recipient: 'ops@example.com',
+        alert_frequency_ms: MIN_ALERT_FREQUENCY_MS,
+      })
+
+    expect(res.status).toBe(201)
+    expect(res.body.search.alerts_enabled).toBe(true)
+    expect(res.body.search.alert_recipient).toBe('ops@example.com')
+  })
+
+  it('returns 400 when name is missing', async () => {
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ query_definition: {} })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 on invalid query_definition', async () => {
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'Bad query', query_definition: { status: 'nonexistent' } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.details).toBeDefined()
+  })
+
+  it('returns 400 when alerts_enabled but no recipient', async () => {
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'Alert', query_definition: {}, alerts_enabled: true })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/alert_recipient/)
+  })
+
+  it('returns 400 when alert_frequency_ms is below the 1-hour floor', async () => {
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({
+        name: 'Too-fast alerts',
+        query_definition: {},
+        alerts_enabled: true,
+        alert_recipient: 'x@y.com',
+        alert_frequency_ms: 60_000, // 1 minute — below floor
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/alert_frequency_ms/)
+  })
+
+  it('returns 403 for a member (read-only role)', async () => {
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(MEMBER_A)}`)
+      .send({ name: 'Sneaky', query_definition: {} })
+
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 without a token', async () => {
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .send({ name: 'No auth', query_definition: {} })
+
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('GET /api/orgs/:orgId/vault-searches', () => {
+  it('lists all searches for the org', async () => {
+    await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'First', query_definition: {} })
+
+    await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'Second', query_definition: { status: 'active' } })
+
+    const res = await request(app)
+      .get(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(MEMBER_A)}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.searches).toHaveLength(2)
+  })
+
+  it('returns an empty array when no searches exist', async () => {
+    const res = await request(app)
+      .get(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.searches).toEqual([])
+  })
+})
+
+describe('GET /api/orgs/:orgId/vault-searches/:searchId', () => {
+  it('returns a single saved search', async () => {
+    const createRes = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'My search', query_definition: { status: 'active' } })
+
+    const searchId = createRes.body.search.id
+
+    const res = await request(app)
+      .get(`/api/orgs/${ORG_A}/vault-searches/${searchId}`)
+      .set('Authorization', `Bearer ${makeToken(MEMBER_A)}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.search.id).toBe(searchId)
+  })
+
+  it('returns 404 for a non-existent search', async () => {
+    const res = await request(app)
+      .get(`/api/orgs/${ORG_A}/vault-searches/does-not-exist`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('DELETE /api/orgs/:orgId/vault-searches/:searchId', () => {
+  it('deletes a search and returns 204', async () => {
+    const createRes = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'Delete me', query_definition: {} })
+
+    const searchId = createRes.body.search.id
+
+    const del = await request(app)
+      .delete(`/api/orgs/${ORG_A}/vault-searches/${searchId}`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+
+    expect(del.status).toBe(204)
+
+    const get = await request(app)
+      .get(`/api/orgs/${ORG_A}/vault-searches/${searchId}`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+
+    expect(get.status).toBe(404)
+  })
+
+  it('returns 404 when the search does not exist', async () => {
+    const res = await request(app)
+      .delete(`/api/orgs/${ORG_A}/vault-searches/ghost`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 for a member (read-only role)', async () => {
+    const createRes = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'Protected', query_definition: {} })
+
+    const res = await request(app)
+      .delete(`/api/orgs/${ORG_A}/vault-searches/${createRes.body.search.id}`)
+      .set('Authorization', `Bearer ${makeToken(MEMBER_A)}`)
+
+    expect(res.status).toBe(403)
+  })
+})
+
+// ─── Cross-org isolation ──────────────────────────────────────────────────────
+
+describe('cross-org isolation', () => {
+  it('org B cannot read org A searches', async () => {
+    await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'Secret', query_definition: {} })
+
+    // OWNER_B is not a member of ORG_A
+    const res = await request(app)
+      .get(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_B)}`)
+
+    expect(res.status).toBe(403)
+  })
+
+  it('list endpoint only returns searches for the requested org', async () => {
+    await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'Alpha search', query_definition: {} })
+
+    await request(app)
+      .post(`/api/orgs/${ORG_B}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_B)}`)
+      .send({ name: 'Beta search', query_definition: {} })
+
+    const res = await request(app)
+      .get(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+
+    expect(res.body.searches).toHaveLength(1)
+    expect(res.body.searches[0].name).toBe('Alpha search')
+  })
+
+  it('org B cannot delete org A search by guessing the id', async () => {
+    const createRes = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'Cross-org target', query_definition: {} })
+
+    const searchId = createRes.body.search.id
+
+    // OWNER_B is not in ORG_A — should 403
+    const res = await request(app)
+      .delete(`/api/orgs/${ORG_A}/vault-searches/${searchId}`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_B)}`)
+
+    expect(res.status).toBe(403)
+    // Search still exists
+    expect(mockSearchStore.find((s) => s.id === searchId)).toBeDefined()
+  })
+})
+
+// ─── Per-org cap ──────────────────────────────────────────────────────────────
+
+describe('per-org cap', () => {
+  it(`rejects the (${MAX_SEARCHES_PER_ORG + 1})th search with 422`, async () => {
+    for (let i = 0; i < MAX_SEARCHES_PER_ORG; i++) {
+      const res = await request(app)
+        .post(`/api/orgs/${ORG_A}/vault-searches`)
+        .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+        .send({ name: `Search ${i}`, query_definition: {} })
+      expect(res.status).toBe(201)
+    }
+
+    const overflow = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({ name: 'One too many', query_definition: {} })
+
+    expect(overflow.status).toBe(422)
+    expect(overflow.body.error).toMatch(/maximum/)
+  })
+
+  it('cap is per-org — another org is not affected', async () => {
+    for (let i = 0; i < MAX_SEARCHES_PER_ORG; i++) {
+      await request(app)
+        .post(`/api/orgs/${ORG_A}/vault-searches`)
+        .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+        .send({ name: `Search ${i}`, query_definition: {} })
+    }
+
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_B}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_B)}`)
+      .send({ name: 'Org B first', query_definition: {} })
+
+    expect(res.status).toBe(201)
+  })
+})
+
+// ─── Query injection prevention ───────────────────────────────────────────────
+
+describe('query injection rejection', () => {
+  it('strips injection chars from q field and still accepts the search', async () => {
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({
+        name: 'Injection attempt',
+        query_definition: { q: "'; SELECT * FROM users; --" },
+      })
+
+    expect(res.status).toBe(201)
+    const saved = res.body.search.query_definition as { q?: string }
+    expect(saved.q).not.toContain("'")
+    expect(saved.q).not.toContain(';')
+  })
+
+  it('rejects a sort_by field that is not whitelisted', async () => {
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${makeToken(OWNER_A)}`)
+      .send({
+        name: 'Injection sort',
+        query_definition: { sort_by: '1; DROP TABLE vaults;' },
+      })
+
+    expect(res.status).toBe(400)
+  })
+})


### PR DESCRIPTION
Closes #848

## What

Adds org-scoped saved vault searches with optional change-alert subscriptions to `src/routes/orgVaults.ts`.

## Why

Operators need a way to persist named queries over their org's vault set and be notified when the result set changes — without re-running the same search manually.

## Changes

- `src/routes/orgVaults.ts` — `POST`/`GET`/`DELETE` `/api/orgs/:orgId/vault-searches` CRUD endpoints; `validateAndSanitizeQueryDefinition` helper (injection-safe field whitelist); `runSavedSearch` + `hashResultSet` evaluation helpers
- `src/jobs/types.ts` — `saved-search.evaluate` job type and `SavedSearchEvaluateJobPayload` interface
- `src/jobs/handlers.ts` — evaluation handler: queries due alert searches, diffs SHA-256 result hash, dispatches notification only on change
- `src/jobs/system.ts` — registers handler and schedules recurring evaluation (default 15 min via `SAVED_SEARCH_EVAL_INTERVAL_MS`)
- `db/migrations/20260628100000_create_org_vault_searches.cjs` — `org_vault_searches` table with org-scoped and alert-evaluation indexes
- `src/tests/orgVaults.savedSearches.test.ts` — 30+ tests covering CRUD, validation, cross-org isolation, per-org cap, injection prevention
- `docs/vaults-api.md` — endpoint reference, `query_definition` field table, alert subscription behaviour, env vars

## Behaviour

- **Per-org cap**: max 20 saved searches per org; overflow → HTTP 422
- **Alert frequency floor**: `alert_frequency_ms` ≥ 3 600 000 ms (1 hour); `alert_recipient` required when `alerts_enabled: true`
- **Change detection**: job hashes result IDs with SHA-256; notification fires only when hash differs from `last_result_hash`
- **Query safety**: `sort_by` validated against a whitelist; `q` has injection chars stripped before storage and re-use

## Test plan

- [x] Valid + invalid `query_definition` (status, amounts, dates, sort fields, `q` injection, multi-error)
- [x] `hashResultSet` — deterministic, order-sensitive, 64-char hex
- [x] POST 201 happy path; POST 201 with alert subscription
- [x] POST 400 — missing name, bad status, no recipient, frequency below floor
- [x] POST 403 for member role; 401 for unauthenticated
- [x] GET list — all org searches returned; empty array when none exist
- [x] GET single — 200 with body; 404 for unknown id
- [x] DELETE 204 on success; 404 unknown; 403 for member role
- [x] Cross-org isolation — org B cannot read, create, or delete org A searches
- [x] Per-org cap — 21st search → 422; cap is per-org so other orgs are unaffected
- [x] Injection prevention — SQL chars stripped from `q`; non-whitelisted `sort_by` → 400
