### PR TITLE
feat: OAuth2 client-credentials token endpoint with scope narrowing

### DIFF
--- a/src/app-bootstrap.ts
+++ b/src/app-bootstrap.ts
@@ -22,6 +22,7 @@ import { adminVerifiersRouter } from './routes/adminVerifiers.js'
 import { adminWebhooksRouter } from './routes/adminWebhooks.js'
 import { verificationsRouter } from './routes/verifications.js'
 import { apiKeysRouter } from './routes/apiKeys.js'
+import { oauthRouter } from './routes/oauth.js'
 import { notificationsRouter } from './routes/notifications.js'
 import { notificationPreferencesRouter } from './routes/notificationPreferences.js'
 import { webhooksRouter } from './routes/webhooks.js'
@@ -76,6 +77,7 @@ export function bootstrapApp(options: BootstrapOptions = {}) {
   app.use('/api/admin/webhooks', adminWebhooksRouter)
   app.use('/api/verifications', verificationsRouter)
   app.use('/api/api-keys', apiKeysRouter)
+  app.use('/api/oauth', oauthRouter)
   app.use('/api/notifications', notificationsRouter)
   app.use('/api/users/me/notification-preferences', notificationPreferencesRouter)
   app.use('/api/webhooks', webhooksRouter)

--- a/src/middleware/oauthBearer.ts
+++ b/src/middleware/oauthBearer.ts
@@ -1,0 +1,70 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import jwt from 'jsonwebtoken'
+import type { ApiScope } from '../types/auth.js'
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production'
+
+export interface OAuthTokenPayload {
+  sub: string
+  client_id: string
+  scope: string
+  org_id?: string
+  user_id?: string
+  iss: string
+  aud: string
+  iat: number
+  exp: number
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      oauthToken?: OAuthTokenPayload
+    }
+  }
+}
+
+/**
+ * Validate an OAuth2 bearer token issued by POST /api/oauth/token.
+ * Attaches the decoded payload to req.oauthToken on success.
+ *
+ * @param requiredScopes  When provided, the token must carry ALL of them.
+ */
+export const authenticateOAuthBearer = (requiredScopes: ApiScope[] = []): RequestHandler => {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const authHeader = req.headers.authorization
+    if (!authHeader?.startsWith('Bearer ')) {
+      res.status(401).json({ error: 'Unauthorized: Bearer token required' })
+      return
+    }
+
+    const token = authHeader.slice(7)
+
+    let payload: OAuthTokenPayload
+    try {
+      payload = jwt.verify(token, JWT_SECRET, {
+        issuer: 'disciplr',
+        audience: 'disciplr-api',
+      }) as OAuthTokenPayload
+    } catch (err) {
+      if (err instanceof jwt.TokenExpiredError) {
+        res.status(401).json({ error: 'Unauthorized: Token expired' })
+      } else {
+        res.status(401).json({ error: 'Unauthorized: Invalid token' })
+      }
+      return
+    }
+
+    if (requiredScopes.length > 0) {
+      const tokenScopes = payload.scope ? payload.scope.split(' ') : []
+      const missing = requiredScopes.filter((s) => !tokenScopes.includes(s))
+      if (missing.length > 0) {
+        res.status(403).json({ error: `Forbidden: missing scope(s): ${missing.join(' ')}` })
+        return
+      }
+    }
+
+    req.oauthToken = payload
+    next()
+  }
+}

