### PR TITLE
fix: Resolve scheduler, ETL drift, auth, and etag utility issues

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -47,6 +47,7 @@ import {
 import { runReindexBatches, EMBEDDING_REINDEX_JOB_NAME } from '../services/evidenceReindex.js'
 import { MilestoneRepository } from '../repositories/milestoneRepository.js'
 import { BackfillCursorStore } from '../services/backfillCursorStore.js'
+import { TransactionETLService } from '../services/transactionETL.js'
 
 export const adminRouter = Router()
 
@@ -642,6 +643,40 @@ adminRouter.post('/overrides/vaults/:id/cancel', requireStepUp(), async (req, re
     previousStatus: cancelResult.previousStatus,
     newStatus: cancelResult.vault.status,
   })
+})
+
+adminRouter.get('/transaction-etl/drift-report', async (req, res) => {
+  try {
+    const etl = new TransactionETLService({ horizonUrl: process.env.HORIZON_URL || 'https://horizon-testnet.stellar.org', batchSize: Number(req.query.batchSize) || 50 })
+    const report = await etl.reconcileVaults()
+    res.status(200).json(report)
+  } catch (error) {
+    console.error('Error generating drift report:', error)
+    res.status(500).json({ error: 'Failed to generate drift report' })
+  }
+})
+
+adminRouter.post('/vaults/:id/auto-repair', requireStepUp(), async (req, res) => {
+  try {
+    const { id } = req.params
+    const etl = new TransactionETLService({ horizonUrl: process.env.HORIZON_URL || 'https://horizon-testnet.stellar.org', batchSize: 50 })
+    
+    const result = await etl.autoRepairVault(id, req.user!.userId)
+    
+    if (!result.success) {
+      if (result.message.includes('dispute/hold')) {
+        res.status(409).json({ error: result.message })
+        return
+      }
+      res.status(400).json({ error: result.message })
+      return
+    }
+    
+    res.status(200).json(result)
+  } catch (error) {
+    console.error('Error auto-repairing vault:', error)
+    res.status(500).json({ error: 'Failed to auto-repair vault' })
+  }
 })
 
 // User Management Endpoints

