### PR TITLE
Duplicate findById method in MilestoneRepository

### DIFF
--- a/src/repositories/milestoneRepository.ts
+++ b/src/repositories/milestoneRepository.ts
@@ -1,23 +1,23 @@
-import { Knex } from 'knex'
-import { CURRENT_EMBEDDING_MODEL_VERSION } from '../services/embeddingProvider.js'
+import { Knex } from "knex";
+import { CURRENT_EMBEDDING_MODEL_VERSION } from "../services/embeddingProvider.js";
 
 export interface MilestoneEmbedding {
-  milestone_id: string
-  embedding: number[]
-  model_version: string
-  created_at: Date
-  updated_at: Date
+  milestone_id: string;
+  embedding: number[];
+  model_version: string;
+  created_at: Date;
+  updated_at: Date;
 }
 
 export interface NearestNeighborResult {
-  milestone_id: string
-  distance: number
+  milestone_id: string;
+  distance: number;
 }
 
 export interface MilestoneSummary {
-  id: string
-  title: string
-  description: string | null
+  id: string;
+  title: string;
+  description: string | null;
 }
 
 /**
@@ -26,13 +26,13 @@ export interface MilestoneSummary {
  * leaking the full vault_PAYLOAD.
  */
 export interface MilestoneLookup {
-  id: string
-  vault_id: string
-  title: string
-  description: string | null
-  verifier_user_id: string | null
-  deleted_at: Date | null
-  created_at: Date
+  id: string;
+  vault_id: string;
+  title: string;
+  description: string | null;
+  verifier_user_id: string | null;
+  deleted_at: Date | null;
+  created_at: Date;
 }
 
 export interface MilestoneQueryOptions {
@@ -40,7 +40,7 @@ export interface MilestoneQueryOptions {
    * When true, soft-deleted milestones (`deleted_at IS NOT NULL`) are also
    * returned. Defaults to `false` so callers always operate on active rows.
    */
-  includeDeleted?: boolean
+  includeDeleted?: boolean;
 }
 
 /**
@@ -61,14 +61,14 @@ export class MilestoneRepository {
     embedding: number[],
     modelVersion: string = CURRENT_EMBEDDING_MODEL_VERSION,
   ): Promise<void> {
-    const vectorLiteral = `[${embedding.join(',')}]`
+    const vectorLiteral = `[${embedding.join(",")}]`;
     await this.db.raw(
       `INSERT INTO milestone_embeddings (milestone_id, embedding, model_version, updated_at)
        VALUES (:milestoneId, :vector::vector, :modelVersion, NOW())
        ON CONFLICT (milestone_id)
        DO UPDATE SET embedding = EXCLUDED.embedding, model_version = EXCLUDED.model_version, updated_at = NOW()`,
       { milestoneId, vector: vectorLiteral, modelVersion },
-    )
+    );
   }
 
   /**
@@ -82,17 +82,22 @@ export class MilestoneRepository {
    * @returns            Array of { milestone_id, distance } sorted closest-first.
    *                     Returns an empty array when no embedding exists for milestoneId.
    */
-  async nearestNeighbors(milestoneId: string, k = 5): Promise<NearestNeighborResult[]> {
+  async nearestNeighbors(
+    milestoneId: string,
+    k = 5,
+  ): Promise<NearestNeighborResult[]> {
     // Fetch the query embedding first so we can pass it as a plain literal.
     // This avoids a correlated sub-query that would prevent index use.
-    const row = (await this.db('milestone_embeddings')
+    const row = (await this.db("milestone_embeddings")
       .where({ milestone_id: milestoneId })
-      .select(this.db.raw('embedding::text AS embedding_text'))
-      .first()) as any
+      .select(this.db.raw("embedding::text AS embedding_text"))
+      .first()) as any;
 
-    if (!row) return []
+    if (!row) return [];
 
-    const rows = await this.db.raw<{ rows: { milestone_id: string; distance: string }[] }>(
+    const rows = await this.db.raw<{
+      rows: { milestone_id: string; distance: string }[];
+    }>(
       `SELECT milestone_id,
               (embedding <=> :queryVec::vector) AS distance
        FROM   milestone_embeddings
@@ -100,42 +105,44 @@ export class MilestoneRepository {
        ORDER  BY embedding <=> :queryVec::vector
        LIMIT  :k`,
       { queryVec: row.embedding_text, milestoneId, k },
-    )
+    );
 
     return rows.rows.map((r) => ({
       milestone_id: r.milestone_id,
       distance: parseFloat(r.distance),
-    }))
+    }));
   }
 
   /**
    * Return the stored embedding record for a milestone, or null if absent.
    */
   async findEmbedding(milestoneId: string): Promise<MilestoneEmbedding | null> {
-    const row = await this.db('milestone_embeddings')
+    const row = await this.db("milestone_embeddings")
       .where({ milestone_id: milestoneId })
       .select(
-        'milestone_id',
-        this.db.raw('embedding::text AS embedding'),
-        'model_version',
-        'created_at',
-        'updated_at',
+        "milestone_id",
+        this.db.raw("embedding::text AS embedding"),
+        "model_version",
+        "created_at",
+        "updated_at",
       )
-      .first()
+      .first();
 
-    if (!row) return null
+    if (!row) return null;
 
     return {
       ...row,
       embedding: JSON.parse(row.embedding) as number[],
-    } as MilestoneEmbedding
+    } as MilestoneEmbedding;
   }
 
   /**
    * Delete the embedding for a milestone (e.g. when the milestone is removed).
    */
   async deleteEmbedding(milestoneId: string): Promise<void> {
-    await this.db('milestone_embeddings').where({ milestone_id: milestoneId }).delete()
+    await this.db("milestone_embeddings")
+      .where({ milestone_id: milestoneId })
+      .delete();
   }
 
   /**
@@ -148,17 +155,20 @@ export class MilestoneRepository {
    * may still need to be cleaned up.  Callers that want soft-delete filtering
    * should use `findById` or `listForVerifier`.
    */
