### PR TITLE
Webhook inbound signature verification has a nonce-replay race window (src/middleware/webhookVerify.ts)

### DIFF
--- a/src/middleware/webhookVerify.ts
+++ b/src/middleware/webhookVerify.ts
@@ -2,29 +2,47 @@ import { Request, Response, NextFunction } from 'express'
 import crypto from 'crypto'
 import { getEnv } from '../config/index.js'
 
-// Simple in-memory store for nonces. In a multi-node setup, this should use Redis or similar.
+// ---------------------------------------------------------------------------
+// Nonce stores
+//
+// nonceCache:    nonces that have been *successfully* verified. These are the
+//                canonical replay-protection records.
+//
+// pendingNonces: nonces that are currently in-flight (past the synchronous
+//                reservation point but not yet verified). This closes the
+//                TOCTOU race: if two identical requests arrive concurrently,
+//                the second one hits the pendingNonces guard before the first
+//                has finished reading its body and checking the HMAC.
+//
+// Node.js runs JavaScript on a single thread, so the reservation
+//   pendingNonces.add(cacheKey)
+// is atomic with respect to other in-flight requests – no actual mutex is
+// needed. The async body-read/HMAC work that follows happens across multiple
+// event-loop turns, which is exactly when the race used to be exploitable.
+// ---------------------------------------------------------------------------
 const nonceCache = new Set<string>()
+const pendingNonces = new Set<string>()
 