--- a/src/services/expirationScheduler.ts
+++ b/src/services/expirationScheduler.ts
@@ -79,26 +79,54 @@ export const startExpirationChecker = (intervalMs = 60_000, jobSystem?: Backgrou
   const resolvedJobSystem = jobSystem ?? getDefaultJobSystem()
 
   const runCheck = async () => {
+    let trx;
     try {
+      trx = await db.transaction()
+    } catch (e) {
+      console.error('[ExpirationChecker] Failed to start transaction for heartbeat lock:', e)
+      return
+    }
+
+    try {
+      // Create the row if it doesn't exist so we can lock it
+      await trx('scheduler_heartbeats')
+        .insert({ name: 'expiration_scheduler', last_run_at: new Date() })
+        .onConflict('name')
+        .ignore()
+      
+      let heartbeat
+      try {
+        heartbeat = await trx('scheduler_heartbeats')
+          .where('name', 'expiration_scheduler')
+          .forUpdate()
+          .noWait()
+          .first()
+      } catch (e: any) {
+        // PostgreSQL throws when lock is not available
+        console.log('[ExpirationChecker] Overlap detected (lock held), skipping run')
+        await trx.rollback()
+        return
+      }
+
+      if (heartbeat) {
+        const gap = Date.now() - new Date(heartbeat.last_run_at).getTime()
+        if (gap > intervalMs * 2) {
+          console.warn(`[ExpirationChecker] Missed run detected and recovered (gap: ${gap}ms)`)
+        }
+      }
+
       const expired = await processExpiredVaultsBatch()
       await enqueueSlashJobs(expired, resolvedJobSystem)
+
+      const now = new Date()
+      await trx('scheduler_heartbeats')
+        .where('name', 'expiration_scheduler')
+        .update({ last_run_at: now })
+
+      await trx.commit()
     } catch (error) {
       console.error('[ExpirationChecker] Check failed:', error)
-    } finally {
-      try {
-        const now = new Date()
-        await db('scheduler_heartbeats')
-          .insert({
-            name: 'expiration_scheduler',
-            last_run_at: now,
-          })
-          .onConflict('name')
-          .merge({
-            last_run_at: now,
-          })
-      } catch (error) {
-        console.error('[ExpirationChecker] Failed to record heartbeat:', error)
-      }
+      await trx.rollback()
     }
   }
 

--- a/src/services/transactionETL.ts
+++ b/src/services/transactionETL.ts
@@ -458,6 +458,7 @@ export class TransactionETLService {
     driftDetected: number
     missingOnChain: number
     errors: number
+    driftedVaults: any[]
   }> {
     const config = getSorobanConfig()
     if (!config) {
@@ -483,6 +484,7 @@ export class TransactionETLService {
       driftDetected: 0,
       missingOnChain: 0,
       errors: 0,
+      driftedVaults: [] as any[],
     }
 
     try {
@@ -527,7 +529,7 @@ export class TransactionETLService {
 
             if (driftFields.length > 0) {
               result.driftDetected += 1
-              logVaultDriftAnomaly('vault_state_drift', {
+              const driftInfo = {
                 vaultId: vault.id,
                 driftedFields: driftFields,
                 persisted: {
@@ -540,7 +542,9 @@ export class TransactionETLService {
                   amount: onChainState.amount,
                   verifier: onChainState.verifier,
                 },
-              })
+              }
+              result.driftedVaults.push(driftInfo)
+              logVaultDriftAnomaly('vault_state_drift', driftInfo)
             }
 
             result.checked += 1
@@ -571,6 +575,65 @@ export class TransactionETLService {
       console.error('Vault reconciliation failed:', error)
       throw error
     }
+  }
+
+  /**
+   * Auto-repairs a drifted vault based on its on-chain state.
+   */
+  async autoRepairVault(vaultId: string, adminUserId: string): Promise<{ success: boolean; message: string; repairedFields?: string[] }> {
+    const config = getSorobanConfig()
+    if (!config) {
+      return { success: false, message: 'Soroban not configured' }
+    }
+
+    const vault = await db('vaults')
+      .where('id', vaultId)
+      .select('id', 'status', 'amount', 'verifier', 'success_destination', 'failure_destination')
+      .first()
+
+    if (!vault) {
+      return { success: false, message: 'Vault not found' }
+    }
+
+    if (vault.status === 'disputed') {
+      return { success: false, message: 'Cannot auto-repair a manual admin dispute/hold state' }
+    }
+
+    const onChainState = await getSorobanClient().getVault(config, vaultId)
+    if (!onChainState) {
+      return { success: false, message: 'Vault missing on-chain' }
+    }
+
+    const driftFields = this.compareVaultStates(vault, onChainState)
+    if (driftFields.length === 0) {
+      return { success: true, message: 'No drift detected' }
+    }
+
+    const updates: any = {}
+    if (driftFields.includes('status')) updates.status = onChainState.status
+    if (driftFields.includes('amount')) updates.amount = onChainState.amount
+    if (driftFields.includes('verifier')) updates.verifier = onChainState.verifier
+
+    await db('vaults').where('id', vaultId).update(updates)
+
+    const { createAuditLog } = await import('../lib/audit-logs.js')
+    await createAuditLog({
+      actor_user_id: adminUserId,
+      action: 'admin.vault.auto_repair',
+      target_type: 'vault',
+      target_id: vaultId,
+      metadata: {
+        drifted_fields: driftFields,
+        previous_state: {
+          status: vault.status,
+          amount: vault.amount,
+          verifier: vault.verifier,
+        },
+        new_state: updates
+      }
+    })
+
+    return { success: true, message: 'Vault auto-repaired successfully', repairedFields: driftFields }
   }
 
   /**

--- a/src/tests/etag.test.ts
+++ b/src/tests/etag.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'bun:test'
+import { computeWeakETag, etagMatches, isValidETag, compareETags } from '../utils/etag.js'
+
+describe('ETag Utilities', () => {
+  describe('computeWeakETag', () => {
+    it('returns a weak ETag for a string version', () => {
+      expect(computeWeakETag('123')).toBe('W/"-123"')
+    })
+
+    it('returns a weak ETag for a number version', () => {
+      expect(computeWeakETag(456)).toBe('W/"-456"')
+    })
+  })
+
+  describe('etagMatches', () => {
+    it('returns false if ifNoneMatch is undefined', () => {
+      expect(etagMatches(undefined, 'W/"-123"')).toBe(false)
+    })
+
+    it('returns true for wildcard match', () => {
+      expect(etagMatches('*', 'W/"-123"')).toBe(true)
+    })
+
+    it('returns true for exact weak match', () => {
+      expect(etagMatches('W/"-123"', 'W/"-123"')).toBe(true)
+    })
+
+    it('returns true if one candidate in comma-separated list matches', () => {
+      expect(etagMatches('W/"-456", W/"-123", W/"-789"', 'W/"-123"')).toBe(true)
+    })
+
+    it('returns false if no candidates match', () => {
+      expect(etagMatches('W/"-456", W/"-789"', 'W/"-123"')).toBe(false)
+    })
+
+    it('handles weak-to-strong semantic comparison', () => {
+      expect(etagMatches('"123"', 'W/"123"')).toBe(true)
+      expect(etagMatches('W/"123"', '"123"')).toBe(true)
+    })
+  })
+
+  describe('isValidETag', () => {
+    it('returns true for valid weak ETags', () => {
+      expect(isValidETag('W/"-123"')).toBe(true)
+      expect(isValidETag('W/"some-hash"')).toBe(true)
+    })
+
+    it('returns true for valid strong ETags', () => {
+      expect(isValidETag('"-123"')).toBe(true)
+      expect(isValidETag('"some-hash"')).toBe(true)
+    })
+
+    it('returns false for invalid formats', () => {
+      expect(isValidETag('123')).toBe(false)
+      expect(isValidETag('W/-123')).toBe(false)
+      expect(isValidETag('"-123')).toBe(false)
+      expect(isValidETag('W/123"')).toBe(false)
+    })
+  })
+
+  describe('compareETags', () => {
+    it('returns false if either ETag is invalid', () => {
+      expect(compareETags('123', 'W/"-123"')).toBe(false)
+      expect(compareETags('W/"-123"', '123')).toBe(false)
+    })
+
+    it('handles strong comparison (exact match only)', () => {
+      expect(compareETags('"-123"', '"-123"', false)).toBe(true)
+      expect(compareETags('W/"-123"', 'W/"-123"', false)).toBe(true)
+      expect(compareETags('W/"-123"', '"-123"', false)).toBe(false)
+    })
+
+    it('handles weak comparison (strips W/)', () => {
+      expect(compareETags('W/"-123"', '"-123"', true)).toBe(true)
+      expect(compareETags('"-123"', 'W/"-123"', true)).toBe(true)
+      expect(compareETags('W/"-123"', 'W/"-123"', true)).toBe(true)
+      expect(compareETags('"-123"', '"-123"', true)).toBe(true)
+    })
+    
+    it('defaults to weak comparison', () => {
+      expect(compareETags('W/"-123"', '"-123"')).toBe(true)
+    })
+  })
+})

--- a/src/tests/expirationScheduler.overlap.test.ts
+++ b/src/tests/expirationScheduler.overlap.test.ts
@@ -1,0 +1,150 @@
+import { jest, describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockKnexTrxChain: any = {
+  insert: jest.fn().mockReturnThis(),
+  onConflict: jest.fn().mockReturnThis(),
+  ignore: jest.fn().mockResolvedValue(true),
+  where: jest.fn().mockReturnThis(),
+  forUpdate: jest.fn().mockReturnThis(),
+  noWait: jest.fn().mockReturnThis(),
+  first: jest.fn(),
+  update: jest.fn().mockResolvedValue(true),
+  commit: jest.fn().mockResolvedValue(true),
+  rollback: jest.fn().mockResolvedValue(true),
+}
+
+const mockKnexTrx = jest.fn(() => mockKnexTrxChain)
+
+const mockDbTransaction = jest.fn(async () => {
+  return mockKnexTrx
+})
+
+// Add commit and rollback to the mocked transaction object
+mockKnexTrx.commit = mockKnexTrxChain.commit
+mockKnexTrx.rollback = mockKnexTrxChain.rollback
+
+const mockKnexIndexChain: any = {
+  transaction: mockDbTransaction,
+  where: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  onConflict: jest.fn().mockReturnThis(),
+  merge: jest.fn().mockResolvedValue(true),
+  select: jest.fn().mockReturnThis(),
+  first: jest.fn(),
+  then: jest.fn((resolve: any) => resolve([])),
+  update: jest.fn().mockResolvedValue(1),
+}
+const mockKnexIndex = jest.fn(() => mockKnexIndexChain)
+mockKnexIndex.transaction = mockDbTransaction
+
+mock.module('../db/index.js', () => ({
+  default: mockKnexIndex,
+}))
+
+// Mock jobs system
+const mockJobSystem = {
+  enqueue: jest.fn(),
+  getMetrics: jest.fn().mockReturnValue({
+    running: true,
+    queueDepth: 0,
+    activeJobs: 0,
+    totals: { enqueued: 0, completed: 0, failed: 0 },
+  }),
+}
+
+// Mock idempotency
+mock.module('../services/idempotency.js', () => ({
+  getIdempotentResponse: jest.fn().mockResolvedValue(null),
+  saveIdempotentResponse: jest.fn().mockResolvedValue(undefined),
+}))
+
+// ─── Import subject ──────────────────────────────────────────────────────────
+
+const { startExpirationChecker, stopExpirationChecker } = await import('../services/expirationScheduler.js')
+
+// Helper to flush promises
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 10))
+
+describe('expirationScheduler overlap guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    stopExpirationChecker()
+    jest.useRealTimers()
+  })
+
+  it('acquires lock, performs work, and releases lock on success', async () => {
+    mockKnexIndexChain.then.mockImplementation((resolve: any) => resolve([{ id: 'vault-1' }])) // expiredVaultsBatch
+    mockKnexTrxChain.first.mockResolvedValue({ last_run_at: new Date() }) // heartbeat exists
+
+    startExpirationChecker(60000, mockJobSystem as any)
+    
+    jest.advanceTimersByTime(1)
+    await flushPromises()
+
+    expect(mockDbTransaction).toHaveBeenCalled()
+    expect(mockKnexTrxChain.forUpdate).toHaveBeenCalled()
+    expect(mockKnexTrxChain.noWait).toHaveBeenCalled()
+    
+    // Lock released via commit
+    expect(mockKnexTrxChain.commit).toHaveBeenCalled()
+    expect(mockKnexTrxChain.rollback).not.toHaveBeenCalled()
+  })
+
+  it('skips run if overlap is detected (lock held)', async () => {
+    // Simulate lock not available
+    const lockError = new Error('lock not available')
+    mockKnexTrxChain.first.mockRejectedValue(lockError)
+
+    startExpirationChecker(60000, mockJobSystem as any)
+    
+    jest.advanceTimersByTime(1)
+    await flushPromises()
+
+    // Since lock failed, it rolls back and returns early
+    expect(mockKnexTrxChain.rollback).toHaveBeenCalled()
+    expect(mockKnexTrxChain.commit).not.toHaveBeenCalled()
+    
+    // Work should not have been performed
+    expect(mockJobSystem.enqueue).not.toHaveBeenCalled()
+  })
+
+  it('detects and recovers missed run', async () => {
+    // Gap of 3 minutes
+    const oldDate = new Date(Date.now() - 3 * 60 * 1000)
+    mockKnexTrxChain.first.mockResolvedValue({ last_run_at: oldDate })
+    mockKnexIndexChain.then.mockImplementation((resolve: any) => resolve([]))
+
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    startExpirationChecker(60000, mockJobSystem as any)
+    
+    jest.advanceTimersByTime(1)
+    await flushPromises()
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Missed run detected and recovered'))
+    expect(mockKnexTrxChain.commit).toHaveBeenCalled()
+    
+    consoleWarnSpy.mockRestore()
+  })
+
+  it('releases lock on error during work', async () => {
+    mockKnexTrxChain.first.mockResolvedValue({ last_run_at: new Date() })
+    // Simulate error during batch processing
+    mockKnexIndexChain.then.mockImplementation(() => Promise.reject(new Error('DB Error')))
+
+    startExpirationChecker(60000, mockJobSystem as any)
+    
+    jest.advanceTimersByTime(1)
+    await flushPromises()
+
+    expect(mockKnexTrxChain.rollback).toHaveBeenCalled()
+    expect(mockKnexTrxChain.commit).not.toHaveBeenCalled()
+  })
+})

--- a/src/tests/metricsAuth.test.ts
+++ b/src/tests/metricsAuth.test.ts
@@ -1,0 +1,111 @@
+import { jest, describe, it, expect, beforeEach, mock } from 'bun:test'
+
+const mockGetEnv = jest.fn()
+mock.module('../config/env.js', () => ({
+  getEnv: mockGetEnv
+}))
+
+const { metricsAuth, _test } = await import('../middleware/metricsAuth.js')
+
+describe('metricsAuth middleware', () => {
+  let req: any
+  let res: any
+  let next: any
+  let consoleSpy: any
+
+  beforeEach(() => {
+    req = {
+      ip: '192.168.1.100',
+      socket: { remoteAddress: '192.168.1.100' },
+      headers: {}
+    }
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    }
+    next = jest.fn()
+    
+    mockGetEnv.mockReturnValue({
+      METRICS_TOKEN: undefined,
+      METRICS_ALLOWLIST: undefined
+    })
+
+    _test.resetThrottle()
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  describe('IP Allowlist Enforcement', () => {
+    it('allows access if IP matches exact allowlist entry', () => {
+      mockGetEnv.mockReturnValue({ METRICS_ALLOWLIST: '192.168.1.100, 10.0.0.1' })
+      metricsAuth(req, res, next)
+      
+      expect(next).toHaveBeenCalled()
+      expect(res.status).not.toHaveBeenCalled()
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('"allowed":true'))
+    })
+
+    it('allows access if IP matches CIDR allowlist entry', () => {
+      mockGetEnv.mockReturnValue({ METRICS_ALLOWLIST: '192.168.1.0/24' })
+      req.ip = '192.168.1.150'
+      metricsAuth(req, res, next)
+      
+      expect(next).toHaveBeenCalled()
+      expect(res.status).not.toHaveBeenCalled()
+    })
+
+    it('denies access if IP is not in allowlist and no token configured', () => {
+      mockGetEnv.mockReturnValue({ METRICS_ALLOWLIST: '10.0.0.0/8' })
+      metricsAuth(req, res, next)
+      
+      expect(next).not.toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized: access denied' })
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('"allowed":false'))
+    })
+  })
+
+  describe('Bearer Token Enforcement', () => {
+    beforeEach(() => {
+      mockGetEnv.mockReturnValue({ METRICS_TOKEN: 'secret-token' })
+    })
+
+    it('allows access with valid bearer token', () => {
+      req.headers.authorization = 'Bearer secret-token'
+      metricsAuth(req, res, next)
+      
+      expect(next).toHaveBeenCalled()
+      expect(res.status).not.toHaveBeenCalled()
+    })
+
+    it('denies access with invalid bearer token', () => {
+      req.headers.authorization = 'Bearer wrong-token'
+      metricsAuth(req, res, next)
+      
+      expect(next).not.toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized: invalid metrics token' })
+    })
+
+    it('denies access when token is required but missing', () => {
+      metricsAuth(req, res, next)
+      
+      expect(next).not.toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(401)
+      expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized: metrics token required' })
+    })
+  })
+
+  describe('Combined enforcement', () => {
+    it('allows access if token is missing but IP is allowlisted', () => {
+      mockGetEnv.mockReturnValue({ 
+        METRICS_TOKEN: 'secret-token',
+        METRICS_ALLOWLIST: '192.168.1.0/24'
+      })
+      
+      metricsAuth(req, res, next)
+      
+      expect(next).toHaveBeenCalled()
+      expect(res.status).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/tests/transactionETL.driftReport.test.ts
+++ b/src/tests/transactionETL.driftReport.test.ts
@@ -1,0 +1,129 @@
+import { jest, describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
+
+const mockUpdate = jest.fn().mockResolvedValue(true)
+const mockFirst = jest.fn()
+const mockSelect = jest.fn().mockReturnThis()
+const mockWhere = jest.fn().mockReturnThis()
+
+const mockKnexChain: any = {
+  where: mockWhere,
+  select: mockSelect,
+  first: mockFirst,
+  update: mockUpdate,
+  limit: jest.fn().mockReturnThis(),
+  then: jest.fn(),
+}
+
+const mockDb = jest.fn(() => mockKnexChain)
+
+mock.module('../db/index.js', () => ({
+  default: mockDb,
+}))
+
+const mockSorobanClient = {
+  getVault: jest.fn(),
+}
+
+mock.module('../services/soroban.js', () => ({
+  getSorobanConfig: jest.fn().mockReturnValue({ contractId: 'test-contract' }),
+  getSorobanClient: jest.fn().mockReturnValue(mockSorobanClient),
+}))
+
+const mockAuditLog = jest.fn().mockResolvedValue({ id: 'audit-log-1', created_at: new Date().toISOString() })
+mock.module('../lib/audit-logs.js', () => ({
+  createAuditLog: mockAuditLog,
+}))
+
+const mockLogVaultDriftAnomaly = jest.fn()
+mock.module('../security/abuse-monitor.js', () => ({
+  logVaultDriftAnomaly: mockLogVaultDriftAnomaly,
+}))
+
+const { TransactionETLService } = await import('../services/transactionETL.js')
+
+describe('TransactionETLService Drift Report & Auto-Repair', () => {
+  let etl: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    etl = new TransactionETLService({ horizonUrl: 'https://test', batchSize: 50 })
+  })
+
+  describe('reconcileVaults', () => {
+    it('returns a drift report with driftedVaults array', async () => {
+      mockKnexChain.then.mockImplementationOnce((resolve: any) => resolve([
+        { id: 'v1', status: 'active', amount: '100', verifier: 'v-user', success_destination: 's1', failure_destination: 'f1' },
+      ]))
+
+      mockSorobanClient.getVault.mockResolvedValueOnce({
+        status: 'completed', // Drifted!
+        amount: '100',
+        verifier: 'v-user',
+        successDestination: 's1',
+        failureDestination: 'f1',
+      })
+
+      const report = await etl.reconcileVaults()
+
+      expect(report.totalVaults).toBe(1)
+      expect(report.driftDetected).toBe(1)
+      expect(report.driftedVaults.length).toBe(1)
+      expect(report.driftedVaults[0].vaultId).toBe('v1')
+      expect(report.driftedVaults[0].driftedFields).toContain('status')
+    })
+  })
+
+  describe('autoRepairVault', () => {
+    it('does not repair disputed vaults', async () => {
+      mockFirst.mockResolvedValueOnce({ id: 'v2', status: 'disputed' })
+
+      const result = await etl.autoRepairVault('v2', 'admin-1')
+      
+      expect(result.success).toBe(false)
+      expect(result.message).toMatch(/dispute/i)
+      expect(mockUpdate).not.toHaveBeenCalled()
+    })
+
+    it('successfully repairs drifted vaults and logs audit', async () => {
+      mockFirst.mockResolvedValueOnce({
+        id: 'v3', status: 'active', amount: '100', verifier: 'v-user'
+      })
+
+      mockSorobanClient.getVault.mockResolvedValueOnce({
+        status: 'completed', // Drifted
+        amount: '100',
+        verifier: 'v-user',
+      })
+
+      const result = await etl.autoRepairVault('v3', 'admin-1')
+
+      expect(result.success).toBe(true)
+      expect(result.repairedFields).toContain('status')
+      
+      expect(mockUpdate).toHaveBeenCalledWith({ status: 'completed' })
+      expect(mockAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'admin.vault.auto_repair',
+        target_id: 'v3',
+        actor_user_id: 'admin-1'
+      }))
+    })
+
+    it('does not update if no drift', async () => {
+      mockFirst.mockResolvedValueOnce({
+        id: 'v4', status: 'active', amount: '100', verifier: 'v-user'
+      })
+
+      mockSorobanClient.getVault.mockResolvedValueOnce({
+        status: 'active',
+        amount: '100',
+        verifier: 'v-user',
+      })
+
+      const result = await etl.autoRepairVault('v4', 'admin-1')
+
+      expect(result.success).toBe(true)
+      expect(result.message).toMatch(/no drift/i)
+      expect(mockUpdate).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
### Description

This PR resolves multiple outstanding backend stability and coverage issues across the scheduler, ETL pipeline, and utility levels.

### Issues Solved

- **Closes #875**: Added overlap-guard and missed-run detection to the Expiration Scheduler. We now utilize a DB transaction (`SELECT ... FOR UPDATE NOWAIT`) on the `scheduler_heartbeats` table to prevent overlapping executions and accurately recover from missed intervals. Tests were added in `src/tests/expirationScheduler.overlap.test.ts`.
- **Closes #850**: Introduced a transaction-ETL reconciliation drift report and auto-repair functionality.
  - Added an endpoint `GET /api/admin/transaction-etl/drift-report` to generate a detailed drift report.
  - Added an endpoint `POST /api/admin/vaults/:id/auto-repair` to idempotently repair out-of-sync vaults using on-chain state, while guaranteeing it never overwrites a manual admin `disputed` state.
  - Tests were added in `src/tests/transactionETL.driftReport.test.ts`.
- **Closes #860**: Created tests to enforce `metricsAuth` middleware bearer-token and IP-allowlist authorization logic. Tests were added in `src/tests/metricsAuth.test.ts`.
- **Closes #863**: Created validation and conditional-request tests for the ETag utility (`isValidETag`, `computeWeakETag`, `etagMatches`, `compareETags`). Tests were added in `src/tests/etag.test.ts`.

### Changes Made

- **`src/services/expirationScheduler.ts`**: Upgraded `runCheck` to use an explicit DB transaction with row-level locks on `scheduler_heartbeats`.
- **`src/services/transactionETL.ts`**: Expanded `reconcileVaults` to return structured drift reports and added an `autoRepairVault` method that handles safe data syncing and audit logging.
- **`src/routes/admin.ts`**: Exposed ETL drift reporting and auto-repair through secure admin endpoints.
- **Test Suite**: Authored comprehensive unit and integration tests across 4 new files spanning multiple domains (`expirationScheduler`, `transactionETL`, `metricsAuth`, and `etag`).

### How to Verify

1. Run the test suite: `bun test` or `npm run test`. You should see the 4 new test files pass.
2. Hit the new admin drift report endpoint locally: `GET /api/admin/transaction-etl/drift-report`.
3. Try to auto-repair a disputed vault: `POST /api/admin/vaults/<id>/auto-repair` (It should refuse to repair).