--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -1,0 +1,121 @@
+import { Router, type Request, type Response } from 'express'
+import jwt from 'jsonwebtoken'
+import { validateApiKey } from '../services/apiKeys.js'
+import { createAuditLog } from '../lib/audit-logs.js'
+import { authRateLimiter } from '../middleware/rateLimiter.js'
+import type { ApiScope } from '../types/auth.js'
+
+export const oauthRouter = Router()
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production'
+const TOKEN_TTL_SECONDS = Number(process.env.OAUTH_TOKEN_TTL_SECONDS ?? 3600)
+
+/** Non-blocking audit log helper — failures are logged but never propagate. */
+const auditLog = (entry: Parameters<typeof createAuditLog>[0]): void => {
+  createAuditLog(entry).catch((err) => {
+    console.error(JSON.stringify({ level: 'error', event: 'oauth.audit_log_failed', error: String(err) }))
+  })
+}
+
+/** RFC 6749 §5.2 error response */
+const oauthError = (res: Response, status: number, error: string, description: string): void => {
+  res
+    .status(status)
+    .set('Cache-Control', 'no-store')
+    .set('Pragma', 'no-cache')
+    .json({ error, error_description: description })
+}
+
+oauthRouter.post('/token', authRateLimiter, async (req: Request, res: Response): Promise<void> => {
+  const { grant_type, client_id, client_secret, scope } = req.body ?? {}
+
+  if (grant_type !== 'client_credentials') {
+    oauthError(res, 400, 'unsupported_grant_type', 'Only client_credentials is supported')
+    return
+  }
+
+  if (!client_id || !client_secret) {
+    oauthError(res, 400, 'invalid_request', 'client_id and client_secret are required')
+    return
+  }
+
+  const result = await validateApiKey(client_secret as string)
+
+  if (!result.valid) {
+    auditLog({
+      actor_user_id: String(client_id),
+      action: 'oauth.token_denied',
+      target_type: 'oauth_client',
+      target_id: String(client_id),
+      metadata: { reason: result.reason, grant_type: 'client_credentials' },
+    })
+    oauthError(res, 401, 'invalid_client', 'Invalid client credentials')
+    return
+  }
+
+  const clientScopes: ApiScope[] = result.context.scopes
+  let grantedScopes: ApiScope[]
+
+  if (scope) {
+    const requested = String(scope)
+      .split(' ')
+      .map((s) => s.trim())
+      .filter(Boolean) as ApiScope[]
+
+    const unknown = requested.filter((s) => !clientScopes.includes(s))
+    if (unknown.length > 0) {
+      auditLog({
+        actor_user_id: String(client_id),
+        action: 'oauth.token_denied',
+        target_type: 'oauth_client',
+        target_id: String(client_id),
+        metadata: { reason: 'scope_exceeded', requested_scopes: requested, client_scopes: clientScopes },
+      })
+      oauthError(res, 400, 'invalid_scope', `Requested scope(s) exceed client grants: ${unknown.join(' ')}`)
+      return
+    }
+
+    grantedScopes = requested
+  } else {
+    grantedScopes = clientScopes
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  const payload = {
+    sub: result.context.apiKeyId,
+    client_id: String(client_id),
+    scope: grantedScopes.join(' '),
+    ...(result.context.orgId && { org_id: result.context.orgId }),
+    ...(result.context.userId && { user_id: result.context.userId }),
+    iss: 'disciplr',
+    aud: 'disciplr-api',
+    iat: now,
+    exp: now + TOKEN_TTL_SECONDS,
+  }
+
+  const accessToken = jwt.sign(payload, JWT_SECRET)
+
+  auditLog({
+    actor_user_id: result.context.userId ?? result.context.apiKeyId,
+    action: 'oauth.token_issued',
+    target_type: 'oauth_client',
+    target_id: result.context.apiKeyId,
+    metadata: {
+      grant_type: 'client_credentials',
+      scopes: grantedScopes,
+      expires_in: TOKEN_TTL_SECONDS,
+      ...(result.context.orgId && { org_id: result.context.orgId }),
+    },
+  })
+
+  res
+    .status(200)
+    .set('Cache-Control', 'no-store')
+    .set('Pragma', 'no-cache')
+    .json({
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: TOKEN_TTL_SECONDS,
+      scope: grantedScopes.join(' '),
+    })
+})

--- a/src/tests/oauth.clientCredentials.test.ts
+++ b/src/tests/oauth.clientCredentials.test.ts
@@ -1,0 +1,380 @@
+import express from 'express'
+import jwt from 'jsonwebtoken'
+import type { Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { oauthRouter } from '../../src/routes/oauth.js'
+import { authenticateOAuthBearer } from '../../src/middleware/oauthBearer.js'
+import { createApiKey, resetApiKeysTable, revokeApiKey } from '../../src/services/apiKeys.js'
+import { ApiScope } from '../../src/types/auth.js'
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production'
+
+let baseUrl: string
+let server: Server
+
+beforeEach(async () => {
+  await resetApiKeysTable()
+
+  const app = express()
+  app.use(express.json())
+  app.use('/api/oauth', oauthRouter)
+
+  app.get('/protected', authenticateOAuthBearer([ApiScope.ReadVaults]), (_req, res) => {
+    res.json({ ok: true })
+  })
+  app.get('/analytics', authenticateOAuthBearer([ApiScope.ReadAnalytics]), (_req, res) => {
+    res.json({ ok: true })
+  })
+  app.get('/open', authenticateOAuthBearer(), (_req, res) => {
+    res.json({ ok: true })
+  })
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve())
+  })
+  const addr = server.address() as AddressInfo
+  baseUrl = `http://127.0.0.1:${addr.port}`
+})
+
+afterEach(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const post = (path: string, body: unknown) =>
+  fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+const get = (path: string, token: string) =>
+  fetch(`${baseUrl}${path}`, { headers: { Authorization: `Bearer ${token}` } })
+
+// ---------------------------------------------------------------------------
+// Valid issuance
+// ---------------------------------------------------------------------------
+
+describe('POST /api/oauth/token – valid issuance', () => {
+  it('returns a bearer token with all client scopes when no scope requested', async () => {
+    const { apiKey, record } = await createApiKey({
+      label: 'test',
+      scopes: [ApiScope.ReadVaults, ApiScope.ReadAnalytics],
+    })
+
+    const res = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_id: record.id,
+      client_secret: apiKey,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    expect(body.token_type).toBe('Bearer')
+    expect(typeof body.access_token).toBe('string')
+    expect(body.expires_in).toBeGreaterThan(0)
+
+    const decoded = jwt.verify(body.access_token, JWT_SECRET) as any
+    expect(decoded.iss).toBe('disciplr')
+    expect(decoded.aud).toBe('disciplr-api')
+    expect(decoded.sub).toBe(record.id)
+    expect(decoded.scope).toContain('read:vaults')
+    expect(decoded.scope).toContain('read:analytics')
+  })
+
+  it('sets Cache-Control: no-store and Pragma: no-cache', async () => {
+    const { apiKey, record } = await createApiKey({ label: 'test', scopes: [ApiScope.ReadVaults] })
+
+    const res = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_id: record.id,
+      client_secret: apiKey,
+    })
+
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    expect(res.headers.get('pragma')).toBe('no-cache')
+  })
+
+  it('includes org_id in token when key has orgId', async () => {
+    const { apiKey, record } = await createApiKey({
+      label: 'org-key',
+      scopes: [ApiScope.ReadVaults],
+      orgId: 'org-abc',
+    })
+
+    const res = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_id: record.id,
+      client_secret: apiKey,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    const decoded = jwt.verify(body.access_token, JWT_SECRET) as any
+    expect(decoded.org_id).toBe('org-abc')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scope narrowing
+// ---------------------------------------------------------------------------
+
+describe('POST /api/oauth/token – scope narrowing', () => {
+  it('narrows to requested subset of client scopes', async () => {
+    const { apiKey, record } = await createApiKey({
+      label: 'wide',
+      scopes: [ApiScope.ReadVaults, ApiScope.ReadAnalytics],
+    })
+
+    const res = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_id: record.id,
+      client_secret: apiKey,
+      scope: 'read:vaults',
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    expect(body.scope).toBe('read:vaults')
+    const decoded = jwt.verify(body.access_token, JWT_SECRET) as any
+    expect(decoded.scope).toBe('read:vaults')
+    expect(decoded.scope).not.toContain('read:analytics')
+  })
+
+  it('rejects scope that exceeds client grants – RFC 6749 invalid_scope', async () => {
+    const { apiKey, record } = await createApiKey({
+      label: 'narrow',
+      scopes: [ApiScope.ReadVaults],
+    })
+
+    const res = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_id: record.id,
+      client_secret: apiKey,
+      scope: 'read:vaults read:analytics',
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json() as any
+    expect(body.error).toBe('invalid_scope')
+    expect(body.error_description).toContain('read:analytics')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Invalid client
+// ---------------------------------------------------------------------------
+
+describe('POST /api/oauth/token – invalid client', () => {
+  it('returns invalid_client for wrong secret', async () => {
+    const { record } = await createApiKey({ label: 'test', scopes: [ApiScope.ReadVaults] })
+
+    const res = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_id: record.id,
+      client_secret: `dsk_${record.id}.wrongsecret`,
+    })
+
+    expect(res.status).toBe(401)
+    const body = await res.json() as any
+    expect(body.error).toBe('invalid_client')
+  })
+
+  it('returns invalid_client for revoked key', async () => {
+    const { apiKey, record } = await createApiKey({
+      label: 'test',
+      scopes: [ApiScope.ReadVaults],
+      userId: 'test-user',
+    } as any)
+    await revokeApiKey(record.id, 'test-user')
+
+    const res = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_id: record.id,
+      client_secret: apiKey,
+    })
+
+    expect(res.status).toBe(401)
+    const body = await res.json() as any
+    expect(body.error).toBe('invalid_client')
+  })
+
+  it('returns invalid_request when client_id or client_secret missing', async () => {
+    const res1 = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_secret: 'dsk_foo.bar',
+    })
+    expect(res1.status).toBe(400)
+    expect(((await res1.json()) as any).error).toBe('invalid_request')
+
+    const res2 = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_id: 'some-id',
+    })
+    expect(res2.status).toBe(400)
+    expect(((await res2.json()) as any).error).toBe('invalid_request')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// grant_type validation
+// ---------------------------------------------------------------------------
+
+describe('POST /api/oauth/token – unsupported_grant_type', () => {
+  it('rejects unsupported grant types', async () => {
+    const res = await post('/api/oauth/token', {
+      grant_type: 'password',
+      client_id: 'x',
+      client_secret: 'y',
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json() as any
+    expect(body.error).toBe('unsupported_grant_type')
+  })
+
+  it('rejects missing grant_type', async () => {
+    const res = await post('/api/oauth/token', { client_id: 'x', client_secret: 'y' })
+    expect(res.status).toBe(400)
+    expect(((await res.json()) as any).error).toBe('unsupported_grant_type')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bearer middleware – oauthBearer
+// ---------------------------------------------------------------------------
+
+describe('authenticateOAuthBearer middleware', () => {
+  const issueToken = async (scopes: ApiScope[]): Promise<string> => {
+    const { apiKey, record } = await createApiKey({ label: 'mw-test', scopes })
+    const res = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_id: record.id,
+      client_secret: apiKey,
+    })
+    return ((await res.json()) as any).access_token as string
+  }
+
+  it('allows request with valid token and matching scope', async () => {
+    const token = await issueToken([ApiScope.ReadVaults])
+    const res = await get('/protected', token)
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects request with missing Authorization header', async () => {
+    const res = await fetch(`${baseUrl}/protected`)
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects request with expired token', async () => {
+    const expired = jwt.sign(
+      { sub: 'x', client_id: 'x', scope: 'read:vaults', iss: 'disciplr', aud: 'disciplr-api' },
+      JWT_SECRET,
+      { expiresIn: -1 },
+    )
+    const res = await get('/protected', expired)
+    expect(res.status).toBe(401)
+    expect(((await res.json()) as any).error).toMatch(/expired/i)
+  })
+
+  it('rejects token signed with wrong secret', async () => {
+    const token = jwt.sign(
+      { sub: 'x', client_id: 'x', scope: 'read:vaults', iss: 'disciplr', aud: 'disciplr-api' },
+      'wrong-secret',
+      { expiresIn: 3600 },
+    )
+    const res = await get('/protected', token)
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects token with wrong issuer', async () => {
+    const token = jwt.sign(
+      { sub: 'x', client_id: 'x', scope: 'read:vaults', iss: 'not-disciplr', aud: 'disciplr-api' },
+      JWT_SECRET,
+      { expiresIn: 3600 },
+    )
+    const res = await get('/protected', token)
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects token with insufficient scope', async () => {
+    const token = await issueToken([ApiScope.ReadVaults])
+    const res = await get('/analytics', token)
+    expect(res.status).toBe(403)
+    expect(((await res.json()) as any).error).toMatch(/missing scope/i)
+  })
+
+  it('allows token with superset of required scopes', async () => {
+    const token = await issueToken([ApiScope.ReadVaults, ApiScope.ReadAnalytics])
+    const res = await get('/analytics', token)
+    expect(res.status).toBe(200)
+  })
+
+  it('allows any valid token on no-scope-requirement route', async () => {
+    const token = await issueToken([ApiScope.ReadVaults])
+    const res = await get('/open', token)
+    expect(res.status).toBe(200)
+  })
+
+  it('attaches oauthToken to req with correct fields', async () => {
+    const token = await issueToken([ApiScope.ReadVaults])
+    const decoded = jwt.verify(token, JWT_SECRET) as any
+    expect(decoded.sub).toBeDefined()
+    expect(decoded.scope).toBe('read:vaults')
+    expect(decoded.iss).toBe('disciplr')
+    expect(decoded.aud).toBe('disciplr-api')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Token expiry structure
+// ---------------------------------------------------------------------------
+
+describe('Token expiry', () => {
+  it('token exp is approximately now + TOKEN_TTL_SECONDS', async () => {
+    const { apiKey, record } = await createApiKey({ label: 'exp-test', scopes: [ApiScope.ReadVaults] })
+    const before = Math.floor(Date.now() / 1000)
+
+    const res = await post('/api/oauth/token', {
+      grant_type: 'client_credentials',
+      client_id: record.id,
+      client_secret: apiKey,
+    })
+    const body = await res.json() as any
+    const decoded = jwt.verify(body.access_token, JWT_SECRET) as any
+    const after = Math.floor(Date.now() / 1000)
+
+    expect(decoded.exp).toBeGreaterThanOrEqual(before + body.expires_in - 2)
+    expect(decoded.exp).toBeLessThanOrEqual(after + body.expires_in + 2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// RFC 6749 error response shape
+// ---------------------------------------------------------------------------
+
+describe('RFC 6749 error response shape', () => {
+  it('all error responses include error + error_description and no-store headers', async () => {
+    const cases = await Promise.all([
+      post('/api/oauth/token', { grant_type: 'password' }),
+      post('/api/oauth/token', { grant_type: 'client_credentials' }),
+      post('/api/oauth/token', {
+        grant_type: 'client_credentials',
+        client_id: 'x',
+        client_secret: 'dsk_bad.bad',
+      }),
+    ])
+
+    for (const res of cases) {
+      const body = await res.json() as any
+      expect(typeof body.error).toBe('string')
+      expect(typeof body.error_description).toBe('string')
+      expect(res.headers.get('cache-control')).toBe('no-store')
+    }
+  })
+})


### PR DESCRIPTION
feat: OAuth2 client-credentials token endpoint with scope narrowing
  
  Summary
  
  Adds a minimal OAuth2 client-credentials grant so partners can exchange a
  client id/secret for a short-lived scoped JWT instead of sending a long-lived
  API key on every request.
  
  Changes
  
  - POST /api/oauth/token — accepts grant_type=client_credentials, client_id,
  client_secret (full dsk_ API key), and optional scope. Validates the client by
  reusing the existing argon2 API key hashing model. Issues a signed JWT with
  iss: disciplr, aud: disciplr-api, and a configurable TTL (default 1 h via
  OAUTH_TOKEN_TTL_SECONDS).
  - Scope narrowing — requested scopes must be a subset of the client's granted
  scopes; requesting broader scopes returns invalid_scope.
  - authenticateOAuthBearer middleware (src/middleware/oauthBearer.ts) — verifies
  issued tokens (signature, issuer, audience, expiry) and enforces required
  scopes on any protected route.
  - Rate-limited via the existing authRateLimiter. Audit-logged (fire-and-forget
  so DB unavailability never breaks the token response).
  - RFC 6749 compliant error shapes — unsupported_grant_type, invalid_request,
  invalid_client, invalid_scope — all with Cache-Control: no-store.
  
  Testing
  
  21 tests in src/tests/oauth.clientCredentials.test.ts:
  
  - Valid token issuance (all scopes, org_id propagation, cache headers)
  - Scope narrowing and over-requesting rejection
  - Invalid client (wrong secret, revoked key, missing params)
  - Unsupported/missing grant type
  - Bearer middleware (valid token, expired, wrong secret, wrong issuer, scope
  enforcement)
  - Token expiry structure
  - RFC 6749 error response shape
  
  All 21 tests pass (npm test src/tests/oauth.clientCredentials.test.ts).
  
  Config
  
  ┌─────────┬─────────┬─────────────┐
  │ Env var                 │ Default │ Description │
  ├─────────────────────────┼─────────┼───────────────────────────┤
  │ OAUTH_TOKEN_TTL_SECONDS │ 3600    │ Token lifetime in seconds │
  └─────────────────────────┴─────────┴───────────────────────────┘
closes #662