### PR TITLE
Delete src/lib/database.ts  Fixes #1101

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,3 +1,0 @@
-import { PrismaClient } from '@prisma/client';
-
-export const prisma = new PrismaClient();


### PR DESCRIPTION
What

Deletes src/lib/database.ts.

Why

src/lib/prisma.ts correctly caches its PrismaClient on globalThis in development to avoid exhausting database connections during hot-reload. src/lib/database.ts duplicated this pattern but incorrectly — it instantiates PrismaClient directly with no caching and no dev/production distinction, meaning every hot-reload would spin up a fresh connection.

A repo-wide search confirms nothing in src/ imports from lib/database.ts — it's dead code. However, its presence alone is a hazard: a future contributor searching for "the prisma client" could easily grab this uncached duplicate instead of the real lib/prisma.ts singleton, silently reintroducing the connection-exhaustion bug that lib/prisma.ts was written to prevent.

Verification
Confirmed no imports of lib/database anywhere in src/ via repo-wide search.
No other files reference this module; deletion has no functional impact.

Fixes #1101