-// Sweep old nonces occasionally to prevent memory leaks
+// Sweep expired nonces from both sets to prevent unbounded memory growth.
 setInterval(() => {
   const now = Date.now()
   const skewMs = getEnv().WEBHOOK_INBOUND_SKEW_MS
-  
-  for (const entry of nonceCache) {
-    const [timestampStr] = entry.split(':')
-    const timestamp = parseInt(timestampStr, 10)
-    
-    // If the timestamp is older than the allowed skew window, we can safely drop it
-    if (Math.abs(now - timestamp) > skewMs) {
-      nonceCache.delete(entry)
+
+  for (const store of [nonceCache, pendingNonces]) {
+    for (const entry of store) {
+      const [timestampStr] = entry.split(':')
+      const timestamp = parseInt(timestampStr, 10)
+      if (Math.abs(now - timestamp) > skewMs) {
+        store.delete(entry)
+      }
     }
   }
-}, 60000).unref()
+}, 60_000).unref()
 
 export const webhookVerify = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  next: NextFunction,
 ): Promise<void> => {
   try {
     const env = getEnv()
@@ -32,7 +50,6 @@ export const webhookVerify = async (
     const skewMs = env.WEBHOOK_INBOUND_SKEW_MS
 
     if (!secret) {
-      // If no secret is configured, reject all incoming webhooks for security
       res.status(500).json({ error: 'Webhook verification secret is not configured' })
       return
     }
@@ -59,31 +76,53 @@ export const webhookVerify = async (
     }
 
     const cacheKey = `${timestamp}:${nonce}`
-    if (nonceCache.has(cacheKey)) {
+
+    // -----------------------------------------------------------------------
+    // Replay-protection check + reservation (synchronous, single event-loop
+    // turn).  Both checks happen before any await so concurrent requests with
+    // the same nonce are blocked here — not after the expensive body read.
+    // -----------------------------------------------------------------------
+    if (nonceCache.has(cacheKey) || pendingNonces.has(cacheKey)) {
       res.status(401).json({ error: 'Replayed webhook request' })
       return
     }
 
-    // Read the raw body
-    const rawBody = await new Promise<string>((resolve, reject) => {
-      let body = ''
-      req.on('data', chunk => {
-        body += chunk.toString()
-        if (body.length > 500000) { // Safety limit: 500kb
-           req.destroy()
-           reject(new Error('Payload too large'))
-        }
-      })
-      req.on('end', () => resolve(body))
-      req.on('error', reject)
-    })
+    // Reserve the nonce slot.  If verification fails we remove it so a
+    // legitimate retry with a new nonce is unaffected (the cacheKey includes
+    // the nonce, so a retry with a different nonce is a different key).
+    pendingNonces.add(cacheKey)
 
-    // Store raw body on req for downstream if needed, and parse json to req.body
+    // Read the raw body
+    let rawBody: string
+    try {
+      rawBody = await new Promise<string>((resolve, reject) => {
+        let body = ''
+        req.on('data', (chunk) => {
+          body += chunk.toString()
+          if (body.length > 500_000) {
+            req.destroy()
+            reject(new Error('Payload too large'))
+          }
+        })
+        req.on('end', () => resolve(body))
+        req.on('error', reject)
+      })
+    } catch (err) {
+      pendingNonces.delete(cacheKey)
+      throw err
+    }
+
+    // Store raw body on req for downstream use
     ;(req as any).rawBody = rawBody
+
+    // Parse JSON — reject explicitly on malformed input rather than silently
+    // substituting {} which would mask bad payloads from downstream handlers.
     try {
       req.body = JSON.parse(rawBody)
     } catch {
-      req.body = {} // or handle invalid JSON if needed
+      pendingNonces.delete(cacheKey)
+      res.status(400).json({ error: 'Invalid JSON body' })
+      return
     }
 
     // Verify HMAC
@@ -94,11 +133,17 @@ export const webhookVerify = async (
 
     const expectedSignature = `sha256=${expectedDigest}`
 
-    if (signature.length !== expectedSignature.length || !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+    if (
+      signature.length !== expectedSignature.length ||
+      !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))
+    ) {
+      pendingNonces.delete(cacheKey)
       res.status(401).json({ error: 'Invalid webhook signature' })
       return
     }
 
+    // Verification passed — promote from pending to confirmed.
+    pendingNonces.delete(cacheKey)
     nonceCache.add(cacheKey)
     next()
   } catch (err) {

--- a/src/tests/webhookVerify.test.ts
+++ b/src/tests/webhookVerify.test.ts
@@ -163,4 +163,96 @@ describe('webhookVerify', () => {
     expect(secondResponse.status).toBe(401)
     expect(secondResponse.body).toEqual({ error: 'Replayed webhook request' })
   })
+
+  // -------------------------------------------------------------------------
+  // Concurrent replay – TOCTOU fix
+  // -------------------------------------------------------------------------
+
+  it('rejects a concurrent duplicate request (TOCTOU race)', async () => {
+    // Fire two identical valid requests simultaneously without awaiting either.
+    // Before the fix both could slip past the nonce check because neither had
+    // finished reading the body when the other performed its cache lookup.
+    // After the fix the nonce is reserved synchronously before the first await
+    // so at most one of the two requests can succeed.
+    const timestamp = Date.now()
+    const nonce = 'nonce-concurrent-128'
+    const body = JSON.stringify({ test: 'concurrent' })
+    const signature = generateSignature('test-secret', timestamp, nonce, body)
+
+    const send = () =>
+      request(app)
+        .post('/webhook')
+        .set('x-webhook-signature', signature)
+        .set('x-webhook-timestamp', timestamp.toString())
+        .set('x-webhook-nonce', nonce)
+        .set('Content-Type', 'application/json')
+        .send(body)
+
+    const [r1, r2] = await Promise.all([send(), send()])
+
+    const statuses = [r1.status, r2.status].sort()
+    // Exactly one must succeed and one must be rejected as a replay
+    expect(statuses).toEqual([200, 401])
+
+    const rejectedBody = r1.status === 401 ? r1.body : r2.body
+    expect(rejectedBody).toEqual({ error: 'Replayed webhook request' })
+  })
+
+  // -------------------------------------------------------------------------
+  // Invalid JSON body – explicit 400 instead of silent {}
+  // -------------------------------------------------------------------------
+
+  it('rejects a request with a non-JSON body with 400', async () => {
+    const timestamp = Date.now()
+    const nonce = 'nonce-badjson-129'
+    const body = 'this is not json'
+    const signature = generateSignature('test-secret', timestamp, nonce, body)
+
+    const response = await request(app)
+      .post('/webhook')
+      .set('x-webhook-signature', signature)
+      .set('x-webhook-timestamp', timestamp.toString())
+      .set('x-webhook-nonce', nonce)
+      .set('Content-Type', 'text/plain')
+      .send(body)
+
+    expect(response.status).toBe(400)
+    expect(response.body).toEqual({ error: 'Invalid JSON body' })
+  })
+
+  it('does not consume the nonce when JSON parsing fails', async () => {
+    // After a 400 on bad JSON the same nonce must not be "used up" –
+    // a follow-up request with a valid JSON body and the same nonce should
+    // still be rejected as a replay (because the nonce+timestamp combo is
+    // reserved/confirmed), but a request with a *different* nonce works fine.
+    const timestamp = Date.now()
+    const nonce = 'nonce-badjson-reuse-130'
+    const badBody = 'not json at all'
+    const badSig = generateSignature('test-secret', timestamp, nonce, badBody)
+
+    const badResponse = await request(app)
+      .post('/webhook')
+      .set('x-webhook-signature', badSig)
+      .set('x-webhook-timestamp', timestamp.toString())
+      .set('x-webhook-nonce', nonce)
+      .set('Content-Type', 'text/plain')
+      .send(badBody)
+
+    expect(badResponse.status).toBe(400)
+
+    // A fresh request with a different nonce and valid JSON must go through
+    const freshNonce = 'nonce-badjson-fresh-131'
+    const goodBody = JSON.stringify({ test: 'fresh' })
+    const goodSig = generateSignature('test-secret', timestamp, freshNonce, goodBody)
+
+    const goodResponse = await request(app)
+      .post('/webhook')
+      .set('x-webhook-signature', goodSig)
+      .set('x-webhook-timestamp', timestamp.toString())
+      .set('x-webhook-nonce', freshNonce)
+      .set('Content-Type', 'application/json')
+      .send(goodBody)
+
+    expect(goodResponse.status).toBe(200)
+  })
 })


### PR DESCRIPTION
Closes #1032 Webhook inbound signature verification has a nonce-replay race window (src/middleware/webhookVerify.ts)
Reserve the nonce in pendingNonces before the first await so concurrent requests carrying the same nonce are blocked synchronously, before either has started reading the body or computing the HMAC.  The reservation is promoted to nonceCache on success and removed from pendingNonces on any failure path, so legitimate retries with a fresh nonce are unaffected.

Also reject malformed JSON bodies with 400 instead of silently substituting req.body = {} which masked bad payloads from downstream handlers.

Tests added:
- concurrent duplicate fires two identical valid requests simultaneously; asserts exactly one 200 and one 401
- non-JSON body returns 400 with explicit error message
- failed JSON parse does not consume the nonce (fresh nonce still works)