### PR TITLE
Fix check-then-act race in removeMembership/changeRole

### DIFF
--- a/src/services/membership.ts
+++ b/src/services/membership.ts
@@ -1,3 +1,4 @@
+import type { Knex } from 'knex'
 import db from '../db/index.js'
 import { createAuditLog } from '../lib/audit-logs.js'
 import type { Membership, CreateMembershipInput } from '../types/enterprise.js'
@@ -144,23 +145,31 @@ export const getUserTeamRole = async (
 
 // ─── Admin Count ──────────────────────────────────────────────────────────────
 
-export const countOrgAdmins = async (orgId: string): Promise<number> => {
-  const result = await db('memberships')
+export const countOrgAdmins = async (
+  orgId: string,
+  queryBuilder: Knex | Knex.Transaction = db,
+): Promise<number> => {
+  // Aggregates can't be combined with a locking clause in Postgres, so the
+  // matching rows are locked and counted in JS instead of via count(*).
+  const rows = await queryBuilder('memberships')
     .where({ organization_id: orgId, team_id: null })
     .whereIn('role', ['owner', 'admin'])
-    .count('* as count')
-    .first()
+    .forUpdate()
+    .select('id')
 
-  return Number(result?.count ?? 0)
+  return rows.length
 }
 
-export const countOrgOwners = async (orgId: string): Promise<number> => {
-  const result = await db('memberships')
+export const countOrgOwners = async (
+  orgId: string,
+  queryBuilder: Knex | Knex.Transaction = db,
+): Promise<number> => {
+  const rows = await queryBuilder('memberships')
     .where({ organization_id: orgId, team_id: null, role: 'owner' })
-    .count('* as count')
-    .first()
+    .forUpdate()
+    .select('id')
 
-  return Number(result?.count ?? 0)
+  return rows.length
 }
 
 // ─── Delete ───────────────────────────────────────────────────────────────────
@@ -169,39 +178,42 @@ export const removeMembership = async (
   userId: string,
   orgId: string,
 ): Promise<void> => {
-  const membership = await db('memberships')
-    .where({
-      user_id: userId,
-      organization_id: orgId,
-      team_id: null,
-    })
-    .first()
+  await db.transaction(async (trx) => {
+    const membership = await trx('memberships')
+      .where({
+        user_id: userId,
+        organization_id: orgId,
+        team_id: null,
+      })
+      .forUpdate()
+      .first()
 
-  if (!membership) {
-    throw new Error('Membership not found.')
-  }
-
-  if (membership.role === 'owner') {
-    const ownerCount = await countOrgOwners(orgId)
-    if (ownerCount <= 1) {
-      throw new Error('Cannot remove the last owner of an organization.')
+    if (!membership) {
+      throw new Error('Membership not found.')
     }
-  }
-  
-  if (isAdminRole(membership.role)) {
-    const adminCount = await countOrgAdmins(orgId)
-    if (adminCount <= 1) {
-      throw new LastAdminError()
-    }
-  }
 
-  await db('memberships')
-    .where({
-      user_id: userId,
-      organization_id: orgId,
-      team_id: null,
-    })
-    .delete()
+    if (membership.role === 'owner') {
+      const ownerCount = await countOrgOwners(orgId, trx)
+      if (ownerCount <= 1) {
+        throw new Error('Cannot remove the last owner of an organization.')
+      }
+    }
+
+    if (isAdminRole(membership.role)) {
+      const adminCount = await countOrgAdmins(orgId, trx)
+      if (adminCount <= 1) {
+        throw new LastAdminError()
+      }
+    }
+
+    await trx('memberships')
+      .where({
+        user_id: userId,
+        organization_id: orgId,
+        team_id: null,
+      })
+      .delete()
+  })
 }
 
 // ─── Update ───────────────────────────────────────────────────────────────────
@@ -212,54 +224,57 @@ export const changeRole = async (
   newRole: string,
   actorUserId: string,
 ): Promise<Membership> => {
-  const membership = await db('memberships')
-    .where({
-      user_id: userId,
-      organization_id: orgId,
-      team_id: null,
-    })
-    .first()
+  return db.transaction(async (trx) => {
+    const membership = await trx('memberships')
+      .where({
+        user_id: userId,
+        organization_id: orgId,
+        team_id: null,
+      })
+      .forUpdate()
+      .first()
 
-  if (!membership) {
-    throw new Error('Membership not found.')
-  }
-
-  const oldRole = membership.role
-  if (oldRole === newRole) {
-    return membership
-  }
-
-  if (oldRole === 'owner') {
-    const ownerCount = await countOrgOwners(orgId)
-    if (ownerCount <= 1) {
-      throw new Error('Cannot demote the last owner of an organization.')
+    if (!membership) {
+      throw new Error('Membership not found.')
     }
-  } else if (isAdminRole(oldRole) && !isAdminRole(newRole)) {
-    const adminCount = await countOrgAdmins(orgId)
-    if (adminCount <= 1) {
-      throw new LastAdminError()
+
+    const oldRole = membership.role
+    if (oldRole === newRole) {
+      return membership
     }
-  }
 
-  const [updated] = await db('memberships')
-    .where({
-      user_id: userId,
+    if (oldRole === 'owner') {
+      const ownerCount = await countOrgOwners(orgId, trx)
+      if (ownerCount <= 1) {
+        throw new Error('Cannot demote the last owner of an organization.')
+      }
+    } else if (isAdminRole(oldRole) && !isAdminRole(newRole)) {
+      const adminCount = await countOrgAdmins(orgId, trx)
+      if (adminCount <= 1) {
+        throw new LastAdminError()
+      }
+    }
+
+    const [updated] = await trx('memberships')
+      .where({
+        user_id: userId,
+        organization_id: orgId,
+        team_id: null,
+      })
+      .update({ role: newRole })
+      .returning('*')
+
+    await createAuditLog({
+      actor_user_id: actorUserId,
       organization_id: orgId,
-      team_id: null,
+      action: 'org.member.role_changed',
+      target_type: 'org_membership',
+      target_id: `${orgId}:${userId}`,
+      metadata: { org_id: orgId, old_role: oldRole, new_role: newRole },
     })
-    .update({ role: newRole })
-    .returning('*')
 
-  await createAuditLog({
-    actor_user_id: actorUserId,
-    organization_id: orgId,
-    action: 'org.member.role_changed',
-    target_type: 'org_membership',
-    target_id: `${orgId}:${userId}`,
-    metadata: { org_id: orgId, old_role: oldRole, new_role: newRole },
+    return updated
   })
-
-  return updated
 }
 
 // ─── Invitations ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Wrap both functions in db.transaction() with FOR UPDATE row locks on the membership and owner/admin count queries, mirroring transferOwnership. Prevents two concurrent requests from each reading a stale "2 admins remain" count and both proceeding, which could strip an org of all admins/owners despite the LastAdminError guard.

Closes #1076