### PR TITLE
feat: per-org notification preferences and channel opt-out

### DIFF
--- a/db/migrations/20260628000000_create_org_notification_preferences.cjs
+++ b/db/migrations/20260628000000_create_org_notification_preferences.cjs
@@ -1,0 +1,28 @@
+/**
+ * Migration for per-organization notification preferences.
+ *
+ * Each row toggles either a single category on the 'email' channel
+ * (category = a known category name) or the whole channel regardless of
+ * category (category = '' sentinel, meaning "all categories").
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('org_notification_preferences', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+    table.uuid('organization_id').notNullable().references('id').inTable('organizations').onDelete('CASCADE')
+    table.string('category', 100).notNullable().defaultTo('')
+    table.string('channel', 50).notNullable().defaultTo('email')
+    table.boolean('enabled').notNullable().defaultTo(true)
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+    table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now())
+
+    table.unique(['organization_id', 'category', 'channel'])
+  })
+
+  await knex.raw(
+    'CREATE INDEX IF NOT EXISTS idx_org_notification_preferences_org ON org_notification_preferences (organization_id)',
+  )
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.dropTableIfExists('org_notification_preferences')
+}

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -70,6 +70,28 @@ Milestone reminders use the `milestone_reminder` notification type and include:
 - Milestone ID
 - Due date
 
+## Per-Organization Notification Preferences
+
+`src/services/notification.ts` consults per-organization preferences before dispatching a vault deadline reminder or lifecycle alert (`createNotification`). An org with no stored preferences behaves exactly as before — every category and channel is enabled by default.
+
+### Data Model
+
+Preferences are stored in the `org_notification_preferences` table (see `src/models/notificationPreferences.ts`), one row per `(organization_id, category, channel)`:
+
+- **Category toggle**: a row with a known category (e.g. `vault_failure`, `milestone_reminder`) disables just that category on the given channel.
+- **Channel opt-out**: a row with the empty-string category sentinel disables every category on that channel, unless a category-specific row overrides it.
+
+Known categories: `vault_failure`, `milestone_reminder`. Known channels: `email`.
+
+### API
+
+- `GET /api/orgs/:orgId/notification-preferences` — any org member can view the resolved preferences (`{ organizationId, categories, channels }`).
+- `PUT /api/orgs/:orgId/notification-preferences` — owners/admins can update preferences by sending `{ categories?: { [category]: boolean }, channels?: { [channel]: boolean } }`. Unknown category or channel names are rejected with `400`.
+
+### Dispatch Behavior
+
+`createNotification` resolves the notification's `organization_id` and `channel` (defaults to `'email'`) and skips insertion entirely (returning `null`) when the category or channel is disabled for that org. Notifications without an `organization_id` are never suppressed.
+
 ## Observability
 
 - **Metrics**: Queue metrics can be accessed via `GET /api/jobs/metrics`.

--- a/src/app-bootstrap.ts
+++ b/src/app-bootstrap.ts
@@ -23,6 +23,7 @@ import { adminWebhooksRouter } from './routes/adminWebhooks.js'
 import { verificationsRouter } from './routes/verifications.js'
 import { apiKeysRouter } from './routes/apiKeys.js'
 import { notificationsRouter } from './routes/notifications.js'
+import { notificationPreferencesRouter } from './routes/notificationPreferences.js'
 import { webhooksRouter } from './routes/webhooks.js'
 import { graphqlRouter } from './routes/graphql.js'
 import { createNotificationService, NotificationService } from './services/notifications/factory.js'
@@ -68,6 +69,7 @@ export function bootstrapApp(options: BootstrapOptions = {}) {
   app.use('/api/organizations', orgAnalyticsRouter)
   app.use('/api/organizations', orgMembersRouter)
   app.use('/api/orgs', orgMembersRouter)
+  app.use('/api/orgs', notificationPreferencesRouter)
   app.use('/api/organizations/:orgId/graphql', graphqlRouter)
   app.use('/api/admin', adminRouter)
   app.use('/api/admin/verifiers', adminVerifiersRouter)

--- a/src/models/notificationPreferences.ts
+++ b/src/models/notificationPreferences.ts
@@ -1,0 +1,119 @@
+import db from '../db/index.js'
+
+// Sentinel category value meaning "every category on this channel" — used to
+// represent a whole-channel opt-out without one row per known category.
+const ALL_CATEGORIES = ''
+
+export const ALLOWED_CATEGORIES = ['vault_failure', 'milestone_reminder'] as const
+export type NotificationCategory = (typeof ALLOWED_CATEGORIES)[number]
+
+export const ALLOWED_CHANNELS = ['email'] as const
+export type NotificationChannel = (typeof ALLOWED_CHANNELS)[number]
+
+export interface OrgNotificationPreferences {
+  organizationId: string
+  categories: Record<NotificationCategory, boolean>
+  channels: Record<NotificationChannel, boolean>
+}
+
+export interface NotificationPreferencesInput {
+  categories?: Partial<Record<string, boolean>>
+  channels?: Partial<Record<string, boolean>>
+}
+
+export class UnknownPreferenceKeyError extends Error {
+  constructor(kind: 'category' | 'channel', key: string) {
+    super(`Unknown ${kind}: ${key}`)
+  }
+}
+
+interface PreferenceRow {
+  category: string
+  channel: string
+  enabled: boolean
+}
+
+function defaultCategories(): Record<NotificationCategory, boolean> {
+  return Object.fromEntries(ALLOWED_CATEGORIES.map((c) => [c, true])) as Record<NotificationCategory, boolean>
+}
+
+function defaultChannels(): Record<NotificationChannel, boolean> {
+  return Object.fromEntries(ALLOWED_CHANNELS.map((c) => [c, true])) as Record<NotificationChannel, boolean>
+}
+
+export async function getOrgNotificationPreferences(organizationId: string): Promise<OrgNotificationPreferences> {
+  const rows: PreferenceRow[] = await db('org_notification_preferences')
+    .where({ organization_id: organizationId })
+    .select('category', 'channel', 'enabled')
+
+  const categories = defaultCategories()
+  const channels = defaultChannels()
+
+  for (const row of rows) {
+    if (row.category === ALL_CATEGORIES) {
+      if ((ALLOWED_CHANNELS as readonly string[]).includes(row.channel)) {
+        channels[row.channel as NotificationChannel] = row.enabled
+      }
+    } else if ((ALLOWED_CATEGORIES as readonly string[]).includes(row.category)) {
+      categories[row.category as NotificationCategory] = row.enabled
+    }
+  }
+
+  return { organizationId, categories, channels }
+}
+
+export async function setOrgNotificationPreferences(
+  organizationId: string,
+  input: NotificationPreferencesInput,
+): Promise<OrgNotificationPreferences> {
+  const rows: { organization_id: string; category: string; channel: string; enabled: boolean }[] = []
+
+  for (const [category, enabled] of Object.entries(input.categories ?? {})) {
+    if (!(ALLOWED_CATEGORIES as readonly string[]).includes(category)) {
+      throw new UnknownPreferenceKeyError('category', category)
+    }
+    rows.push({ organization_id: organizationId, category, channel: 'email', enabled: enabled! })
+  }
+
+  for (const [channel, enabled] of Object.entries(input.channels ?? {})) {
+    if (!(ALLOWED_CHANNELS as readonly string[]).includes(channel)) {
+      throw new UnknownPreferenceKeyError('channel', channel)
+    }
+    rows.push({ organization_id: organizationId, category: ALL_CATEGORIES, channel, enabled: enabled! })
+  }
+
+  if (rows.length > 0) {
+    await db('org_notification_preferences')
+      .insert(rows)
+      .onConflict(['organization_id', 'category', 'channel'])
+      .merge(['enabled', 'updated_at'])
+  }
+
+  return getOrgNotificationPreferences(organizationId)
+}
+
+/**
+ * Consulted by the dispatch path before a notification is created. A
+ * category-specific row always wins over the whole-channel row, which in
+ * turn wins over the all-enabled default.
+ */
+export async function isNotificationEnabled(
+  organizationId: string | null | undefined,
+  category: string,
+  channel: string = 'email',
+): Promise<boolean> {
+  if (!organizationId) return true
+
+  const rows: PreferenceRow[] = await db('org_notification_preferences')
+    .where({ organization_id: organizationId, channel })
+    .whereIn('category', [category, ALL_CATEGORIES])
+    .select('category', 'enabled')
+
+  const categoryRow = rows.find((r) => r.category === category)
+  if (categoryRow) return categoryRow.enabled
+
+  const channelRow = rows.find((r) => r.category === ALL_CATEGORIES)
+  if (channelRow) return channelRow.enabled
+
+  return true
+}

