### PR TITLE
atomically upsert user preferences with ON CONFLICT

### DIFF
--- a/src/services/userNotificationPreferences.service.ts
+++ b/src/services/userNotificationPreferences.service.ts
@@ -98,43 +98,35 @@ export async function upsertUserPreferences(
     throw new Error(`Invalid quiet_hours_end format: ${input.quiet_hours_end}. Expected HH:MM.`)
   }
 
-  const now = new Date().toISOString()
-  const existing = await db(TABLE).where('user_id', userId).first()
+  const defaults = getDefaultPreferences(userId)
 
-  if (existing) {
-    // Update existing preferences
-    const updateData: Record<string, unknown> = { updated_at: now }
-
-    if (input.timezone !== undefined) updateData.timezone = input.timezone
-    if (input.quiet_hours_enabled !== undefined) updateData.quiet_hours_enabled = input.quiet_hours_enabled
-    if (input.quiet_hours_start !== undefined) updateData.quiet_hours_start = input.quiet_hours_start
-    if (input.quiet_hours_end !== undefined) updateData.quiet_hours_end = input.quiet_hours_end
-
-    await db(TABLE)
-      .where('user_id', userId)
-      .update(updateData)
-
-    const updated = await db(TABLE).where('user_id', userId).first()
-    return mapRowToPreferences(updated)
-  } else {
-    // Insert new preferences
-    const defaults = getDefaultPreferences(userId)
-    const insertData = {
-      user_id: userId,
-      timezone: input.timezone ?? defaults.timezone,
-      quiet_hours_enabled: input.quiet_hours_enabled ?? defaults.quiet_hours_enabled,
-      quiet_hours_start: input.quiet_hours_start ?? defaults.quiet_hours_start,
-      quiet_hours_end: input.quiet_hours_end ?? defaults.quiet_hours_end,
-      created_at: now,
-      updated_at: now,
-    }
-
-    const [inserted] = await db(TABLE)
-      .insert(insertData)
-      .returning('*')
-
-    return mapRowToPreferences(inserted)
+  // Build the insert data with defaults for missing fields
+  const insertData = {
+    user_id: userId,
+    timezone: input.timezone ?? defaults.timezone,
+    quiet_hours_enabled: input.quiet_hours_enabled ?? defaults.quiet_hours_enabled,
+    quiet_hours_start: input.quiet_hours_start ?? defaults.quiet_hours_start,
+    quiet_hours_end: input.quiet_hours_end ?? defaults.quiet_hours_end,
+    created_at: db.fn.now(),
+    updated_at: db.fn.now(),
   }
+
+  // Build the merge data (only includes fields that might be updated)
+  const mergeData: Record<string, unknown> = {
+    updated_at: db.fn.now(),
+  }
+  if (input.timezone !== undefined) mergeData.timezone = input.timezone
+  if (input.quiet_hours_enabled !== undefined) mergeData.quiet_hours_enabled = input.quiet_hours_enabled
+  if (input.quiet_hours_start !== undefined) mergeData.quiet_hours_start = input.quiet_hours_start
+  if (input.quiet_hours_end !== undefined) mergeData.quiet_hours_end = input.quiet_hours_end
+
+  const [result] = await db(TABLE)
+    .insert(insertData)
+    .onConflict('user_id')
+    .merge(mergeData)
+    .returning('*')
+
+  return mapRowToPreferences(result)
 }
 
 /**


### PR DESCRIPTION
This update refactors the user notification preferences persistence layer to eliminate race conditions during concurrent requests by replacing the previous check-then-act workflow with a single atomic database operation.

The upsertUserPreferences service was reworked to leverage PostgreSQL's native INSERT ... ON CONFLICT DO UPDATE semantics through Knex's .onConflict('user_id').merge() API. This removes the need for an initial existence check followed by separate insert/update branches, ensuring that all preference writes are handled safely within a single database statement.

By moving conflict resolution into the database engine, the implementation prevents duplicate inserts and unique constraint violations that could occur when multiple requests attempted to create preferences for the same user simultaneously. The refactor also simplifies the service by consolidating insert and update logic into a unified, easier-to-maintain code path.

Timestamp handling was preserved by setting both created_at and updated_at on initial inserts while updating only updated_at during conflict resolution. The service continues to return the persisted preference record after each operation, maintaining compatibility with existing callers.

Highlights
Replaced the non-atomic SELECT → INSERT/UPDATE flow with a single atomic PostgreSQL UPSERT.
Implemented Knex's .onConflict('user_id').merge() pattern for database-level conflict handling.
Eliminated race conditions during concurrent updates to user notification preferences.
Prevented duplicate records and unique constraint violations under high concurrency.
Preserved correct created_at and updated_at timestamp behavior.
Simplified the service by removing conditional branching and redundant database queries.
Aligned the implementation with the existing organization notification preferences upsert pattern for consistency across the codebase.
Improved reliability, maintainability, and transactional safety without changing the service's external behavior.

Closes #1119 