-  async listMilestonesAfter(afterId: string | null, limit: number): Promise<MilestoneSummary[]> {
-    let query = this.db('milestones')
-      .select('id', 'title', 'description')
-      .orderBy('id', 'asc')
-      .limit(limit)
+  async listMilestonesAfter(
+    afterId: string | null,
+    limit: number,
+  ): Promise<MilestoneSummary[]> {
+    let query = this.db("milestones")
+      .select("id", "title", "description")
+      .orderBy("id", "asc")
+      .limit(limit);
 
     if (afterId !== null) {
-      query = query.where('id', '>', afterId)
+      query = query.where("id", ">", afterId);
     }
 
-    return query
+    return query;
   }
 
   /**
@@ -176,27 +186,27 @@ export class MilestoneRepository {
     id: string,
     opts: MilestoneQueryOptions = {},
   ): Promise<MilestoneLookup | null> {
-    const includeDeleted = opts.includeDeleted === true
-    let query = this.db('milestones')
+    const includeDeleted = opts.includeDeleted === true;
+    let query = this.db("milestones")
       .where({ id })
       .select(
-        'id',
-        'vault_id',
-        'title',
-        'description',
-        'verifier_user_id',
-        'deleted_at',
-        'created_at',
+        "id",
+        "vault_id",
+        "title",
+        "description",
+        "verifier_user_id",
+        "deleted_at",
+        "created_at",
       )
-      .first()
+      .first();
 
     if (!includeDeleted) {
-      query = query.whereNull('deleted_at')
+      query = query.whereNull("deleted_at");
     }
 
     // Knex's `.first()` resolves to `undefined` when nothing matches; the
     // contract for this method is `null`.
-    return (await query) ?? null
+    return (await query) ?? null;
   }
 
   /**
@@ -211,25 +221,25 @@ export class MilestoneRepository {
     verifierUserId: string,
     opts: MilestoneQueryOptions = {},
   ): Promise<MilestoneLookup[]> {
-    const includeDeleted = opts.includeDeleted === true
-    let query = this.db('milestones')
+    const includeDeleted = opts.includeDeleted === true;
+    let query = this.db("milestones")
       .where({ verifier_user_id: verifierUserId })
       .select(
-        'id',
-        'vault_id',
-        'title',
-        'description',
-        'verifier_user_id',
-        'deleted_at',
-        'created_at',
+        "id",
+        "vault_id",
+        "title",
+        "description",
+        "verifier_user_id",
+        "deleted_at",
+        "created_at",
       )
-      .orderBy('id', 'asc')
+      .orderBy("id", "asc");
 
     if (!includeDeleted) {
-      query = query.whereNull('deleted_at')
+      query = query.whereNull("deleted_at");
     }
 
-    return query
+    return query;
   }
 
   /**
@@ -241,12 +251,12 @@ export class MilestoneRepository {
    * leave a milestone invisible to default reads.
    */
   async softDelete(id: string, deletedAt: Date = new Date()): Promise<boolean> {
-    const updated = await this.db('milestones')
+    const updated = await this.db("milestones")
       .where({ id })
-      .whereNull('deleted_at')
-      .update({ deleted_at: deletedAt })
+      .whereNull("deleted_at")
+      .update({ deleted_at: deletedAt });
 
-    return updated > 0
+    return updated > 0;
   }
 
   /**
@@ -255,28 +265,35 @@ export class MilestoneRepository {
    * soft-deleted.
    */
   async restore(id: string): Promise<boolean> {
-    const updated = await this.db('milestones')
+    const updated = await this.db("milestones")
       .where({ id })
-      .whereNotNull('deleted_at')
-      .update({ deleted_at: null })
+      .whereNotNull("deleted_at")
+      .update({ deleted_at: null });
 
-    return updated > 0
+    return updated > 0;
   }
 
   /**
    * Return the model_version of every embedding that exists among the given
    * milestone ids. Ids absent from the returned map have no stored embedding.
    */
-  async findEmbeddingModelVersions(milestoneIds: string[]): Promise<Map<string, string>> {
+  async findEmbeddingModelVersions(
+    milestoneIds: string[],
+  ): Promise<Map<string, string>> {
     if (milestoneIds.length === 0) {
-      return new Map()
+      return new Map();
     }
 
-    const rows = await this.db('milestone_embeddings')
-      .whereIn('milestone_id', milestoneIds)
-      .select('milestone_id', 'model_version')
+    const rows = await this.db("milestone_embeddings")
+      .whereIn("milestone_id", milestoneIds)
+      .select("milestone_id", "model_version");
 
-    return new Map(rows.map((row: { milestone_id: string; model_version: string }) => [row.milestone_id, row.model_version]))
+    return new Map(
+      rows.map((row: { milestone_id: string; model_version: string }) => [
+        row.milestone_id,
+        row.model_version,
+      ]),
+    );
   }
 
   /**
@@ -284,77 +301,87 @@ export class MilestoneRepository {
    * keyset pagination, and soft-delete exclusion.
    */
   async findMany(options: {
-    orgId: string
-    verifierUserId?: string
-    afterId?: string | null
-    limit?: number
-    includeDeleted?: boolean
+    orgId: string;
+    verifierUserId?: string;
+    afterId?: string | null;
+    limit?: number;
+    includeDeleted?: boolean;
   }): Promise<any[]> {
-    const { orgId, verifierUserId, afterId, limit = 10, includeDeleted = false } = options
+    const {
+      orgId,
+      verifierUserId,
+      afterId,
+      limit = 10,
+      includeDeleted = false,
+    } = options;
 
-    let query = this.db('milestones')
-      .join('vaults', 'milestones.vault_id', 'vaults.id')
+    let query = this.db("milestones")
+      .join("vaults", "milestones.vault_id", "vaults.id")
       .select(
-        'milestones.id',
-        'milestones.vault_id as vaultId',
-        'milestones.title',
-        'milestones.description',
-        'milestones.target_amount as targetAmount',
-        'milestones.current_amount as currentAmount',
-        'milestones.deadline',
-        'milestones.status',
-        'milestones.verifier_user_id as verifierUserId',
-        'milestones.created_at as createdAt',
-        'milestones.updated_at as updatedAt',
-        'milestones.deleted_at as deletedAt',
+        "milestones.id",
+        "milestones.vault_id as vaultId",
+        "milestones.title",
+        "milestones.description",
+        "milestones.target_amount as targetAmount",
+        "milestones.current_amount as currentAmount",
+        "milestones.deadline",
+        "milestones.status",
+        "milestones.verifier_user_id as verifierUserId",
+        "milestones.created_at as createdAt",
+        "milestones.updated_at as updatedAt",
+        "milestones.deleted_at as deletedAt",
       )
-      .where('vaults.organization_id', orgId)
-      .orderBy('milestones.id', 'asc')
-      .limit(limit)
+      .where("vaults.organization_id", orgId)
+      .orderBy("milestones.id", "asc")
+      .limit(limit);
 
     if (!includeDeleted) {
-      query = query.whereNull('milestones.deleted_at')
+      query = query.whereNull("milestones.deleted_at");
     }
 
     if (verifierUserId) {
-      query = query.where('milestones.verifier_user_id', verifierUserId)
+      query = query.where("milestones.verifier_user_id", verifierUserId);
     }
 
     if (afterId) {
-      query = query.where('milestones.id', '>', afterId)
+      query = query.where("milestones.id", ">", afterId);
     }
 
-    return query
+    return query;
   }
 
   /**
    * Find a milestone by ID, scoped to a specific organization.
    */
-  async findById(id: string, orgId: string, includeDeleted = false): Promise<any | null> {
-    let query = this.db('milestones')
-      .join('vaults', 'milestones.vault_id', 'vaults.id')
+  async findByIdForOrg(
+    id: string,
+    orgId: string,
+    includeDeleted = false,
+  ): Promise<any | null> {
+    let query = this.db("milestones")
+      .join("vaults", "milestones.vault_id", "vaults.id")
       .select(
-        'milestones.id',
-        'milestones.vault_id as vaultId',
-        'milestones.title',
-        'milestones.description',
-        'milestones.target_amount as targetAmount',
-        'milestones.current_amount as currentAmount',
-        'milestones.deadline',
-        'milestones.status',
-        'milestones.verifier_user_id as verifierUserId',
-        'milestones.created_at as createdAt',
-        'milestones.updated_at as updatedAt',
-        'milestones.deleted_at as deletedAt',
+        "milestones.id",
+        "milestones.vault_id as vaultId",
+        "milestones.title",
+        "milestones.description",
+        "milestones.target_amount as targetAmount",
+        "milestones.current_amount as currentAmount",
+        "milestones.deadline",
+        "milestones.status",
+        "milestones.verifier_user_id as verifierUserId",
+        "milestones.created_at as createdAt",
+        "milestones.updated_at as updatedAt",
+        "milestones.deleted_at as deletedAt",
       )
-      .where('milestones.id', id)
-      .where('vaults.organization_id', orgId)
+      .where("milestones.id", id)
+      .where("vaults.organization_id", orgId);
 
     if (!includeDeleted) {
-      query = query.whereNull('milestones.deleted_at')
+      query = query.whereNull("milestones.deleted_at");
     }
 
-    const row = await query.first()
-    return row || null
+    const row = await query.first();
+    return row || null;
   }
 }

--- a/src/tests/milestoneRepository.queries.test.ts
+++ b/src/tests/milestoneRepository.queries.test.ts
@@ -1,264 +1,284 @@
-import * as crypto from 'node:crypto'
-import knex, { Knex } from 'knex'
-import { MilestoneRepository } from '../repositories/milestoneRepository.js'
+import * as crypto from "node:crypto";
+import knex, { Knex } from "knex";
+import { MilestoneRepository } from "../repositories/milestoneRepository.js";
 
-const TEST_DB_URL = process.env.DATABASE_URL
-const describeWithDb = TEST_DB_URL ? describe : describe.skip
+const TEST_DB_URL = process.env.DATABASE_URL;
+const describeWithDb = TEST_DB_URL ? describe : describe.skip;
 
-describeWithDb('MilestoneRepository - Query Behaviour Matrix', () => {
-  let db: Knex
-  let repo: MilestoneRepository
+describeWithDb("MilestoneRepository - Query Behaviour Matrix", () => {
+  let db: Knex;
+  let repo: MilestoneRepository;
 
   // Test data tracking for cleanup
-  const orgIds: string[] = []
-  const userIds: string[] = []
-  const vaultIds: string[] = []
-  const milestoneIds: string[] = []
+  const orgIds: string[] = [];
+  const userIds: string[] = [];
+  const vaultIds: string[] = [];
+  const milestoneIds: string[] = [];
 
   beforeAll(async () => {
     db = knex({
-      client: 'pg',
+      client: "pg",
       connection: TEST_DB_URL!,
-    })
+    });
     // Ensure connection
-    await db.raw('SELECT 1')
-    repo = new MilestoneRepository(db)
-  })
+    await db.raw("SELECT 1");
+    repo = new MilestoneRepository(db);
+  });
 
   afterAll(async () => {
     if (db) {
       // Cleanup test data in reverse dependency order
       if (milestoneIds.length > 0) {
-        await db('milestones').whereIn('id', milestoneIds).delete()
+        await db("milestones").whereIn("id", milestoneIds).delete();
       }
       if (vaultIds.length > 0) {
-        await db('vaults').whereIn('id', vaultIds).delete()
+        await db("vaults").whereIn("id", vaultIds).delete();
       }
       if (userIds.length > 0) {
-        await db('users').whereIn('id', userIds).delete()
+        await db("users").whereIn("id", userIds).delete();
       }
       if (orgIds.length > 0) {
-        await db('organizations').whereIn('id', orgIds).delete()
+        await db("organizations").whereIn("id", orgIds).delete();
       }
-      await db.destroy()
+      await db.destroy();
     }
-  })
+  });
 
   // Helper to seed a test organization
   async function createOrg(name: string): Promise<string> {
-    const id = crypto.randomUUID()
-    const slug = `org-${id}`
-    await db('organizations').insert({ id, name, slug })
-    orgIds.push(id)
-    return id
+    const id = crypto.randomUUID();
+    const slug = `org-${id}`;
+    await db("organizations").insert({ id, name, slug });
+    orgIds.push(id);
+    return id;
   }
 
   // Helper to seed a test user (for vault creator / verifier)
   async function createUser(email: string): Promise<string> {
-    const id = crypto.randomUUID()
-    await db('users').insert({
+    const id = crypto.randomUUID();
+    await db("users").insert({
       id,
       email,
-      passwordHash: 'dummy-hash',
-      role: 'USER',
-      status: 'ACTIVE',
-    })
-    userIds.push(id)
-    return id
+      passwordHash: "dummy-hash",
+      role: "USER",
+      status: "ACTIVE",
+    });
+    userIds.push(id);
+    return id;
   }
 
   // Helper to seed a test vault