--- a/src/routes/notificationPreferences.ts
+++ b/src/routes/notificationPreferences.ts
@@ -1,0 +1,57 @@
+import { Router, type Request, type Response, type NextFunction } from 'express'
+import { authenticate } from '../middleware/auth.js'
+import { requireOrgAccess } from '../middleware/orgAuth.js'
+import { AppError } from '../middleware/errorHandler.js'
+import {
+  getOrgNotificationPreferences,
+  setOrgNotificationPreferences,
+  UnknownPreferenceKeyError,
+} from '../models/notificationPreferences.js'
+
+export const notificationPreferencesRouter = Router()
+
+// ─── GET /api/orgs/:orgId/notification-preferences ─────────────────────────
+// Any member can view the org's notification preferences.
+
+notificationPreferencesRouter.get(
+  '/:orgId/notification-preferences',
+  authenticate,
+  requireOrgAccess('owner', 'admin', 'member'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const preferences = await getOrgNotificationPreferences(req.params.orgId)
+      res.json(preferences)
+    } catch (err) {
+      next(err)
+    }
+  },
+)
+
+// ─── PUT /api/orgs/:orgId/notification-preferences ──────────────────────────
+// Only owners and admins may change notification preferences.
+
+notificationPreferencesRouter.put(
+  '/:orgId/notification-preferences',
+  authenticate,
+  requireOrgAccess('owner', 'admin'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { categories, channels } = req.body ?? {}
+
+    if (categories !== undefined && (typeof categories !== 'object' || categories === null || Array.isArray(categories))) {
+      return next(AppError.badRequest('categories must be an object of category to boolean'))
+    }
+    if (channels !== undefined && (typeof channels !== 'object' || channels === null || Array.isArray(channels))) {
+      return next(AppError.badRequest('channels must be an object of channel to boolean'))
+    }
+
+    try {
+      const preferences = await setOrgNotificationPreferences(req.params.orgId, { categories, channels })
+      res.json(preferences)
+    } catch (err) {
+      if (err instanceof UnknownPreferenceKeyError) {
+        return next(AppError.badRequest(err.message))
+      }
+      next(err)
+    }
+  },
+)

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -1,5 +1,6 @@
 import db from '../db/index.js'
 import type { Notification, CreateNotificationInput } from '../types/notification.js'
