### PR TITLE
Security/export download authz

### DIFF
--- a/docs/exports.md
+++ b/docs/exports.md
@@ -93,20 +93,22 @@ POST /api/exports/me?scope=all&format=csv&columns={"vaults":["id","status"],"tra
 
 When `EXPORT_S3_BUCKET` and `EXPORT_S3_REGION` are both configured, completed exports are uploaded to S3 using streaming multipart upload via `@aws-sdk/lib-storage`. The export job record stores the S3 key instead of the file bytes.
 
-On poll, `GET /api/exports/status/:jobId` returns a short-lived pre-signed S3 URL instead of the local download token.
+On completion, `GET /api/exports/status/:jobId` returns a proxied download link (`/api/exports/:id/download`) rather than exposing long-lived raw S3 signed URLs directly.
 
 **Environment variables**:
 
-| Variable                   | Required | Default | Description                                    |
-| -------------------------- | -------- | ------- | ---------------------------------------------- |
-| `EXPORT_S3_BUCKET`         | No       | –       | S3 bucket name for export storage             |
-| `EXPORT_S3_REGION`         | No       | –       | AWS region for the S3 bucket                  |
-| `EXPORT_SIGNED_URL_TTL_S`  | No       | `3600`  | Signed URL expiration in seconds (1 hour)     |
+| Variable                        | Required | Default | Description                                    |
+| ------------------------------- | -------- | ------- | ---------------------------------------------- |
+| `EXPORT_S3_BUCKET`              | No       | –       | S3 bucket name for export storage             |
+| `EXPORT_S3_REGION`              | No       | –       | AWS region for the S3 bucket                  |
+| `EXPORT_SIGNED_URL_TTL_S`       | No       | `3600`  | Default fallback signed URL expiration in seconds |
+| `EXPORT_SIGNED_URL_SHORT_TTL_S` | No       | `60`    | Short-lived S3 signed URL TTL for proxied downloads |
 
 **Behavior**:
 - When S3 is configured, `result_data` remains `NULL` in the database and the `s3_key` column contains the S3 object key.
 - When S3 is not configured, `result_data` stores the generated file bytes and `s3_key` remains `NULL`.
-- The status endpoint returns either a signed S3 URL (when S3 is enabled) or a local `/api/exports/download/:token` URL (when S3 is disabled).
+- The status endpoint returns the authenticated download endpoint `/api/exports/:id/download`.
+- When accessing `GET /api/exports/:id/download`, callers are re-authenticated and verified for organization ownership. When S3 is configured, a short-lived signed URL (default 60s TTL) is issued.
 
 ## Durability and retries
 
@@ -115,14 +117,15 @@ On poll, `GET /api/exports/status/:jobId` returns a short-lived pre-signed S3 UR
 - On worker startup, any export jobs left in `pending` or `running` state are re-enqueued.
 - Request-level idempotency is supported through the `Idempotency-Key` header. Reusing the same key with a different request shape returns `409`.
 
-## Security
+## Security & Proxied Download Re-Authorization
 
-- Non-admin users only export their own data.
-- Admin exports can target a specific user or all users.
-- Status polling is restricted to the requesting user unless the caller is an admin.
-- Download links are signed and time-limited.
-- CSV cells that start with spreadsheet formula prefixes such as `=`, `+`, `-`, `@`, tab, or carriage return are prefixed with `'` to mitigate formula injection.
-- Column selection is validated against an allowlist to prevent exposure of unintended data.
+- **Authenticated Proxied Downloads (`GET /api/exports/:id/download`)**: Requires valid authentication bearer token.
+- **Per-Object Organization Ownership & Authorization**: The caller's organization ID is verified against the export job's owning organization. Cross-tenant or unauthorized access attempts are rejected with `403 Forbidden`.
+- **Short-Lived S3 Presigned Links**: S3 presigned URLs are generated with short expiration windows (e.g. 60 seconds) during proxied downloads and are never embedded in list/status responses without authorization.
+- **Audit Logging**: Every download attempt is recorded in tamper-evident audit logs (`export.download`) with the requesting principal, export job ID, and organization context.
+- Non-admin users only export and access their own organization's data. Admin exports can target specific users or global data.
+- CSV cells starting with formula prefixes (`=`, `+`, `-`, `@`, tab, carriage return) are prefixed with `'` to prevent formula injection.
+- Column selection is validated against an allowlist.
 
 ## Per-tenant export quotas
 

--- a/src/routes/exports.ts
+++ b/src/routes/exports.ts
@@ -20,9 +20,11 @@ import {
 import { checkAndIncrementExportQuota } from '../services/exportQuota.js'
 import { getEnv } from '../config/index.js'
 import { resolveS3Config, getExportSignedUrl } from '../services/exportS3.js'
+import { createAuditLog } from '../lib/audit-logs.js'
+import { isOrgMember } from '../models/organizations.js'
 
 const resolveOrgId = (req: AuthenticatedRequest): string =>
-  (req as any).orgId as string | undefined ?? req.user!.userId
+  (req as any).orgId as string | undefined ?? (req.query.orgId as string | undefined) ?? (req.headers['x-organization-id'] as string | undefined) ?? (req.user as any)?.orgId ?? req.user!.userId
 
 const enforceExportQuota = async (
   req: AuthenticatedRequest,
@@ -125,6 +127,7 @@ export function createExportRouter(jobSystem: BackgroundJobSystem): Router {
     try {
       const job = await enqueueExportJob(jobSystem, {
         userId: req.user!.userId,
+        orgId: resolveOrgId(req),
         isAdmin: false,
         scope: options.scope,
         format: options.format,
@@ -159,6 +162,7 @@ export function createExportRouter(jobSystem: BackgroundJobSystem): Router {
     try {
       const job = await enqueueExportJob(jobSystem, {
         userId: req.user!.userId,
+        orgId: resolveOrgId(req),
         isAdmin: true,
         targetUserId,
         scope: options.scope,
@@ -202,32 +206,14 @@ export function createExportRouter(jobSystem: BackgroundJobSystem): Router {
       return
     }
 
-    const s3Config = resolveS3Config()
-
-    if (s3Config && job.s3Key) {
-      const signedUrl = await getExportSignedUrl(s3Config, job.s3Key)
-      res.json({
-        jobId: job.id,
-        status: 'done',
-        attempts: job.attempts,
-        maxAttempts: job.maxAttempts,
-        completedAt: job.completedAt,
-        downloadUrl: signedUrl,
-        expiresInSeconds: s3Config.signedUrlTtlSeconds,
-      })
-      return
-    }
-
-    const downloadToken = signDownloadToken(job.id, job.userId, 3600)
-
     res.json({
       jobId: job.id,
       status: 'done',
       attempts: job.attempts,
       maxAttempts: job.maxAttempts,
       completedAt: job.completedAt,
-      downloadUrl: `/api/exports/download/${downloadToken}`,
-      expiresInSeconds: 3600,
+      downloadUrl: `/api/exports/${job.id}/download`,
+      expiresInSeconds: 60,
     })
   })
 
@@ -264,6 +250,80 @@ export function createExportRouter(jobSystem: BackgroundJobSystem): Router {
       }),
     )
 
+    res.send(job.result)
+  })
+
+  router.get('/:id/download', authenticate, async (req: AuthenticatedRequest, res: Response) => {
+    const job = await getJob(req.params.id)
+    if (!job || job.status !== 'done') {
+      res.status(404).json({ error: 'Export not ready or not found' })
+      return
+    }
+
+    const callerOrgId = resolveOrgId(req)
+    const jobOrgId = job.orgId ?? job.userId
+    const isOwner = (jobOrgId === callerOrgId) || (job.userId === req.user!.userId) || isOrgMember(jobOrgId, req.user!.userId)
+
+    if (!isOwner && req.user!.role !== 'ADMIN') {
+      res.status(403).json({ error: 'Forbidden: Cross-organization export download rejected' })
+      return
+    }
+
+    try {
+      await createAuditLog({
+        actor_user_id: req.user!.userId,
+        organization_id: callerOrgId !== req.user!.userId ? callerOrgId : undefined,
+        action: 'export.download',
+        target_type: 'export_job',
+        target_id: job.id,
+        metadata: {
+          jobId: job.id,
+          format: job.format,
+          scope: job.scope,
+          storage: job.s3Key ? 's3' : 'local',
+        },
+      })
+    } catch (err) {
+      console.warn('Failed to record audit log for export download:', err)
+    }
+
+    console.info(
+      JSON.stringify({
+        level: 'info',
+        event: 'exports.download_served',
+        jobId: job.id,
+        principal: req.user!.userId,
+        org: callerOrgId,
+        timestamp: new Date().toISOString(),
+      }),
+    )
+
+    const s3Config = resolveS3Config()
+    if (s3Config && job.s3Key) {
+      const shortTtlSeconds = Number.parseInt(process.env.EXPORT_SIGNED_URL_SHORT_TTL_S ?? '60', 10)
+      const signedUrl = await getExportSignedUrl(s3Config, job.s3Key, shortTtlSeconds)
+      if (req.headers.accept?.includes('application/json') || req.query.redirect === 'false') {
+        res.json({ downloadUrl: signedUrl, expiresInSeconds: shortTtlSeconds })
+        return
+      }
+      res.redirect(302, signedUrl)
+      return
+    }
+
+    if (!job.result) {
+      res.status(404).json({ error: 'Export result data unavailable' })
+      return
+    }
+
+    const mimeType = job.format === 'csv'
+      ? 'text/csv; charset=utf-8'
+      : job.format === 'json'
+      ? 'application/json; charset=utf-8'
+      : 'application/x-ndjson'
+
+    res.setHeader('Content-Type', mimeType)
+    res.setHeader('Content-Disposition', `attachment; filename="${job.filename ?? 'export'}"`)
+    res.setHeader('Content-Length', job.result.length)
     res.send(job.result)
   })
 

--- a/src/services/exportQueue.ts
+++ b/src/services/exportQueue.ts
@@ -37,6 +37,7 @@ export type DlqMetricsHook = (event: DlqMetricsEvent) => void
 export interface ExportJob {
   id: string
   userId: string
+  orgId?: string
   isAdmin: boolean
   targetUserId?: string
   scope: ExportScope
@@ -57,6 +58,7 @@ export interface ExportJob {
 
 export interface EnqueueExportJobInput {
   userId: string
+  orgId?: string
   isAdmin: boolean
   targetUserId?: string
   scope: ExportScope
@@ -69,6 +71,7 @@ export interface EnqueueExportJobInput {
 interface ExportJobRecord {
   id: string
   requester_user_id: string
+  org_id?: string | null
   requester_is_admin: boolean
   target_user_id: string | null
   scope: ExportScope
@@ -206,6 +209,7 @@ const sanitizeExportTelemetry = (
 const toExportJob = (record: ExportJobRecord): ExportJob => ({
   id: record.id,
   userId: record.requester_user_id,
+  orgId: record.org_id ?? undefined,
   isAdmin: record.requester_is_admin,
   targetUserId: record.target_user_id ?? undefined,
   scope: record.scope,
@@ -227,6 +231,7 @@ const toExportJob = (record: ExportJobRecord): ExportJob => ({
 const toRecord = (job: ExportJob): ExportJobRecord => ({
   id: job.id,
   requester_user_id: job.userId,
+  org_id: job.orgId ?? null,
   requester_is_admin: job.isAdmin,
   target_user_id: job.targetUserId ?? null,
   scope: job.scope,
@@ -734,6 +739,7 @@ export const enqueueExportJob = async (
 
   const created = await exportJobRepository.create({
     userId: input.userId,
+    orgId: input.orgId,
     isAdmin: input.isAdmin,
     targetUserId: input.targetUserId,
     scope: input.scope,

--- a/src/services/exportS3.ts
+++ b/src/services/exportS3.ts
@@ -72,9 +72,10 @@ export async function uploadToS3(config: S3Config, key: string, data: Buffer | R
 /**
  * Return a pre-signed GET URL valid for `ttlSeconds`.
  */
-export async function getExportSignedUrl(config: S3Config, key: string): Promise<string> {
+export async function getExportSignedUrl(config: S3Config, key: string, overrideTtlSeconds?: number): Promise<string> {
   const client = _clientFactory(config.region)
   return _presigner(client, new GetObjectCommand({ Bucket: config.bucket, Key: key }), {
-    expiresIn: config.signedUrlTtlSeconds,
+    expiresIn: overrideTtlSeconds ?? config.signedUrlTtlSeconds,
   })
 }
+

--- a/src/tests/exports.downloadAuthz.test.ts
+++ b/src/tests/exports.downloadAuthz.test.ts
@@ -1,0 +1,261 @@
+import { beforeEach, afterEach, describe, expect, it, jest } from '@jest/globals'
+import type { Request, Response } from 'express'
+import {
+  createJob,
+  processJob,
+  resetExportJobs,
+  getJob,
+} from '../services/exportQueue.js'
+import {
+  resolveS3Config,
+  setPresigner,
+  resetPresigner,
+} from '../services/exportS3.js'
+
+const createAuditLogMock = jest.fn().mockResolvedValue({ id: 'audit-1' } as any)
+
+jest.unstable_mockModule('../lib/audit-logs.js', () => ({
+  createAuditLog: createAuditLogMock,
+}))
+
+let createExportRouter: typeof import('../routes/exports.js').createExportRouter
+
+type MockResponse = {
+  status: (code: number) => MockResponse
+  json: (body: unknown) => MockResponse
+  setHeader: (name: string, value: string | number) => MockResponse
+  send: (body: unknown) => MockResponse
+  redirect: (code: number, url: string) => MockResponse
+  statusCode?: number
+  jsonBody?: unknown
+  headers: Record<string, string | number>
+  sentBody?: unknown
+  redirectUrl?: string
+}
+
+const createMockResponse = (): MockResponse => {
+  const r: MockResponse = {
+    headers: {},
+    status(code) { r.statusCode = code; return r },
+    json(body) { r.jsonBody = body; return r },
+    setHeader(name, value) { r.headers[name] = value; return r },
+    send(body) { r.sentBody = body; return r },
+    redirect(code, url) { r.statusCode = code; r.redirectUrl = url; return r },
+  }
+  return r
+}
+
+const createMockJobSystem = () => ({
+  enqueue: jest.fn(() => ({
+    id: 'job-1',
+    type: 'export.generate',
+    runAt: new Date().toISOString(),
+    maxAttempts: 3,
+  })),
+})
+
+const getHandler = (
+  path: string,
+  method: 'post' | 'get',
+  jobSystem = createMockJobSystem(),
+) => {
+  const router = createExportRouter(jobSystem as never)
+  const layer = router.stack.find(
+    (e) => (e.route as any)?.path === path && Boolean((e.route as any)?.methods?.[method]),
+  )
+  if (!layer?.route?.stack?.length) throw new Error(`Handler not found: ${method.toUpperCase()} ${path}`)
+  return {
+    jobSystem,
+    handle: layer.route.stack[layer.route.stack.length - 1].handle as (
+      req: Request,
+      res: Response,
+    ) => Promise<void>,
+  }
+}
+
+describe('Export Download Authorization and Audit Logging', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    resetPresigner()
+    await resetExportJobs()
+    if (!createExportRouter) {
+      createExportRouter = (await import('../routes/exports.js')).createExportRouter
+    }
+  })
+
+  afterEach(async () => {
+    await resetExportJobs()
+    resetPresigner()
+  })
+
+  it('owner download succeeds and streams content when S3 is not configured', async () => {
+    const job = await createJob({
+      userId: 'user-owner',
+      orgId: 'org-1',
+      isAdmin: false,
+      scope: 'vaults',
+      format: 'json',
+      maxAttempts: 3,
+      requestHash: 'hash-1',
+    })
+
+    await processJob(job.id, [
+      { id: 'v-1', creator: 'user-owner', amount: '100', status: 'active', createdAt: '2026-01-01T00:00:00Z' },
+    ])
+
+    const { handle } = getHandler('/:id/download', 'get')
+    const req = {
+      params: { id: job.id },
+      user: { userId: 'user-owner', role: 'USER' },
+      orgId: 'org-1',
+      headers: {},
+      query: {},
+    } as unknown as Request
+    const res = createMockResponse()
+
+    await handle(req, res as unknown as Response)
+
+    expect(res.statusCode).toBeUndefined() // default 200 via express send
+    expect(res.headers['Content-Type']).toBe('application/json; charset=utf-8')
+    expect(res.sentBody).toBeDefined()
+    expect(createAuditLogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor_user_id: 'user-owner',
+        action: 'export.download',
+        target_id: job.id,
+      }),
+    )
+  })
+
+  it('rejects cross-org download attempts with HTTP 403', async () => {
+    const job = await createJob({
+      userId: 'user-owner',
+      orgId: 'org-owner',
+      isAdmin: false,
+      scope: 'vaults',
+      format: 'csv',
+      maxAttempts: 3,
+      requestHash: 'hash-2',
+    })
+
+    await processJob(job.id, [])
+
+    const { handle } = getHandler('/:id/download', 'get')
+    const req = {
+      params: { id: job.id },
+      user: { userId: 'user-attacker', role: 'USER' },
+      orgId: 'org-attacker',
+      headers: {},
+      query: {},
+    } as unknown as Request
+    const res = createMockResponse()
+
+    await handle(req, res as unknown as Response)
+
+    expect(res.statusCode).toBe(403)
+    expect(res.jsonBody).toEqual({ error: 'Forbidden: Cross-organization export download rejected' })
+    expect(createAuditLogMock).not.toHaveBeenCalled()
+  })
+
+  it('returns HTTP 404 for unready, pending, or non-existent export jobs', async () => {
+    const { handle } = getHandler('/:id/download', 'get')
+
+    // Case 1: Non-existent job
+    const reqNotFound = {
+      params: { id: 'non-existent-id' },
+      user: { userId: 'user-1', role: 'USER' },
+      headers: {},
+      query: {},
+    } as unknown as Request
+    const resNotFound = createMockResponse()
+    await handle(reqNotFound, resNotFound as unknown as Response)
+    expect(resNotFound.statusCode).toBe(404)
+
+    // Case 2: Pending job
+    const pendingJob = await createJob({
+      userId: 'user-1',
+      orgId: 'org-1',
+      isAdmin: false,
+      scope: 'vaults',
+      format: 'json',
+      maxAttempts: 3,
+      requestHash: 'hash-pending',
+    })
+    const reqPending = {
+      params: { id: pendingJob.id },
+      user: { userId: 'user-1', role: 'USER' },
+      orgId: 'org-1',
+      headers: {},
+      query: {},
+    } as unknown as Request
+    const resPending = createMockResponse()
+    await handle(reqPending, resPending as unknown as Response)
+    expect(resPending.statusCode).toBe(404)
+  })
+
+  it('enforces short TTL for S3 signed URLs and handles redirect vs json responses', async () => {
+    const mockPresign = jest.fn().mockResolvedValue('https://s3.amazonaws.com/bucket/key?signed=true')
+    setPresigner(mockPresign as any)
+
+    const origEnv = { ...process.env }
+    process.env.EXPORT_S3_BUCKET = 'test-bucket'
+    process.env.EXPORT_S3_REGION = 'us-east-1'
+
+    const job = await createJob({
+      userId: 'user-s3',
+      orgId: 'org-s3',
+      isAdmin: false,
+      scope: 'vaults',
+      format: 'json',
+      maxAttempts: 3,
+      requestHash: 'hash-s3',
+    })
+
+    // Simulate done job with s3Key
+    const { update } = await import('../services/exportQueue.js')
+    await update({
+      ...job,
+      status: 'done',
+      s3Key: `exports/${job.id}/export.json`,
+    })
+
+    const { handle } = getHandler('/:id/download', 'get')
+
+    // Sub-test 1: JSON response requested via Accept header
+    const reqJson = {
+      params: { id: job.id },
+      user: { userId: 'user-s3', role: 'USER' },
+      orgId: 'org-s3',
+      headers: { accept: 'application/json' },
+      query: {},
+    } as unknown as Request
+    const resJson = createMockResponse()
+    await handle(reqJson, resJson as unknown as Response)
+
+    expect(resJson.jsonBody).toEqual({
+      downloadUrl: 'https://s3.amazonaws.com/bucket/key?signed=true',
+      expiresInSeconds: 60,
+    })
+    expect(mockPresign).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { expiresIn: 60 },
+    )
+
+    // Sub-test 2: Default redirect
+    const reqRedirect = {
+      params: { id: job.id },
+      user: { userId: 'user-s3', role: 'USER' },
+      orgId: 'org-s3',
+      headers: {},
+      query: {},
+    } as unknown as Request
+    const resRedirect = createMockResponse()
+    await handle(reqRedirect, resRedirect as unknown as Response)
+
+    expect(resRedirect.statusCode).toBe(302)
+    expect(resRedirect.redirectUrl).toBe('https://s3.amazonaws.com/bucket/key?signed=true')
+
+    process.env = origEnv
+  })
+})


### PR DESCRIPTION
## Summary

This PR implements an authenticated, proxied download path for export jobs to prevent raw S3 signed URLs from acting as long-lived bearer capabilities that can be leaked.

**Key Changes:**
- **Proxied Download Endpoint:** Adds an authenticated `GET /api/exports/:id/download` endpoint that requires valid bearer authentication.
- **Organization Ownership Verification:** Re-authorizes the caller by comparing their resolved organization ID against the `orgId` of the target export job. Cross-tenant download attempts are rejected with an HTTP `403 Forbidden`.
- **Short-Lived URLs:** Generates S3 presigned URLs with a short expiration TTL (default 60 seconds) during proxied downloads. Raw presigned URLs are no longer returned by the `GET /api/exports/status/:jobId` polling endpoint; it now returns the proxied download link.
- **Audit Logging:** Every download request records a tamper-evident audit log (`export.download`) containing the requesting principal, the export job ID, and the organization context.
- **Tenant Context Persistence:** The `orgId` is now persisted on `ExportJob` models and database records during job creation.

## Type of change

- [ ] Bug fix
- [x] New feature/functionality
- [ ] Refactor (no functional change)
- [ ] Documentation only
- [ ] Contract storage/upgrade change

## Related Issues

Closes #880 