-  async function createVault(orgId: string, creatorId: string): Promise<string> {
-    const id = crypto.randomUUID()
-    await db('vaults').insert({
+  async function createVault(
+    orgId: string,
+    creatorId: string,
+  ): Promise<string> {
+    const id = crypto.randomUUID();
+    await db("vaults").insert({
       id,
       creator_id: creatorId,
-      amount: '1000',
+      amount: "1000",
       start_date: new Date(),
       end_date: new Date(Date.now() + 86400000),
-      verifier: 'dummy-verifier',
-      success_destination: 'destination-a',
-      failure_destination: 'destination-b',
-      status: 'ACTIVE',
+      verifier: "dummy-verifier",
+      success_destination: "destination-a",
+      failure_destination: "destination-b",
+      status: "ACTIVE",
       organization_id: orgId,
-    })
-    vaultIds.push(id)
-    return id
+    });
+    vaultIds.push(id);
+    return id;
   }
 
   // Helper to seed a milestone
   async function createMilestone(
     vaultId: string,
     options: {
-      id?: string
-      title?: string
-      verifierUserId?: string | null
-      deletedAt?: Date | null
+      id?: string;
+      title?: string;
+      verifierUserId?: string | null;
+      deletedAt?: Date | null;
     } = {},
   ): Promise<string> {
-    const id = options.id || crypto.randomUUID()
-    await db('milestones').insert({
+    const id = options.id || crypto.randomUUID();
+    await db("milestones").insert({
       id,
       vault_id: vaultId,
-      title: options.title || 'Milestone Title',
-      description: 'Milestone Description',
+      title: options.title || "Milestone Title",
+      description: "Milestone Description",
       target_amount: 500,
       current_amount: 0,
       deadline: new Date(Date.now() + 86400000),
-      status: 'pending',
+      status: "pending",
       verifier_user_id: options.verifierUserId || null,
       deleted_at: options.deletedAt || null,
-    })
-    milestoneIds.push(id)
-    return id
+    });
+    milestoneIds.push(id);
+    return id;
   }
 
-  describe('Org Scoping', () => {
-    it('should strictly isolate findMany queries to the requested organization', async () => {
-      const orgA = await createOrg('Org A')
-      const orgB = await createOrg('Org B')
-      const creator = await createUser('creator1@test.com')
+  describe("Org Scoping", () => {
+    it("should strictly isolate findMany queries to the requested organization", async () => {
+      const orgA = await createOrg("Org A");
+      const orgB = await createOrg("Org B");
+      const creator = await createUser("creator1@test.com");
 
-      const vaultA = await createVault(orgA, creator)
-      const vaultB = await createVault(orgB, creator)
+      const vaultA = await createVault(orgA, creator);
+      const vaultB = await createVault(orgB, creator);
 
-      const mA = await createMilestone(vaultA, { title: 'Org A Milestone' })
-      const mB = await createMilestone(vaultB, { title: 'Org B Milestone' })
+      const mA = await createMilestone(vaultA, { title: "Org A Milestone" });
+      const mB = await createMilestone(vaultB, { title: "Org B Milestone" });
 
-      const resultsA = await repo.findMany({ orgId: orgA })
-      expect(resultsA).toHaveLength(1)
-      expect(resultsA[0].id).toBe(mA)
+      const resultsA = await repo.findMany({ orgId: orgA });
+      expect(resultsA).toHaveLength(1);
+      expect(resultsA[0].id).toBe(mA);
 
-      const resultsB = await repo.findMany({ orgId: orgB })
-      expect(resultsB).toHaveLength(1)
-      expect(resultsB[0].id).toBe(mB)
-    })
+      const resultsB = await repo.findMany({ orgId: orgB });
+      expect(resultsB).toHaveLength(1);
+      expect(resultsB[0].id).toBe(mB);
+    });
 
-    it('should strictly isolate findById queries to the requested organization', async () => {
-      const orgA = await createOrg('Org A')
-      const orgB = await createOrg('Org B')
-      const creator = await createUser('creator2@test.com')
+    it("should strictly isolate findByIdForOrg queries to the requested organization", async () => {
+      const orgA = await createOrg("Org A");
+      const orgB = await createOrg("Org B");
+      const creator = await createUser("creator2@test.com");
 
-      const vaultA = await createVault(orgA, creator)
-      const mA = await createMilestone(vaultA, { title: 'Org A Milestone' })
+      const vaultA = await createVault(orgA, creator);
+      const mA = await createMilestone(vaultA, { title: "Org A Milestone" });
 
       // Querying mA under Org A should succeed
-      const foundA = await repo.findById(mA, orgA)
-      expect(foundA).not.toBeNull()
-      expect(foundA.id).toBe(mA)
+      const foundA = await repo.findByIdForOrg(mA, orgA);
+      expect(foundA).not.toBeNull();
+      expect(foundA.id).toBe(mA);
 
       // Querying mA under Org B should return null
-      const foundB = await repo.findById(mA, orgB)
-      expect(foundB).toBeNull()
-    })
-  })
+      const foundB = await repo.findByIdForOrg(mA, orgB);
+      expect(foundB).toBeNull();
+    });
+  });
 
-  describe('Soft-Delete Exclusion', () => {
-    it('should exclude soft-deleted milestones by default and include them explicitly', async () => {
-      const org = await createOrg('Soft Delete Org')
-      const creator = await createUser('creator3@test.com')
-      const vault = await createVault(org, creator)
+  describe("Soft-Delete Exclusion", () => {
+    it("should exclude soft-deleted milestones by default and include them explicitly", async () => {
+      const org = await createOrg("Soft Delete Org");
+      const creator = await createUser("creator3@test.com");
+      const vault = await createVault(org, creator);
 
-      const activeId = await createMilestone(vault, { title: 'Active Milestone' })
+      const activeId = await createMilestone(vault, {
+        title: "Active Milestone",
+      });
       const deletedId = await createMilestone(vault, {
-        title: 'Deleted Milestone',
+        title: "Deleted Milestone",
         deletedAt: new Date(),
-      })
+      });
 
       // Default findMany
-      const defaultList = await repo.findMany({ orgId: org })
-      expect(defaultList.map((m) => m.id)).toContain(activeId)
-      expect(defaultList.map((m) => m.id)).not.toContain(deletedId)
+      const defaultList = await repo.findMany({ orgId: org });
+      expect(defaultList.map((m) => m.id)).toContain(activeId);
+      expect(defaultList.map((m) => m.id)).not.toContain(deletedId);
 
       // Explicitly including deleted in findMany
-      const fullList = await repo.findMany({ orgId: org, includeDeleted: true })
-      expect(fullList.map((m) => m.id)).toContain(activeId)
-      expect(fullList.map((m) => m.id)).toContain(deletedId)
+      const fullList = await repo.findMany({
+        orgId: org,
+        includeDeleted: true,
+      });
+      expect(fullList.map((m) => m.id)).toContain(activeId);
+      expect(fullList.map((m) => m.id)).toContain(deletedId);
 
-      // Default findById
-      const foundActive = await repo.findById(activeId, org)
-      expect(foundActive).not.toBeNull()
-      const foundDeletedDefault = await repo.findById(deletedId, org)
-      expect(foundDeletedDefault).toBeNull()
+      // Default findByIdForOrg
+      const foundActive = await repo.findByIdForOrg(activeId, org);
+      expect(foundActive).not.toBeNull();
+      const foundDeletedDefault = await repo.findByIdForOrg(deletedId, org);
+      expect(foundDeletedDefault).toBeNull();
 
-      // Explicitly including deleted in findById
-      const foundDeletedExplicit = await repo.findById(deletedId, org, true)
-      expect(foundDeletedExplicit).not.toBeNull()
-      expect(foundDeletedExplicit.id).toBe(deletedId)
-    })
-  })
+      // Explicitly including deleted in findByIdForOrg
+      const foundDeletedExplicit = await repo.findByIdForOrg(
+        deletedId,
+        org,
+        true,
+      );
+      expect(foundDeletedExplicit).not.toBeNull();
+      expect(foundDeletedExplicit.id).toBe(deletedId);
+    });
+  });
 
