### PR TITLE
feat: cursor-based keyset pagination for notifications list

### DIFF
--- a/db/migrations/20260628120000_add_notifications_keyset_index.cjs
+++ b/db/migrations/20260628120000_add_notifications_keyset_index.cjs
@@ -1,0 +1,13 @@
+/**
+ * Support keyset pagination for GET /api/notifications.
+ */
+exports.up = async function up(knex) {
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_notifications_user_archived_created_id
+    ON notifications (user_id, archived_at, created_at DESC, id DESC)
+  `)
+}
+
+exports.down = async function down(knex) {
+  await knex.raw('DROP INDEX IF EXISTS idx_notifications_user_archived_created_id')
+}

--- a/docs/notifications-api.md
+++ b/docs/notifications-api.md
@@ -18,12 +18,14 @@ Returns the authenticated user's inbox.
 
 Query parameters:
 
-- `page`: page number, default `1`
-- `pageSize`: page size, default `20`, max `100`
-- `sortBy`: one of `created_at`, `read_at`, `title`, `type`
-- `sortOrder`: `asc` or `desc`, default `desc`
+- `limit`: page size, default `20`, max `100`
+- `cursor`: opaque cursor from the previous page's `pagination.next_cursor`
 - `status`: `all`, `read`, or `unread`, default `all`
 - `includeArchived`: `true` to include archived notifications, default `false`
+
+Notifications are returned newest first using a stable `(created_at DESC, id DESC)` keyset.
+Clients must treat cursors as opaque and only pass back `next_cursor` values returned by this endpoint.
+Rows inserted after page 1 do not cause skips or duplicates while scrolling older pages.
 
 Example response:
 
@@ -46,19 +48,16 @@ Example response:
     }
   ],
   "pagination": {
-    "page": 1,
-    "pageSize": 20,
-    "total": 1,
-    "totalPages": 1,
-    "hasNext": false,
-    "hasPrev": false
-  },
-  "sort": {
-    "sortBy": "created_at",
-    "sortOrder": "desc"
+    "limit": 20,
+    "cursor": null,
+    "next_cursor": "MjAyNi0wNC0yNFQxMDowMDowMC4wMDBafG5vdGlmXzEyMw",
+    "has_more": true,
+    "count": 1
   }
 }
 ```
+
+When `has_more` is `false`, `next_cursor` is omitted. An invalid `cursor` returns `400`.
 
 ### `PATCH /api/notifications/:id/read`
 

--- a/src/routes/notifications.ts
+++ b/src/routes/notifications.ts
@@ -1,10 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express'
 import { authenticate } from '../middleware/auth.js'
 import { queryParser } from '../middleware/queryParser.js'
-import type {
-  NotificationReadStatus,
-  NotificationSortField,
-} from '../types/notification.js'
+import type { NotificationReadStatus } from '../types/notification.js'
 import {
   listUserNotifications,
   markAllAsRead,
@@ -12,8 +9,6 @@ import {
 } from '../services/notification.js'
 import { AppError } from '../middleware/errorHandler.js'
 
-const DEFAULT_SORT_BY: NotificationSortField = 'created_at'
-const DEFAULT_SORT_ORDER = 'desc' as const
 const ALLOWED_STATUSES: NotificationReadStatus[] = ['all', 'read', 'unread']
 
 export const notificationsRouter = Router()
@@ -22,9 +17,7 @@ notificationsRouter.use(authenticate)
 
 notificationsRouter.get(
   '/',
-  queryParser({
-    allowedSortFields: ['created_at', 'read_at', 'title', 'type'],
-  }),
+  queryParser(),
   async (req: Request, res: Response, next: NextFunction) => {
     if (!req.user) {
       return next(AppError.unauthorized('Unauthenticated'))
@@ -36,10 +29,24 @@ notificationsRouter.get(
     }
 
     const includeArchived = ['true', '1'].includes(String(req.query.includeArchived ?? '').toLowerCase())
+    const limit = req.cursorPagination?.limit ?? 20
+    const cursor = req.cursorPagination?.cursor
 
-    const notifications = await listUserNotifications(req.user!.userId)
+    try {
+      const notifications = await listUserNotifications(req.user!.userId, {
+        cursor,
+        limit,
+        includeArchived,
+        readStatus: rawStatus,
+      })
 
-    res.json(notifications)
+      res.json(notifications)
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Invalid cursor') {
+        return next(AppError.badRequest('Invalid cursor'))
+      }
+      return next(error)
+    }
   },
 )
 
@@ -65,4 +72,3 @@ notificationsRouter.post('/read-all', async (req: Request, res: Response, next: 
   const updated = await markAllAsRead(req.user.userId)
   res.json({ updated })
 })
-

--- a/src/services/notification.ts
+++ b/src/services/notification.ts
@@ -1,5 +1,11 @@
 import db from '../db/index.js'
-import type { Notification, CreateNotificationInput } from '../types/notification.js'
+import type {
+  Notification,
+  CreateNotificationInput,
+  NotificationListOptions,
+  NotificationListResult,
+} from '../types/notification.js'
+import { decodeCursor, encodeCursor } from '../utils/pagination.js'
 
 // Minimal structured logger — emits JSON to stdout, no PII (no user_id, title, message)
 const log = {
@@ -62,11 +68,57 @@ export const createNotification = async (input: CreateNotificationInput): Promis
   }
 }
 
-export const listUserNotifications = async (userId: string): Promise<Notification[]> => {
-  return db('notifications')
+export const listUserNotifications = async (
+  userId: string,
+  options: NotificationListOptions,
+): Promise<NotificationListResult> => {
+  const query = db('notifications')
     .where({ user_id: userId })
+    .modify((builder) => {
+      if (!options.includeArchived) {
+        builder.whereNull('archived_at')
+      }
+
+      if (options.readStatus === 'read') {
+        builder.whereNotNull('read_at')
+      } else if (options.readStatus === 'unread') {
+        builder.whereNull('read_at')
+      }
+    })
+
+  if (options.cursor) {
+    const { timestamp, id } = decodeCursor(options.cursor)
+    query.where(function () {
+      this.where('created_at', '<', timestamp)
+        .orWhere(function () {
+          this.where('created_at', '=', timestamp).andWhere('id', '<', id)
+        })
+    })
+  }
+
+  const rows = await query
     .orderBy('created_at', 'desc')
+    .orderBy('id', 'desc')
+    .limit(options.limit + 1)
     .select('*')
+
+  const hasMore = rows.length > options.limit
+  const data = rows.slice(0, options.limit)
+  const nextCursor =
+    hasMore && data.length > 0
+      ? encodeCursor(new Date(data[data.length - 1].created_at), data[data.length - 1].id)
+      : undefined
+
+  return {
+    data,
+    pagination: {
+      limit: options.limit,
+      cursor: options.cursor ?? null,
+      next_cursor: nextCursor,
+      has_more: hasMore,
+      count: data.length,
+    },
+  }
 }
 
 export const markAsRead = async (id: string, userId: string): Promise<Notification | null> => {

--- a/src/tests/notifications.pagination.test.ts
+++ b/src/tests/notifications.pagination.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import type { Notification } from '../types/notification.js'
+
+type Predicate = (row: Notification) => boolean
+
+let notifications: Notification[] = []
+
+const compareValues = (left: unknown, operator: string, right: unknown): boolean => {
+  const leftValue = left instanceof Date ? left.getTime() : new Date(String(left)).getTime() || String(left)
+  const rightValue = right instanceof Date ? right.getTime() : new Date(String(right)).getTime() || String(right)
+
+  switch (operator) {
+    case '<':
+      return leftValue < rightValue
+    case '=':
+      return leftValue === rightValue
+    default:
+      throw new Error(`Unsupported operator ${operator}`)
+  }
+}
+
+class PredicateGroup {
+  private predicates: Predicate[] = []
+
+  where(column: keyof Notification, operator: string, value: unknown): this
+  where(callback: (this: PredicateGroup) => void): this
+  where(arg1: keyof Notification | ((this: PredicateGroup) => void), operator?: string, value?: unknown): this {
+    if (typeof arg1 === 'function') {
+      arg1.call(this)
+      return this
+    }
+    this.predicates.push((row) => compareValues(row[arg1], operator!, value))
+    return this
+  }
+
+  andWhere(column: keyof Notification, operator: string, value: unknown): this {
+    return this.where(column, operator, value)
+  }
+
+  orWhere(callback: (this: PredicateGroup) => void): this {
+    const group = new PredicateGroup()
+    callback.call(group)
+    const current = this.toPredicate()
+    const next = group.toPredicate()
+    this.predicates = [(row) => current(row) || next(row)]
+    return this
+  }
+
+  toPredicate(): Predicate {
+    const predicates = [...this.predicates]
+    return (row) => predicates.every((predicate) => predicate(row))
+  }
+}
+
+class NotificationQuery {
+  private predicates: Predicate[] = []
+  private orderings: Array<{ column: keyof Notification; direction: 'asc' | 'desc' }> = []
+  private limitValue: number | undefined
+
+  where(values: Partial<Notification>): this
+  where(callback: (this: PredicateGroup) => void): this
+  where(arg: Partial<Notification> | ((this: PredicateGroup) => void)): this {
+    if (typeof arg === 'function') {
+      const group = new PredicateGroup()
+      arg.call(group)
+      this.predicates.push(group.toPredicate())
+      return this
+    }
+
+    this.predicates.push((row) =>
+      Object.entries(arg).every(([key, value]) => row[key as keyof Notification] === value),
+    )
+    return this
+  }
+
+  whereNull(column: keyof Notification): this {
+    this.predicates.push((row) => row[column] === null)
+    return this
+  }
+
+  whereNotNull(column: keyof Notification): this {
+    this.predicates.push((row) => row[column] !== null)
+    return this
+  }
+
+  modify(callback: (builder: this) => void): this {
+    callback(this)
+    return this
+  }
+
+  orderBy(column: keyof Notification, direction: 'asc' | 'desc'): this {
+    this.orderings.push({ column, direction })
+    return this
+  }
+
+  limit(limit: number): this {
+    this.limitValue = limit
+    return this
+  }
+
+  async select(): Promise<Notification[]> {
+    const rows = notifications
+      .filter((row) => this.predicates.every((predicate) => predicate(row)))
+      .sort((a, b) => {
+        for (const ordering of this.orderings) {
+          const left = a[ordering.column]
+          const right = b[ordering.column]
+          if (left === right) continue
+          const result = String(left).localeCompare(String(right))
+          return ordering.direction === 'asc' ? result : -result
+        }
+        return 0
+      })
+
+    return typeof this.limitValue === 'number' ? rows.slice(0, this.limitValue) : rows
+  }
+}
+
+jest.unstable_mockModule('../db/index.js', () => ({
+  default: (table: string) => {
+    if (table !== 'notifications') throw new Error(`Unexpected table ${table}`)
+    return new NotificationQuery()
+  },
+}))
+
+const { listUserNotifications } = await import('../services/notification.js')
+
+const notification = (
+  id: string,
+  userId: string,
+  createdAt: string,
+  overrides: Partial<Notification> = {},
+): Notification => ({
+  id,
+  user_id: userId,
+  type: 'vault_failure',
+  title: `Notification ${id}`,
+  message: `Message ${id}`,
+  data: null,
+  idempotency_key: null,
+  read_at: null,
+  archived_at: null,
+  created_at: createdAt,
+  ...overrides,
+})
+
+describe('notification cursor pagination', () => {
+  beforeEach(() => {
+    notifications = [
+      notification('n5', 'user-a', '2026-06-28T10:04:00.000Z'),
+      notification('n4', 'user-a', '2026-06-28T10:03:00.000Z'),
+      notification('n3', 'user-a', '2026-06-28T10:02:00.000Z'),
+      notification('n2', 'user-a', '2026-06-28T10:01:00.000Z'),
+      notification('n1', 'user-a', '2026-06-28T10:00:00.000Z'),
+      notification('other-1', 'user-b', '2026-06-28T10:05:00.000Z'),
+    ]
+  })
+
+  it('paginates by created_at and id without overlap', async () => {
+    const first = await listUserNotifications('user-a', { limit: 2, readStatus: 'all' })
+    const second = await listUserNotifications('user-a', {
+      limit: 2,
+      cursor: first.pagination.next_cursor,
+      readStatus: 'all',
+    })
+
+    expect(first.data.map((item) => item.id)).toEqual(['n5', 'n4'])
+    expect(second.data.map((item) => item.id)).toEqual(['n3', 'n2'])
+    expect(first.pagination.has_more).toBe(true)
+    expect(second.pagination.cursor).toBe(first.pagination.next_cursor)
+  })
+
+  it('does not skip or duplicate older rows when a newer notification arrives mid-scroll', async () => {
+    const first = await listUserNotifications('user-a', { limit: 2, readStatus: 'all' })
+    notifications.push(notification('n6', 'user-a', '2026-06-28T10:06:00.000Z'))
+
+    const second = await listUserNotifications('user-a', {
+      limit: 2,
+      cursor: first.pagination.next_cursor,
+      readStatus: 'all',
+    })
+
+    expect(second.data.map((item) => item.id)).toEqual(['n3', 'n2'])
+  })
+
+  it('omits next_cursor on the last page', async () => {
+    const first = await listUserNotifications('user-a', { limit: 4, readStatus: 'all' })
+    const last = await listUserNotifications('user-a', {
+      limit: 4,
+      cursor: first.pagination.next_cursor,
+      readStatus: 'all',
+    })
+
+    expect(last.data.map((item) => item.id)).toEqual(['n1'])
+    expect(last.pagination.has_more).toBe(false)
+    expect(last.pagination.next_cursor).toBeUndefined()
+  })
+
+  it('returns an empty page with cursor metadata for users without notifications', async () => {
+    const page = await listUserNotifications('missing-user', { limit: 2, readStatus: 'all' })
+
+    expect(page).toEqual({
+      data: [],
+      pagination: {
+        limit: 2,
+        cursor: null,
+        next_cursor: undefined,
+        has_more: false,
+        count: 0,
+      },
+    })
+  })
+
+  it('keeps pagination scoped to the authenticated user', async () => {
+    const page = await listUserNotifications('user-b', { limit: 10, readStatus: 'all' })
+
+    expect(page.data.map((item) => item.id)).toEqual(['other-1'])
+  })
+
+  it('applies read-status and archived filters before pagination', async () => {
+    notifications = [
+      notification('unread-visible', 'user-a', '2026-06-28T10:03:00.000Z'),
+      notification('read-visible', 'user-a', '2026-06-28T10:02:00.000Z', {
+        read_at: '2026-06-28T10:02:30.000Z',
+      }),
+      notification('unread-archived', 'user-a', '2026-06-28T10:01:00.000Z', {
+        archived_at: '2026-06-28T10:01:30.000Z',
+      }),
+    ]
+
+    const page = await listUserNotifications('user-a', {
+      limit: 10,
+      readStatus: 'unread',
+      includeArchived: false,
+    })
+
+    expect(page.data.map((item) => item.id)).toEqual(['unread-visible'])
+  })
+})

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -26,10 +26,8 @@ export type NotificationSortField = 'created_at' | 'read_at' | 'title' | 'type'
 export type NotificationReadStatus = 'all' | 'read' | 'unread'
 
 export interface NotificationListOptions {
-  page: number
-  pageSize: number
-  sortBy?: NotificationSortField
-  sortOrder: 'asc' | 'desc'
+  cursor?: string
+  limit: number
   includeArchived?: boolean
   readStatus?: NotificationReadStatus
 }
@@ -37,15 +35,10 @@ export interface NotificationListOptions {
 export interface NotificationListResult {
   data: Notification[]
   pagination: {
-    page: number
-    pageSize: number
-    total: number
-    totalPages: number
-    hasNext: boolean
-    hasPrev: boolean
-  }
-  sort: {
-    sortBy: NotificationSortField
-    sortOrder: 'asc' | 'desc'
+    limit: number
+    cursor: string | null
+    next_cursor?: string
+    has_more: boolean
+    count: number
   }
 }


### PR DESCRIPTION
Closes #714

## Summary
- migrate GET /api/notifications from raw offset-style listing to created_at/id keyset pagination
- return cursor metadata consistent with other list endpoints
- add a notifications keyset index, docs, and focused pagination tests

## Tests
- npm test -- --runTestsByPath src/tests/notifications.pagination.test.ts

## Notes
- bun test src/tests/notifications.pagination.test.ts could not run locally because bun is not installed in this workspace.
- npm run build is currently blocked by pre-existing syntax errors in unrelated files: src/jobs/handlers.ts, src/jobs/types.ts, src/services/featureFlags.ts, and src/services/soroban.ts.