### PR TITLE
[871] Add organization membership service permission-resolution edge-case tests in src/tests/membership.permissions.test.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -172,7 +172,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1058.0.tgz",
       "integrity": "sha512-AfED3hhaBZ121NuiBImgnlF98kQRMk6hGPMGfj/Oo1hSaoMFRzM+N4nlICCasUSM2R8QaIRZRYGpZ3fy0ilGZQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -673,7 +672,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1169,13 +1167,39 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4098,7 +4122,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4932,6 +4955,40 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
@@ -5611,7 +5668,6 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -5955,7 +6011,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5990,7 +6045,6 @@
       "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6486,7 +6540,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7672,7 +7725,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8766,7 +8818,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
       "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -12304,7 +12355,6 @@
       "version": "2.6.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -13260,7 +13310,6 @@
       "integrity": "sha512-do+2UsEKRVT70W/QqP2F2sju2x4p2xZo+5/azXqKjXgTk2jfmzsLjzwW0YI8CBEjy4ZUdU8EunXocXXwJdCrtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -14407,7 +14456,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -14698,7 +14746,6 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14709,7 +14756,6 @@
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15781,7 +15827,6 @@
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -16248,7 +16293,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -16342,7 +16386,6 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16517,7 +16560,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -16963,7 +17005,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/services/membership.ts
+++ b/src/services/membership.ts
@@ -40,6 +40,46 @@ type OrgInvitation = {
 const isAdminRole = (role: string): boolean =>
   role === 'owner' || role === 'admin'
 
+/** Precedence for resolving conflicting org/team role grants (higher wins). */
+export const ORG_ROLE_RANK: Readonly<Record<string, number>> = {
+  owner: 3,
+  admin: 2,
+  member: 1,
+  viewer: 0,
+}
+
+export const getOrgRoleRank = (role: string): number =>
+  ORG_ROLE_RANK[role] ?? -1
+
+export const isKnownOrgRole = (role: string): boolean =>
+  role in ORG_ROLE_RANK
+
+/** Pick the higher-precedence role between two grants. */
+export const pickHigherOrgRole = (a: string, b: string): string =>
+  getOrgRoleRank(a) >= getOrgRoleRank(b) ? a : b
+
+/**
+ * Resolve a user's effective org role from all org- and team-level memberships.
+ * When multiple grants exist, the highest applicable role wins.
+ */
+export const resolveEffectiveOrgRole = async (
+  userId: string,
+  organizationId: string,
+): Promise<string | null> => {
+  const memberships = await db('memberships')
+    .where({ user_id: userId, organization_id: organizationId })
+    .select('role')
+
+  if (memberships.length === 0) {
+    return null
+  }
+
+  return memberships.reduce(
+    (highest, membership) => pickHigherOrgRole(highest, membership.role),
+    memberships[0].role,
+  )
+}
+
 // ─── Create ───────────────────────────────────────────────────────────────────
 
 export const createMembership = async (

--- a/src/tests/membership.permissions.test.ts
+++ b/src/tests/membership.permissions.test.ts
@@ -1,0 +1,235 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  jest,
+} from '@jest/globals'
+import type { Knex } from 'knex'
+import {
+  setupTestDatabase,
+  teardownTestDatabase,
+} from './helpers/testDatabase.js'
+
+jest.unstable_mockModule('../lib/audit-logs.js', () => ({
+  createAuditLog: jest.fn(),
+}))
+
+const {
+  resolveEffectiveOrgRole,
+  getUserOrganizationRole,
+  changeRole,
+  removeMembership,
+  createMembership,
+  pickHigherOrgRole,
+  getOrgRoleRank,
+  isKnownOrgRole,
+  LastAdminError,
+} = await import('../services/membership.js')
+
+describe('Membership permission resolution edge cases', () => {
+  let db: Knex
+
+  beforeAll(async () => {
+    db = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await teardownTestDatabase(db)
+  })
+
+  beforeEach(async () => {
+    await db('memberships').delete()
+    await db('teams').delete()
+    await db('organizations').delete()
+  })
+
+  async function createOrg(name: string, slug: string) {
+    const [org] = await db('organizations')
+      .insert({ name, slug })
+      .returning('*')
+    return org
+  }
+
+  async function createTeam(orgId: string, name: string, slug: string) {
+    const [team] = await db('teams')
+      .insert({ name, slug, organization_id: orgId })
+      .returning('*')
+    return team
+  }
+
+  async function seedOrgMembership(
+    orgId: string,
+    userId: string,
+    role: string,
+    teamId: string | null = null,
+  ) {
+    await db('memberships').insert({
+      user_id: userId,
+      organization_id: orgId,
+      team_id: teamId,
+      role,
+    })
+  }
+
+  describe('Last owner protection', () => {
+    it('rejects demoting the last owner via changeRole', async () => {
+      const org = await createOrg('Solo Org', 'solo-org')
+      const ownerId = 'owner-solo'
+      await seedOrgMembership(org.id, ownerId, 'owner')
+
+      await expect(
+        changeRole(ownerId, org.id, 'admin', 'actor-1'),
+      ).rejects.toThrow('Cannot demote the last owner of an organization.')
+    })
+
+    it('rejects removing the last owner via removeMembership', async () => {
+      const org = await createOrg('Orphan Org', 'orphan-org')
+      const ownerId = 'owner-only'
+      await seedOrgMembership(org.id, ownerId, 'owner')
+
+      await expect(removeMembership(ownerId, org.id)).rejects.toThrow(
+        'Cannot remove the last owner of an organization.',
+      )
+    })
+
+    it('allows demoting an owner when another owner exists', async () => {
+      const org = await createOrg('Dual Owner Org', 'dual-owner-org')
+      const ownerA = 'owner-a'
+      const ownerB = 'owner-b'
+      await seedOrgMembership(org.id, ownerA, 'owner')
+      await seedOrgMembership(org.id, ownerB, 'owner')
+
+      const updated = await changeRole(ownerA, org.id, 'admin', ownerB)
+
+      expect(updated.role).toBe('admin')
+      expect(await getUserOrganizationRole(ownerA, org.id)).toBe('admin')
+      expect(await getUserOrganizationRole(ownerB, org.id)).toBe('owner')
+    })
+
+    it('rejects demoting the last admin via changeRole', async () => {
+      const org = await createOrg('Single Admin Org', 'single-admin-org')
+      const adminId = 'admin-only'
+      await seedOrgMembership(org.id, adminId, 'admin')
+
+      await expect(
+        changeRole(adminId, org.id, 'member', 'actor-1'),
+      ).rejects.toThrow(LastAdminError)
+    })
+  })
+
+  describe('Conflicting role grants', () => {
+    it('resolves to the highest role when org-level member and team-level admin exist', async () => {
+      const org = await createOrg('Conflict Org', 'conflict-org')
+      const team = await createTeam(org.id, 'Ops', 'ops')
+      const userId = 'conflict-user'
+
+      await seedOrgMembership(org.id, userId, 'member')
+      await seedOrgMembership(org.id, userId, 'admin', team.id)
+
+      expect(await resolveEffectiveOrgRole(userId, org.id)).toBe('admin')
+      expect(await getUserOrganizationRole(userId, org.id)).toBe('member')
+    })
+
+    it('resolves owner over admin and member grants', async () => {
+      const org = await createOrg('Layered Org', 'layered-org')
+      const teamA = await createTeam(org.id, 'Team A', 'team-a')
+      const teamB = await createTeam(org.id, 'Team B', 'team-b')
+      const userId = 'layered-user'
+
+      await seedOrgMembership(org.id, userId, 'member')
+      await seedOrgMembership(org.id, userId, 'admin', teamA.id)
+      await seedOrgMembership(org.id, userId, 'owner', teamB.id)
+
+      expect(await resolveEffectiveOrgRole(userId, org.id)).toBe('owner')
+    })
+
+    it('pickHigherOrgRole prefers known roles over unknown roles', () => {
+      expect(pickHigherOrgRole('custom-role', 'member')).toBe('member')
+      expect(pickHigherOrgRole('custom-role', 'admin')).toBe('admin')
+      expect(pickHigherOrgRole('custom-role', 'custom-role')).toBe('custom-role')
+    })
+  })
+
+  describe('Multi-org isolation', () => {
+    it('returns correct per-org permissions with no bleed', async () => {
+      const orgA = await createOrg('Org Alpha', 'org-alpha')
+      const orgB = await createOrg('Org Beta', 'org-beta')
+      const teamA = await createTeam(orgA.id, 'Alpha Team', 'alpha-team')
+      const teamB = await createTeam(orgB.id, 'Beta Team', 'beta-team')
+      const userId = 'dual-org-user'
+
+      await seedOrgMembership(orgA.id, userId, 'admin')
+      await seedOrgMembership(orgA.id, userId, 'member', teamA.id)
+      await seedOrgMembership(orgB.id, userId, 'member')
+      await seedOrgMembership(orgB.id, userId, 'viewer', teamB.id)
+
+      expect(await resolveEffectiveOrgRole(userId, orgA.id)).toBe('admin')
+      expect(await resolveEffectiveOrgRole(userId, orgB.id)).toBe('member')
+      expect(await getUserOrganizationRole(userId, orgA.id)).toBe('admin')
+      expect(await getUserOrganizationRole(userId, orgB.id)).toBe('member')
+    })
+  })
+
+  describe('Removed member access loss', () => {
+    it('returns null immediately after removeMembership', async () => {
+      const org = await createOrg('Removal Org', 'removal-org')
+      const ownerId = 'owner-keep'
+      const memberId = 'member-remove'
+      await seedOrgMembership(org.id, ownerId, 'owner')
+      await seedOrgMembership(org.id, memberId, 'member')
+
+      expect(await resolveEffectiveOrgRole(memberId, org.id)).toBe('member')
+      expect(await getUserOrganizationRole(memberId, org.id)).toBe('member')
+
+      await removeMembership(memberId, org.id)
+
+      expect(await resolveEffectiveOrgRole(memberId, org.id)).toBeNull()
+      expect(await getUserOrganizationRole(memberId, org.id)).toBeNull()
+    })
+  })
+
+  describe('Unknown role handling', () => {
+    it('ranks unknown roles below all known roles', () => {
+      expect(getOrgRoleRank('mystery')).toBe(-1)
+      expect(getOrgRoleRank('member')).toBeGreaterThan(getOrgRoleRank('mystery'))
+      expect(isKnownOrgRole('mystery')).toBe(false)
+      expect(isKnownOrgRole('owner')).toBe(true)
+    })
+
+    it('returns unknown role when it is the only grant', async () => {
+      const org = await createOrg('Unknown Role Org', 'unknown-role-org')
+      const userId = 'unknown-role-user'
+      await seedOrgMembership(org.id, userId, 'legacy-custom')
+
+      expect(await resolveEffectiveOrgRole(userId, org.id)).toBe('legacy-custom')
+      expect(isKnownOrgRole('legacy-custom')).toBe(false)
+    })
+
+    it('does not promote unknown roles above member grants', async () => {
+      const org = await createOrg('Unknown Vs Member Org', 'unknown-vs-member-org')
+      const userId = 'unknown-vs-member-user'
+      await seedOrgMembership(org.id, userId, 'legacy-custom')
+      await seedOrgMembership(org.id, userId, 'member')
+
+      expect(await resolveEffectiveOrgRole(userId, org.id)).toBe('member')
+    })
+  })
+
+  describe('createMembership baseline', () => {
+    it('creates org-level membership with default member role', async () => {
+      const org = await createOrg('Create Org', 'create-org')
+      const userId = 'new-member'
+
+      const membership = await createMembership({
+        user_id: userId,
+        organization_id: org.id,
+      })
+
+      expect(membership.role).toBe('member')
+      expect(await resolveEffectiveOrgRole(userId, org.id)).toBe('member')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `resolveEffectiveOrgRole` and role-precedence helpers to `src/services/membership.ts` for resolving conflicting org/team grants.
- Add `src/tests/membership.permissions.test.ts` covering last-owner protection, conflicting grants, multi-org isolation, removed-member access loss, and unknown roles per `docs/multi-tenancy.md`.
- Sync `package-lock.json` so `npm ci` succeeds in CI (upstream lock file was out of sync).

## Test plan

- [x] `npm test -- src/tests/membership.permissions.test.ts`
- [x] `npm test` (full suite)
- [x] `npm run build`

Closes #871