-  describe('Verifier-Assignment Filtering', () => {
-    it('should return only milestones assigned to the specified verifier', async () => {
-      const org = await createOrg('Verifier Org')
-      const creator = await createUser('creator4@test.com')
-      const vault = await createVault(org, creator)
+  describe("Verifier-Assignment Filtering", () => {
+    it("should return only milestones assigned to the specified verifier", async () => {
+      const org = await createOrg("Verifier Org");
+      const creator = await createUser("creator4@test.com");
+      const vault = await createVault(org, creator);
 
-      const verifierA = 'verifier-a'
-      const verifierB = 'verifier-b'
+      const verifierA = "verifier-a";
+      const verifierB = "verifier-b";
 
-      const mA = await createMilestone(vault, { verifierUserId: verifierA })
-      const mB = await createMilestone(vault, { verifierUserId: verifierB })
-      const mNone = await createMilestone(vault, { verifierUserId: null })
+      const mA = await createMilestone(vault, { verifierUserId: verifierA });
+      const mB = await createMilestone(vault, { verifierUserId: verifierB });
+      const mNone = await createMilestone(vault, { verifierUserId: null });
 
       // Filter by Verifier A
-      const listA = await repo.findMany({ orgId: org, verifierUserId: verifierA })
-      expect(listA.map((m) => m.id)).toContain(mA)
-      expect(listA.map((m) => m.id)).not.toContain(mB)
-      expect(listA.map((m) => m.id)).not.toContain(mNone)
+      const listA = await repo.findMany({
+        orgId: org,
+        verifierUserId: verifierA,
+      });
+      expect(listA.map((m) => m.id)).toContain(mA);
+      expect(listA.map((m) => m.id)).not.toContain(mB);
+      expect(listA.map((m) => m.id)).not.toContain(mNone);
 
       // Filter by Verifier B
-      const listB = await repo.findMany({ orgId: org, verifierUserId: verifierB })
-      expect(listB.map((m) => m.id)).toContain(mB)
-      expect(listB.map((m) => m.id)).not.toContain(mA)
-      expect(listB.map((m) => m.id)).not.toContain(mNone)
-    })
-  })
+      const listB = await repo.findMany({
+        orgId: org,
+        verifierUserId: verifierB,
+      });
+      expect(listB.map((m) => m.id)).toContain(mB);
+      expect(listB.map((m) => m.id)).not.toContain(mA);
+      expect(listB.map((m) => m.id)).not.toContain(mNone);
+    });
+  });
 