+import { isNotificationEnabled } from '../models/notificationPreferences.js'
 
 // Minimal structured logger — emits JSON to stdout, no PII (no user_id, title, message)
 const log = {
@@ -19,7 +20,13 @@ const log = {
   },
 }
 
-export const createNotification = async (input: CreateNotificationInput): Promise<Notification> => {
+export const createNotification = async (input: CreateNotificationInput): Promise<Notification | null> => {
+  const channel = input.channel ?? 'email'
+  const enabled = await isNotificationEnabled(input.organization_id, input.type, channel)
+  if (!enabled) {
+    return null
+  }
+
   const row: Record<string, unknown> = {
     user_id: input.user_id,
     type: input.type,

--- a/src/services/vaultExpiry.service.ts
+++ b/src/services/vaultExpiry.service.ts
@@ -38,7 +38,8 @@ export const markVaultExpiries = async (
       type: 'vault_failure',
       title: 'Vault Deadline Reached',
       message: 'A vault in your account has expired and been marked as failed.',
-      data: { vaultId: vault.id }
+      data: { vaultId: vault.id },
+      organization_id: vault.organization_id
     })
   }
 
@@ -61,6 +62,7 @@ export const sendMilestoneReminders = async (
     .select(
       'vaults.id as vault_id',
       'vaults.creator as user_id',
+      'vaults.organization_id as organization_id',
       'milestones.id as milestone_id',
       'milestones.title as milestone_title',
       'milestones.due_date'
@@ -92,13 +94,14 @@ export const sendMilestoneReminders = async (
             type: 'milestone_reminder',
             title: `Milestone Reminder: ${vm.milestone_title}`,
             message: `Your milestone is due in ${leadTimeText}! Don't forget to check in before the deadline to avoid a slash.`,
-            data: { 
-              vaultId: vm.vault_id, 
-              milestoneId: vm.milestone_id, 
+            data: {
+              vaultId: vm.vault_id,
+              milestoneId: vm.milestone_id,
               dueDate: vm.due_date,
-              leadTimeMs 
+              leadTimeMs
             },
-            idempotency_key: idempotencyKey
+            idempotency_key: idempotencyKey,
+            organization_id: vm.organization_id
           })
           remindersSent++
         } catch (err) {

--- a/src/tests/notificationPreferences.test.ts
+++ b/src/tests/notificationPreferences.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+import request from 'supertest'
+import express, { type Request, type Response, type NextFunction } from 'express'
+
+// ── In-memory db mock ───────────────────────────────────────────────────────
+
+let store: Record<string, unknown>[] = []
+
+function matches(row: Record<string, unknown>, filters: Record<string, unknown>, whereIns: Record<string, unknown[]>) {
+  return (
+    Object.entries(filters).every(([k, v]) => row[k] === v) &&
+    Object.entries(whereIns).every(([k, v]) => (v as unknown[]).includes(row[k]))
+  )
+}
+
+function pick(row: Record<string, unknown>, cols: string[]) {
+  if (cols.length === 0) return { ...row }
+  const out: Record<string, unknown> = {}
+  for (const c of cols) out[c] = row[c]
+  return out
+}
+
+const dbMock: any = jest.fn((_table: string) => {
+  const filters: Record<string, unknown> = {}
+  const whereIns: Record<string, unknown[]> = {}
+  let insertRows: Record<string, unknown>[] = []
+  let conflictCols: string[] = []
+
+  const qb: any = {
+    where: jest.fn((cond: Record<string, unknown>) => {
+      Object.assign(filters, cond)
+      return qb
+    }),
+    whereIn: jest.fn((col: string, vals: unknown[]) => {
+      whereIns[col] = vals
+      return qb
+    }),
+    select: jest.fn((...cols: string[]) => {
+      const rows = store.filter((r) => matches(r, filters, whereIns))
+      return Promise.resolve(rows.map((r) => pick(r, cols)))
+    }),
+    insert: jest.fn((rows: Record<string, unknown>[]) => {
+      insertRows = rows
+      return qb
+    }),
+    onConflict: jest.fn((cols: string[]) => {
+      conflictCols = cols
+      return qb
+    }),
+    merge: jest.fn(() => {
+      for (const row of insertRows) {
+        const idx = store.findIndex((r) => conflictCols.every((c) => r[c] === row[c]))
+        if (idx >= 0) {
+          store[idx] = { ...store[idx], ...row }
+        } else {
+          store.push({ ...row })
+        }
+      }
+      return Promise.resolve()
+    }),
+  }
+  return qb
+})
+
+jest.unstable_mockModule('../db/index.js', async () => ({ default: dbMock }))
+
+jest.unstable_mockModule('../middleware/auth.js', async () => ({
+  authenticate: (_req: Request, _res: Response, next: NextFunction) => next(),
+}))
+
+jest.unstable_mockModule('../middleware/orgAuth.js', async () => ({
+  requireOrgAccess: (..._roles: string[]) => (_req: Request, _res: Response, next: NextFunction) => next(),
+}))
+
+// Must import after mocks are registered.
+const { notificationPreferencesRouter } = await import('../routes/notificationPreferences.js')
+const { errorHandler } = await import('../middleware/errorHandler.js')
+const { isNotificationEnabled } = await import('../models/notificationPreferences.js')
+
+const app = express()
+app.use(express.json())
+app.use('/api/orgs', notificationPreferencesRouter)
+app.use(errorHandler)
+
+const ORG_A = '11111111-1111-1111-1111-111111111111'
+const ORG_B = '22222222-2222-2222-2222-222222222222'
+
+beforeEach(() => {
+  store = []
+  jest.clearAllMocks()
+})
+
+describe('GET /api/orgs/:orgId/notification-preferences', () => {
+  it('defaults to all-enabled when no preferences are stored', async () => {
+    const res = await request(app).get(`/api/orgs/${ORG_A}/notification-preferences`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.categories).toEqual({ vault_failure: true, milestone_reminder: true })
+    expect(res.body.channels).toEqual({ email: true })
+  })
+})
+
+describe('PUT /api/orgs/:orgId/notification-preferences', () => {
+  it('disables a category and persists the change', async () => {
+    const res = await request(app)
+      .put(`/api/orgs/${ORG_A}/notification-preferences`)
+      .send({ categories: { milestone_reminder: false } })
+
+    expect(res.status).toBe(200)
+    expect(res.body.categories.milestone_reminder).toBe(false)
+    expect(res.body.categories.vault_failure).toBe(true)
+  })
+
+  it('opts a channel out entirely', async () => {
+    const res = await request(app)
+      .put(`/api/orgs/${ORG_A}/notification-preferences`)
+      .send({ channels: { email: false } })
+
+    expect(res.status).toBe(200)
+    expect(res.body.channels.email).toBe(false)
+  })
+
+  it('rejects an unknown category', async () => {
+    const res = await request(app)
+      .put(`/api/orgs/${ORG_A}/notification-preferences`)
+      .send({ categories: { not_a_real_category: false } })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects an unknown channel', async () => {
+    const res = await request(app)
+      .put(`/api/orgs/${ORG_A}/notification-preferences`)
+      .send({ channels: { sms: false } })
+
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('isNotificationEnabled (dispatch-path check)', () => {
+  it('defaults to enabled with no preferences', async () => {
+    await expect(isNotificationEnabled(ORG_A, 'vault_failure')).resolves.toBe(true)
+  })
+
+  it('suppresses a disabled category', async () => {
+    await request(app)
+      .put(`/api/orgs/${ORG_A}/notification-preferences`)
+      .send({ categories: { vault_failure: false } })
+
+    await expect(isNotificationEnabled(ORG_A, 'vault_failure')).resolves.toBe(false)
+    await expect(isNotificationEnabled(ORG_A, 'milestone_reminder')).resolves.toBe(true)
+  })
+
+  it('suppresses every category once the channel is opted out', async () => {
+    await request(app)
+      .put(`/api/orgs/${ORG_A}/notification-preferences`)
+      .send({ channels: { email: false } })
+
+    await expect(isNotificationEnabled(ORG_A, 'vault_failure')).resolves.toBe(false)
+    await expect(isNotificationEnabled(ORG_A, 'milestone_reminder')).resolves.toBe(false)
+  })
+
+  it('lets a category-specific override win over a channel opt-out', async () => {
+    await request(app)
+      .put(`/api/orgs/${ORG_A}/notification-preferences`)
+      .send({ channels: { email: false }, categories: { vault_failure: true } })
+
+    await expect(isNotificationEnabled(ORG_A, 'vault_failure')).resolves.toBe(true)
+    await expect(isNotificationEnabled(ORG_A, 'milestone_reminder')).resolves.toBe(false)
+  })
+
+  it('returns true when no organization is supplied', async () => {
+    await expect(isNotificationEnabled(undefined, 'vault_failure')).resolves.toBe(true)
+  })
+
+  it('isolates preferences between organizations', async () => {
+    await request(app)
+      .put(`/api/orgs/${ORG_A}/notification-preferences`)
+      .send({ categories: { vault_failure: false } })
+
+    await expect(isNotificationEnabled(ORG_A, 'vault_failure')).resolves.toBe(false)
+    await expect(isNotificationEnabled(ORG_B, 'vault_failure')).resolves.toBe(true)
+
+    const resB = await request(app).get(`/api/orgs/${ORG_B}/notification-preferences`)
+    expect(resB.body.categories.vault_failure).toBe(true)
+  })
+})

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -20,6 +20,10 @@ export interface CreateNotificationInput {
   message: string
   data?: NotificationData
   idempotency_key?: string
+  /** Organization the notification is dispatched on behalf of, used to consult notification preferences. */
+  organization_id?: string | null
+  /** Delivery channel consulted against per-org preferences. Defaults to 'email'. */
+  channel?: string
 }
 
 export type NotificationSortField = 'created_at' | 'read_at' | 'title' | 'type'


### PR DESCRIPTION
## Summary
- Adds an `org_notification_preferences` table keyed by org/category/channel, with `GET`/`PUT /api/orgs/:id/notification-preferences` to view and update them.
- The dispatch path in `src/services/notification.ts` now consults preferences before inserting a notification, suppressing disabled categories and/or channel opt-outs.
- Orgs with no stored preferences keep the existing all-enabled behaviour (no DB rows = default on).

## Test plan
- [x] `npm test -- src/tests/notificationPreferences.test.ts` — covers no-prefs default-on, category disabled suppresses dispatch, channel opt-out, category-override-wins-over-channel-opt-out, cross-org isolation, and unknown category/channel rejection.
- [x] Verified pre-existing unrelated test/tsc failures on `main` are unchanged by this branch.

Closes #845