-  describe('Keyset Pagination stability', () => {
-    it('should page through milestones stably and handle concurrent inserts without skipping or duplicating rows', async () => {
-      const org = await createOrg('Pagination Org')
-      const creator = await createUser('creator5@test.com')
-      const vault = await createVault(org, creator)
+  describe("Keyset Pagination stability", () => {
+    it("should page through milestones stably and handle concurrent inserts without skipping or duplicating rows", async () => {
+      const org = await createOrg("Pagination Org");
+      const creator = await createUser("creator5@test.com");
+      const vault = await createVault(org, creator);
 
       // Seed 5 milestones with deterministic IDs (lexicographically ordered)
-      const seededIds = [
-        'ms-01',
-        'ms-03',
-        'ms-05',
-        'ms-07',
-        'ms-09',
-      ]
+      const seededIds = ["ms-01", "ms-03", "ms-05", "ms-07", "ms-09"];
       for (const id of seededIds) {
-        await createMilestone(vault, { id, title: `Seeded ${id}` })
+        await createMilestone(vault, { id, title: `Seeded ${id}` });
       }
 
       // We will page with limit = 2
       // Page 1 should return ms-01, ms-03
-      const page1 = await repo.findMany({ orgId: org, limit: 2 })
-      expect(page1).toHaveLength(2)
-      expect(page1[0].id).toBe('ms-01')
-      expect(page1[1].id).toBe('ms-03')
+      const page1 = await repo.findMany({ orgId: org, limit: 2 });
+      expect(page1).toHaveLength(2);
+      expect(page1[0].id).toBe("ms-01");
+      expect(page1[1].id).toBe("ms-03");
 
       // Simulate a concurrent insert of 'ms-02' (inserted between ms-01 and ms-03, i.e. already passed page 1's cursor)
       // and 'ms-06' (inserted between ms-05 and ms-07, i.e. ahead of the next page cursor)
-      await createMilestone(vault, { id: 'ms-02', title: 'Concurrent ms-02' })
-      await createMilestone(vault, { id: 'ms-06', title: 'Concurrent ms-06' })
+      await createMilestone(vault, { id: "ms-02", title: "Concurrent ms-02" });
+      await createMilestone(vault, { id: "ms-06", title: "Concurrent ms-06" });
 
       // Page 2: we pass afterId = 'ms-03' (last item from Page 1)
       // With keyset pagination: where id > 'ms-03'.
       // This should fetch 'ms-05', 'ms-06' (since ms-06 is > ms-03 and < ms-07)
-      const page2 = await repo.findMany({ orgId: org, afterId: 'ms-03', limit: 2 })
-      expect(page2).toHaveLength(2)
-      expect(page2[0].id).toBe('ms-05')
-      expect(page2[1].id).toBe('ms-06')
+      const page2 = await repo.findMany({
+        orgId: org,
+        afterId: "ms-03",
+        limit: 2,
+      });
+      expect(page2).toHaveLength(2);
+      expect(page2[0].id).toBe("ms-05");
+      expect(page2[1].id).toBe("ms-06");
 
       // Page 3: we pass afterId = 'ms-06'
       // This should fetch 'ms-07', 'ms-09'
-      const page3 = await repo.findMany({ orgId: org, afterId: 'ms-06', limit: 2 })
-      expect(page3).toHaveLength(2)
-      expect(page3[0].id).toBe('ms-07')
-      expect(page3[1].id).toBe('ms-09')
+      const page3 = await repo.findMany({
+        orgId: org,
+        afterId: "ms-06",
+        limit: 2,
+      });
+      expect(page3).toHaveLength(2);
+      expect(page3[0].id).toBe("ms-07");
+      expect(page3[1].id).toBe("ms-09");
 
       // Assert all queried items across the pages:
       // Page 1: ms-01, ms-03
@@ -268,10 +288,10 @@ describeWithDb('MilestoneRepository - Query Behaviour Matrix', () => {
       // Notice that 'ms-02' was skipped because it was inserted *behind* the cursor (after ms-01 was read and cursor moved to ms-03).
       // This is the expected and correct behavior of keyset pagination: it guarantees no duplicate rows
       // are served, and new items ahead of the cursor are successfully included without disrupting the page offsets.
-      const allFetchedIds = [...page1, ...page2, ...page3].map((m) => m.id)
-      const uniqueFetchedIds = Array.from(new Set(allFetchedIds))
+      const allFetchedIds = [...page1, ...page2, ...page3].map((m) => m.id);
+      const uniqueFetchedIds = Array.from(new Set(allFetchedIds));
 
-      expect(allFetchedIds).toHaveLength(uniqueFetchedIds.length) // No duplicates!
-    })
-  })
-})
+      expect(allFetchedIds).toHaveLength(uniqueFetchedIds.length); // No duplicates!
+    });
+  });
+});


### PR DESCRIPTION
Close: #982


## Summary of the Fix
We fixed the duplicate findById method in src/repositories/milestoneRepository.ts :

1. **Renamed the org‑scoped findById method to findByIdForOrg
2. Updated all the calls to this method in `src/tests/milestoneRepository.queries.test.ts
3. Verified there were no other callsites in the codebase!
4. Ran the build and confirmed there were no errors related to what we changed!