### PR TITLE
Refactor organization and team role middleware for improved error han…

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,237 +1,301 @@
-import { Request, Response, NextFunction } from 'express'
-import crypto from 'crypto'
-import jwt from 'jsonwebtoken'
-import { randomUUID } from 'node:crypto'
-import { recordSession, validateSession } from '../services/session.js'
-import { UserRole } from '../types/user.js'
-import { verifyAccessToken } from '../lib/auth-utils.js'
-import { config } from '../config/index.js'
+import { Request, Response, NextFunction } from "express";
+import crypto from "crypto";
+import jwt from "jsonwebtoken";
+import { randomUUID } from "node:crypto";
+import { recordSession, validateSession } from "../services/session.js";
+import { UserRole } from "../types/user.js";
+import { verifyAccessToken } from "../lib/auth-utils.js";
+import { config } from "../config/index.js";
 
-import { JWTPayload } from '../types/auth.js'
+import { JWTPayload } from "../types/auth.js";
 
-export type Role = 'user' | 'verifier' | 'admin'
+export type Role = "user" | "verifier" | "admin";
 
 // Use JWTPayload from types/auth.ts as source of truth, adding jti for sessions
-export type JwtPayload = JWTPayload & { jti?: string }
+export type JwtPayload = JWTPayload & { jti?: string };
 
-const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production'
+const JWT_SECRET = process.env.JWT_SECRET ?? "change-me-in-production";
 
-const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
-export function csrfProtection(req: Request, res: Response, next: NextFunction): void {
+export function csrfProtection(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
   if (SAFE_METHODS.has(req.method)) {
-    next()
-    return
+    next();
+    return;
   }
 
-  const authHeader = req.headers.authorization
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    next()
-    return
+  const authHeader = req.headers.authorization;
+  if (authHeader && authHeader.startsWith("Bearer ")) {
+    next();
+    return;
   }
 
-  const origin = req.headers.origin as string | undefined
-  const referer = req.headers.referer as string | undefined
+  const origin = req.headers.origin as string | undefined;
+  const referer = req.headers.referer as string | undefined;
 
   if (!origin && !referer) {
-    next()
-    return
+    next();
+    return;
   }
 
-  const allowedOrigins = config.corsOrigins
+  const allowedOrigins = config.corsOrigins;
 
   if (origin) {
-    if (allowedOrigins === '*') {
-      next()
-      return
+    if (allowedOrigins === "*") {
+      next();
+      return;
     }
     if (Array.isArray(allowedOrigins) && allowedOrigins.includes(origin)) {
-      next()
-      return
+      next();
+      return;
     }
   }
 
   if (!origin && referer) {
     try {
-      const refererUrl = new URL(referer)
-      const refererOrigin = `${refererUrl.protocol}//${refererUrl.host}`
-      if (allowedOrigins === '*') {
-        next()
-        return
+      const refererUrl = new URL(referer);
+      const refererOrigin = `${refererUrl.protocol}//${refererUrl.host}`;
+      if (allowedOrigins === "*") {
+        next();
+        return;
       }
-      if (Array.isArray(allowedOrigins) && allowedOrigins.includes(refererOrigin)) {
-        next()
-        return
+      if (
+        Array.isArray(allowedOrigins) &&
+        allowedOrigins.includes(refererOrigin)
+      ) {
+        next();
+        return;
       }
     } catch {
-      res.status(403).json({ error: 'Forbidden' })
-      return
+      res.status(403).json({ error: "Forbidden" });
+      return;
     }
   }
 
-  res.status(403).json({ error: 'Forbidden' })
+  res.status(403).json({ error: "Forbidden" });
 }
 
-export async function authenticate(req: Request, res: Response, next: NextFunction): Promise<void> {
-     const authHeader = req.headers.authorization
+export async function authenticate(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  const authHeader = req.headers.authorization;
 
-     if (!authHeader || !authHeader.startsWith('Bearer ')) {
-          res.status(401).json({ error: 'Unauthorized: Missing or malformed Authorization header' })
-          return
-     }
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res
+      .status(401)
+      .json({
+        error: "Unauthorized: Missing or malformed Authorization header",
+      });
+    return;
+  }
 
-     const token = authHeader.slice(7)
+  const token = authHeader.slice(7);
 
-     try {
-          // First try verifyAccessToken from lib/auth-utils.ts (which uses JWT_ACCESS_SECRET)
-          let payload: JwtPayload
-          try {
-               payload = verifyAccessToken(token) as JwtPayload
-          } catch {
-               // Fallback to legacy JWT_SECRET for backward compatibility
-               payload = jwt.verify(token, JWT_SECRET) as JwtPayload
-          }
+  try {
+    // First try verifyAccessToken from lib/auth-utils.ts (which uses JWT_ACCESS_SECRET)
+    let payload: JwtPayload;
+    try {
+      payload = verifyAccessToken(token) as JwtPayload;
+    } catch {
+      // Fallback to legacy JWT_SECRET for backward compatibility
+      payload = jwt.verify(token, JWT_SECRET) as JwtPayload;
+    }
 
-          // Reject tokens with iat too far in the future (beyond clock tolerance)
-          const iat = (payload as any).iat as number | undefined
-          if (iat && iat > Math.floor(Date.now() / 1000) + 30) {
-               res.status(401).json({ error: 'Unauthorized: Invalid token' })
-               return
-          }
+    // Reject tokens with iat too far in the future (beyond clock tolerance)
+    const iat = (payload as any).iat as number | undefined;
+    if (iat && iat > Math.floor(Date.now() / 1000) + 30) {
+      res.status(401).json({ error: "Unauthorized: Invalid token" });
+      return;
+    }
 
-          if (payload.jti) {
-               const isValid = await validateSession(payload.jti)
+    if (payload.jti) {
+      const isValid = await validateSession(payload.jti);
 
-               if (!isValid) {
-                    res.status(401).json({ error: 'Unauthorized: Session revoked or expired' })
-                    return
-               }
-          }
+      if (!isValid) {
+        res
+          .status(401)
+          .json({ error: "Unauthorized: Session revoked or expired" });
+        return;
+      }
+    }
 
-          req.user = payload
-          next()
-     } catch (err) {
-          if (err instanceof jwt.TokenExpiredError) {
-               res.status(401).json({ error: 'Unauthorized: Token expired' })
-          } else {
-               res.status(401).json({ error: 'Unauthorized: Invalid token' })
-          }
-     }
+    req.user = payload;
+    next();
+  } catch (err) {
+    if (err instanceof jwt.TokenExpiredError) {
+      res.status(401).json({ error: "Unauthorized: Token expired" });
+    } else {
+      res.status(401).json({ error: "Unauthorized: Invalid token" });
+    }
+  }
 }
 
-export async function signToken(payload: Omit<JwtPayload, 'jti'>, expiresIn = '1h'): Promise<string> {
-     const jti = randomUUID()
-     const fullPayload = { ...payload, jti }
-     
-     // Calculate expiration date
-     // Default matches 1h (1 hour)
-     const durationMs = 60 * 60 * 1000 
-     const expiresAt = new Date(Date.now() + durationMs)
-     
-     await recordSession(payload.userId, jti, expiresAt)
-     
-     return jwt.sign(fullPayload, JWT_SECRET, { expiresIn } as jwt.SignOptions)
+export async function signToken(
+  payload: Omit<JwtPayload, "jti">,
+  expiresIn = "1h",
+): Promise<string> {
+  const jti = randomUUID();
+  const fullPayload = { ...payload, jti };
+
+  // Calculate expiration date
+  // Default matches 1h (1 hour)
+  const durationMs = 60 * 60 * 1000;
+  const expiresAt = new Date(Date.now() + durationMs);
+
+  await recordSession(payload.userId, jti, expiresAt);
+
+  return jwt.sign(fullPayload, JWT_SECRET, { expiresIn } as jwt.SignOptions);
 }
 
 export interface AuthenticatedRequest extends Request {
-    user?: JwtPayload
+  user?: JwtPayload;
+}
+
+export function getAuthenticatedUserId(req: Request): string | null {
+  const candidates = [
+    (req as any).user?.userId,
+    (req as any).user?.sub,
+    (req as any).authUser?.userId,
+    (req as any).authUser?.sub,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") {
+      const trimmed = candidate.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  }
+
+  return null;
 }
 
 export function requireAdmin(
-    req: AuthenticatedRequest,
-    res: Response,
-    next: NextFunction,
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
 ): void {
-    if (!req.user) {
-        res.status(401).json({ error: 'Unauthorized: Authentication required' })
-        return
-    }
-    // Block impersonation tokens from accessing admin endpoints
-    if (req.user.impersonator) {
-        res.status(403).json({ error: 'Forbidden: Impersonation tokens cannot access admin endpoints' })
-        return
-    }
-    if (req.user.role !== 'ADMIN') {
-        res.status(403).json({ error: 'Forbidden: Admin role required' })
-        return
-    }
-    next()
+  if (!req.user) {
+    res.status(401).json({ error: "Unauthorized: Authentication required" });
+    return;
+  }
+  // Block impersonation tokens from accessing admin endpoints
+  if (req.user.impersonator) {
+    res
+      .status(403)
+      .json({
+        error: "Forbidden: Impersonation tokens cannot access admin endpoints",
+      });
+    return;
+  }
+  if (req.user.role !== "ADMIN") {
+    res.status(403).json({ error: "Forbidden: Admin role required" });
+    return;
+  }
+  next();
 }
 
 export function authorize(allowedRoles: UserRole[]) {
-    return (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
-        if (!req.user) {
-            res.status(401).json({ error: 'Unauthenticated' })
-            return
-        }
-
-        if (!allowedRoles.includes(req.user.role as UserRole)) {
-            res.status(403).json({
-                error: `Forbidden: requires role ${allowedRoles.join(' or ')}, got '${req.user.role}'`,
-            })
-            return
-        }
-
-        next()
+  return (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ): void => {
+    if (!req.user) {
+      res.status(401).json({ error: "Unauthenticated" });
+      return;
     }
+
+    if (!allowedRoles.includes(req.user.role as UserRole)) {
+      res.status(403).json({
+        error: `Forbidden: requires role ${allowedRoles.join(" or ")}, got '${req.user.role}'`,
+      });
+      return;
+    }
+
+    next();
+  };
 }
 
 /** Generate a time-limited, HMAC-signed download token */
-const DOWNLOAD_SECRET = process.env.DOWNLOAD_SECRET ?? 'change-me-in-production'
+const DOWNLOAD_SECRET =
+  process.env.DOWNLOAD_SECRET ?? "change-me-in-production";
 
-export function signDownloadToken(jobId: string, userId: string, ttlSeconds = 3600): string {
-    const exp = Math.floor(Date.now() / 1000) + ttlSeconds
-    const payload = `${jobId}:${userId}:${exp}`
-    const sig = crypto.createHmac('sha256', DOWNLOAD_SECRET).update(payload).digest('hex')
-    return Buffer.from(JSON.stringify({ jobId, userId, exp, sig })).toString('base64url')
+export function signDownloadToken(
+  jobId: string,
+  userId: string,
+  ttlSeconds = 3600,
+): string {
+  const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const payload = `${jobId}:${userId}:${exp}`;
+  const sig = crypto
+    .createHmac("sha256", DOWNLOAD_SECRET)
+    .update(payload)
+    .digest("hex");
+  return Buffer.from(JSON.stringify({ jobId, userId, exp, sig })).toString(
+    "base64url",
+  );
 }
 
 export function verifyDownloadToken(
-    token: string,
+  token: string,
 ): { jobId: string; userId: string } | null {
-    try {
-        const { jobId, userId, exp, sig } = JSON.parse(
-            Buffer.from(token, 'base64url').toString(),
-        ) as { jobId: string; userId: string; exp: number; sig: string }
+  try {
+    const { jobId, userId, exp, sig } = JSON.parse(
+      Buffer.from(token, "base64url").toString(),
+    ) as { jobId: string; userId: string; exp: number; sig: string };
 
-        if (Date.now() / 1000 > exp) return null
+    if (Date.now() / 1000 > exp) return null;
 
-        const expected = crypto
-            .createHmac('sha256', DOWNLOAD_SECRET)
-            .update(`${jobId}:${userId}:${exp}`)
-            .digest('hex')
+    const expected = crypto
+      .createHmac("sha256", DOWNLOAD_SECRET)
+      .update(`${jobId}:${userId}:${exp}`)
+      .digest("hex");
 
-        if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) return null
+    if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected)))
+      return null;
 
-        return { jobId, userId }
-    } catch {
-        return null
-    }
+    return { jobId, userId };
+  } catch {
+    return null;
+  }
 }
 /**
  * @deprecated Use standard `authenticate` instead. Legacy mock auth for early dev. Tracking removal in #454
  */
-export const requireUserAuth = (req: Request, res: Response, next: NextFunction): void => {
-    const headerUserId = req.header('x-user-id')?.trim()
-    let bearerUserId = null
-    const authHeader = req.header('authorization')
-    if (authHeader) {
-        const match = /^Bearer\s+(.+)$/i.exec(authHeader)
-        if (match) {
-            const token = match[1].trim()
-            bearerUserId = token.startsWith('user:') ? token.slice(5) : token
-        }
+export const requireUserAuth = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  const headerUserId = req.header("x-user-id")?.trim();
+  let bearerUserId = null;
+  const authHeader = req.header("authorization");
+  if (authHeader) {
+    const match = /^Bearer\s+(.+)$/i.exec(authHeader);
+    if (match) {
+      const token = match[1].trim();
+      bearerUserId = token.startsWith("user:") ? token.slice(5) : token;
     }
-    const userId = headerUserId || bearerUserId
-    
-    if (!userId) {
-        res.status(401).json({
-            error: 'Authentication required. Provide x-user-id header or Authorization: Bearer user:<user-id>.',
-        })
-        return
-    }
-    
-    // @ts-ignore - Preserving legacy property assignment
-    req.authUser = { userId }
-    next()
-}
+  }
+  const userId = headerUserId || bearerUserId;
+
+  if (!userId) {
+    res.status(401).json({
+      error:
+        "Authentication required. Provide x-user-id header or Authorization: Bearer user:<user-id>.",
+    });
+    return;
+  }
+
+  // @ts-ignore - Preserving legacy property assignment
+  req.authUser = { userId };
+  next();
+};

--- a/src/middleware/orgAuth.ts
+++ b/src/middleware/orgAuth.ts
@@ -1,14 +1,14 @@
-import { Request, Response, NextFunction } from 'express'
-import { AuthenticatedRequest } from './auth.js'
-import { AppError } from './errorHandler.js'
+import { Request, Response, NextFunction } from "express";
+import { AuthenticatedRequest, getAuthenticatedUserId } from "./auth.js";
+import { AppError } from "./errorHandler.js";
 import {
   getOrganization,
   getMemberRole as lookupMemberRole,
-} from '../models/organizations.js'
-import type { OrgRole } from '../models/organizations.js'
-import db from '../db/index.js'
+} from "../models/organizations.js";
+import type { OrgRole } from "../models/organizations.js";
+import db from "../db/index.js";
 
-export type { OrgRole } from '../models/organizations.js'
+export type { OrgRole } from "../models/organizations.js";
 
 /**
  * In-memory org access middleware (used by orgVaults routes).
@@ -16,84 +16,114 @@ export type { OrgRole } from '../models/organizations.js'
  */
 export function requireOrgAccess(...allowedRoles: (OrgRole | string)[]) {
   return (req: AuthenticatedRequest, _res: Response, next: NextFunction) => {
-    const orgId = req.params.orgId || (req.query.orgId as string)
-    const userId = req.user?.userId || (req.user as any)?.sub || (req as any).authUser?.userId
+    const orgId = req.params.orgId || (req.query.orgId as string);
+    const userId = getAuthenticatedUserId(req);
 
     if (!orgId || !userId) {
-      next(AppError.unauthorized('Auth/Org info missing'))
-      return
+      next(AppError.unauthorized("Auth/Org info missing"));
+      return;
     }
 
-    const org = getOrganization(orgId)
+    const org = getOrganization(orgId);
     if (!org) {
-      next(AppError.notFound('Organization not found'))
-      return
+      next(AppError.notFound("Organization not found"));
+      return;
     }
-    ;(req as any).orgId = orgId
+    (req as any).orgId = orgId;
 
-    const role = lookupMemberRole(orgId, userId)
+    const role = lookupMemberRole(orgId, userId);
     if (!role) {
-      next(AppError.forbidden('Forbidden: not a member of this organization'))
-      return
+      next(AppError.forbidden("Forbidden: not a member of this organization"));
+      return;
     }
 
     if (!allowedRoles.includes(role)) {
-      next(AppError.forbidden(`Forbidden: requires role ${allowedRoles.join(' or ')}`))
-      return
+      next(
+        AppError.forbidden(
+          `Forbidden: requires role ${allowedRoles.join(" or ")}`,
+        ),
+      );
+      return;
     }
 
-    next()
-  }
+    next();
+  };
 }
 
 /**
  * DB-based org role middleware (used by enterprise routes).
  */
 export const requireOrgRole = (roles: (OrgRole | string)[]) => {
-  return async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-    const orgId = req.params.orgId || (req.query.orgId as string)
-    const userId = req.user?.userId || (req.user as any)?.sub
+  return async (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const orgId = req.params.orgId || (req.query.orgId as string);
+    const userId = req.user?.userId || (req.user as any)?.sub;
 
     if (!orgId || !userId) {
-      res.status(401).json({ error: 'Auth/Org info missing' })
-      return
+      res.status(401).json({ error: "Auth/Org info missing" });
+      return;
     }
 
     try {
-      const membership = await db('org_members').where({ org_id: orgId, user_id: userId }).first()
+      const membership = await db("org_members")
+        .where({ org_id: orgId, user_id: userId })
+        .first();
       if (!membership || !roles.includes(membership.role)) {
-        res.status(403).json({ error: `Forbidden: requires organization role ${roles.join(' or ')}` })
-        return
+        res
+          .status(403)
+          .json({
+            error: `Forbidden: requires organization role ${roles.join(" or ")}`,
+          });
+        return;
       }
-      next()
+      next();
     } catch {
-      res.status(403).json({ error: `Forbidden: requires organization role ${roles.join(' or ')}` })
+      res
+        .status(403)
+        .json({
+          error: `Forbidden: requires organization role ${roles.join(" or ")}`,
+        });
     }
-  }
-}
+  };
+};
 
 /**
  * DB-based team role middleware (used by enterprise routes).
  */
 export const requireTeamRole = (roles: (OrgRole | string)[]) => {
-  return async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-    const teamId = req.params.teamId || (req.query.teamId as string)
-    const userId = req.user?.userId || (req.user as any)?.sub
+  return async (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const teamId = req.params.teamId || (req.query.teamId as string);
+    const userId = req.user?.userId || (req.user as any)?.sub;
 
     if (!teamId || !userId) {
-      res.status(401).json({ error: 'Auth/Team info missing' })
-      return
+      res.status(401).json({ error: "Auth/Team info missing" });
+      return;
     }
 
     try {
-      const membership = await db('team_members').where({ team_id: teamId, user_id: userId }).first()
+      const membership = await db("team_members")
+        .where({ team_id: teamId, user_id: userId })
+        .first();
       if (!membership || !roles.includes(membership.role)) {
-        res.status(403).json({ error: `Forbidden: requires team role ${roles.join(' or ')}` })
-        return
+        res
+          .status(403)
+          .json({
+            error: `Forbidden: requires team role ${roles.join(" or ")}`,
+          });
+        return;
       }
-      next()
+      next();
     } catch {
-      res.status(403).json({ error: `Forbidden: requires team role ${roles.join(' or ')}` })
+      res
+        .status(403)
+        .json({ error: `Forbidden: requires team role ${roles.join(" or ")}` });
     }
-  }
-}
+  };
+};

--- a/src/routes/orgVaults.ts
+++ b/src/routes/orgVaults.ts
@@ -1,172 +1,210 @@
-import { orgReadRateLimiter, orgWriteRateLimiter } from '../middleware/rateLimiter.js'
-import { Router, Request, Response } from 'express'
-import { authenticate } from '../middleware/auth.js'
-import { requireOrgAccess } from '../middleware/orgAuth.js'
-import { queryParser } from '../middleware/queryParser.js'
-import { applyFilters, applySort, paginateArray, encodeCursor, decodeCursor } from '../utils/pagination.js'
-import { vaults } from './vaults.js'
-import db from '../db/index.js'
-import type { Knex } from 'knex'
-import { createHash } from 'node:crypto'
+import {
+  orgReadRateLimiter,
+  orgWriteRateLimiter,
+} from "../middleware/rateLimiter.js";
+import { Router, Request, Response, NextFunction } from "express";
+import { authenticate, getAuthenticatedUserId } from "../middleware/auth.js";
+import { requireOrgAccess } from "../middleware/orgAuth.js";
+import { AppError } from "../middleware/errorHandler.js";
+import { queryParser } from "../middleware/queryParser.js";
+import {
+  applyFilters,
+  applySort,
+  paginateArray,
+  encodeCursor,
+  decodeCursor,
+} from "../utils/pagination.js";
+import { vaults } from "./vaults.js";
+import db from "../db/index.js";
+import type { Knex } from "knex";
+import { createHash } from "node:crypto";
 
-export const orgVaultsRouter = Router()
+export const orgVaultsRouter = Router();
 
 // ─── Existing vault list ──────────────────────────────────────────────────────
 
 orgVaultsRouter.get(
-  '/:orgId/vaults',
+  "/:orgId/vaults",
   authenticate,
-  requireOrgAccess('owner', 'admin', 'member'),
+  requireOrgAccess("owner", "admin", "member"),
   orgReadRateLimiter,
   queryParser({
-    allowedSortFields: ['createdAt', 'amount', 'endTimestamp', 'status'],
-    allowedFilterFields: ['status', 'creator'],
+    allowedSortFields: ["createdAt", "amount", "endTimestamp", "status"],
+    allowedFilterFields: ["status", "creator"],
   }),
   (req: Request, res: Response) => {
-    const { orgId } = req.params
-    let result = vaults.filter((v) => v.orgId === orgId)
+    const { orgId } = req.params;
+    let result = vaults.filter((v) => v.orgId === orgId);
 
     if (req.filters) {
-      result = applyFilters(result, req.filters)
+      result = applyFilters(result, req.filters);
     }
 
     if (req.sort) {
-      result = applySort(result, req.sort)
+      result = applySort(result, req.sort);
     }
 
-    const paginatedResult = paginateArray(result, req.pagination!)
-    res.json(paginatedResult)
+    const paginatedResult = paginateArray(result, req.pagination!);
+    res.json(paginatedResult);
   },
-)
+);
 
 // ─── Saved-search constants ───────────────────────────────────────────────────
 
-export const MAX_SEARCHES_PER_ORG = 20
-export const MIN_ALERT_FREQUENCY_MS = 3_600_000 // 1 hour
+export const MAX_SEARCHES_PER_ORG = 20;
+export const MIN_ALERT_FREQUENCY_MS = 3_600_000; // 1 hour
 
-const VALID_STATUSES = new Set(['draft', 'active', 'completed', 'failed', 'cancelled'])
-const VALID_SORT_FIELDS = new Set(['created_at', 'amount', 'end_date', 'status'])
-const VALID_SORT_ORDERS = new Set(['asc', 'desc'])
+const VALID_STATUSES = new Set([
+  "draft",
+  "active",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+const VALID_SORT_FIELDS = new Set([
+  "created_at",
+  "amount",
+  "end_date",
+  "status",
+]);
+const VALID_SORT_ORDERS = new Set(["asc", "desc"]);
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface SavedSearchQueryDefinition {
-  q?: string
-  status?: string
-  verifier?: string
-  amount_min?: string
-  amount_max?: string
-  date_from?: string
-  date_to?: string
-  sort_by?: string
-  sort_order?: string
-  limit?: number
+  q?: string;
+  status?: string;
+  verifier?: string;
+  amount_min?: string;
+  amount_max?: string;
+  date_from?: string;
+  date_to?: string;
+  sort_by?: string;
+  sort_order?: string;
+  limit?: number;
 }
 
 export interface OrgVaultSearch {
-  id: string
-  org_id: string
-  name: string
-  query_definition: SavedSearchQueryDefinition
-  alerts_enabled: boolean
-  alert_recipient: string | null
-  alert_frequency_ms: number
-  last_evaluated_at: string | null
-  last_result_hash: string | null
-  created_by: string
-  created_at: string
-  updated_at: string
+  id: string;
+  org_id: string;
+  name: string;
+  query_definition: SavedSearchQueryDefinition;
+  alerts_enabled: boolean;
+  alert_recipient: string | null;
+  alert_frequency_ms: number;
+  last_evaluated_at: string | null;
+  last_result_hash: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
 }
 
 // ─── Validation ───────────────────────────────────────────────────────────────
 
 export interface QueryValidationResult {
-  valid: boolean
-  errors: string[]
-  sanitized: SavedSearchQueryDefinition
+  valid: boolean;
+  errors: string[];
+  sanitized: SavedSearchQueryDefinition;
 }
 
-export function validateAndSanitizeQueryDefinition(raw: unknown): QueryValidationResult {
-  const errors: string[] = []
-  const sanitized: SavedSearchQueryDefinition = {}
+export function validateAndSanitizeQueryDefinition(
+  raw: unknown,
+): QueryValidationResult {
+  const errors: string[] = [];
+  const sanitized: SavedSearchQueryDefinition = {};
 
-  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
-    return { valid: false, errors: ['query_definition must be an object'], sanitized }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return {
+      valid: false,
+      errors: ["query_definition must be an object"],
+      sanitized,
+    };
   }
 
-  const input = raw as Record<string, unknown>
+  const input = raw as Record<string, unknown>;
 
   if (input.q !== undefined) {
-    if (typeof input.q !== 'string') {
-      errors.push('q must be a string')
+    if (typeof input.q !== "string") {
+      errors.push("q must be a string");
     } else {
-      sanitized.q = input.q.replace(/[^\w\s.\-]/g, '').substring(0, 200)
+      sanitized.q = input.q.replace(/[^\w\s.\-]/g, "").substring(0, 200);
     }
   }
 
   if (input.status !== undefined) {
-    if (typeof input.status !== 'string' || !VALID_STATUSES.has(input.status)) {
-      errors.push(`status must be one of: ${[...VALID_STATUSES].join(', ')}`)
+    if (typeof input.status !== "string" || !VALID_STATUSES.has(input.status)) {
+      errors.push(`status must be one of: ${[...VALID_STATUSES].join(", ")}`);
     } else {
-      sanitized.status = input.status
+      sanitized.status = input.status;
     }
   }
 
   if (input.verifier !== undefined) {
-    if (typeof input.verifier !== 'string') {
-      errors.push('verifier must be a string')
+    if (typeof input.verifier !== "string") {
+      errors.push("verifier must be a string");
     } else {
-      sanitized.verifier = input.verifier.slice(0, 256)
+      sanitized.verifier = input.verifier.slice(0, 256);
     }
   }
 
-  for (const field of ['amount_min', 'amount_max'] as const) {
+  for (const field of ["amount_min", "amount_max"] as const) {
     if (input[field] !== undefined) {
-      const v = String(input[field])
+      const v = String(input[field]);
       if (!/^\d+(\.\d+)?$/.test(v)) {
-        errors.push(`${field} must be a non-negative numeric string`)
+        errors.push(`${field} must be a non-negative numeric string`);
       } else {
-        sanitized[field] = v
+        sanitized[field] = v;
       }
     }
   }
 
-  for (const field of ['date_from', 'date_to'] as const) {
+  for (const field of ["date_from", "date_to"] as const) {
     if (input[field] !== undefined) {
-      if (typeof input[field] !== 'string' || isNaN(Date.parse(input[field] as string))) {
-        errors.push(`${field} must be a valid ISO 8601 date string`)
+      if (
+        typeof input[field] !== "string" ||
+        isNaN(Date.parse(input[field] as string))
+      ) {
+        errors.push(`${field} must be a valid ISO 8601 date string`);
       } else {
-        sanitized[field] = input[field] as string
+        sanitized[field] = input[field] as string;
       }
     }
   }
 
   if (input.sort_by !== undefined) {
-    if (typeof input.sort_by !== 'string' || !VALID_SORT_FIELDS.has(input.sort_by)) {
-      errors.push(`sort_by must be one of: ${[...VALID_SORT_FIELDS].join(', ')}`)
+    if (
+      typeof input.sort_by !== "string" ||
+      !VALID_SORT_FIELDS.has(input.sort_by)
+    ) {
+      errors.push(
+        `sort_by must be one of: ${[...VALID_SORT_FIELDS].join(", ")}`,
+      );
     } else {
-      sanitized.sort_by = input.sort_by
+      sanitized.sort_by = input.sort_by;
     }
   }
 
   if (input.sort_order !== undefined) {
-    if (typeof input.sort_order !== 'string' || !VALID_SORT_ORDERS.has(input.sort_order)) {
-      errors.push('sort_order must be "asc" or "desc"')
+    if (
+      typeof input.sort_order !== "string" ||
+      !VALID_SORT_ORDERS.has(input.sort_order)
+    ) {
+      errors.push('sort_order must be "asc" or "desc"');
     } else {
-      sanitized.sort_order = input.sort_order
+      sanitized.sort_order = input.sort_order;
     }
   }
 
   if (input.limit !== undefined) {
-    const n = Number(input.limit)
+    const n = Number(input.limit);
     if (!Number.isInteger(n) || n < 1 || n > 100) {
-      errors.push('limit must be an integer between 1 and 100')
+      errors.push("limit must be an integer between 1 and 100");
     } else {
-      sanitized.limit = n
+      sanitized.limit = n;
     }
   }
 
-  return { valid: errors.length === 0, errors, sanitized }
+  return { valid: errors.length === 0, errors, sanitized };
 }
 
 // ─── Shared evaluation helper (also used by the periodic job) ─────────────────
@@ -175,107 +213,146 @@ export async function runSavedSearch(
   orgId: string,
   queryDef: SavedSearchQueryDefinition,
 ): Promise<string[]> {
-  const limit = Math.min(100, Math.max(1, queryDef.limit ?? 20))
+  const limit = Math.min(100, Math.max(1, queryDef.limit ?? 20));
 
-  let query = db('vaults')
-    .where('organization_id', orgId)
-    .whereNull('deleted_at')
-    .select('id')
+  let query = db("vaults")
+    .where("organization_id", orgId)
+    .whereNull("deleted_at")
+    .select("id");
 
   if (queryDef.q) {
-    const q = queryDef.q
-    const hasFtsColumn = await db('information_schema.columns')
-      .where({ table_schema: 'public', table_name: 'vaults', column_name: 'search_vector' })
+    const q = queryDef.q;
+    const hasFtsColumn = await db("information_schema.columns")
+      .where({
+        table_schema: "public",
+        table_name: "vaults",
+        column_name: "search_vector",
+      })
       .first()
-      .then(Boolean)
+      .then(Boolean);
 
     if (hasFtsColumn) {
-      query = query.whereRaw(
-        `search_vector @@ to_tsquery('simple', ?)`,
-        [q.split(/\s+/).filter(Boolean).map((t) => `${t}:*`).join(' & ')],
-      )
+      query = query.whereRaw(`search_vector @@ to_tsquery('simple', ?)`, [
+        q
+          .split(/\s+/)
+          .filter(Boolean)
+          .map((t) => `${t}:*`)
+          .join(" & "),
+      ]);
     } else {
       query = query.where((builder: Knex.QueryBuilder) => {
-        builder.where('creator', 'ilike', `%${q}%`).orWhere('verifier', 'ilike', `%${q}%`)
-      })
+        builder
+          .where("creator", "ilike", `%${q}%`)
+          .orWhere("verifier", "ilike", `%${q}%`);
+      });
     }
   }
 
-  if (queryDef.status) query = query.where('status', queryDef.status)
-  if (queryDef.verifier) query = query.where('verifier', queryDef.verifier)
-  if (queryDef.amount_min) query = query.where('amount', '>=', queryDef.amount_min)
-  if (queryDef.amount_max) query = query.where('amount', '<=', queryDef.amount_max)
-  if (queryDef.date_from) query = query.where('created_at', '>=', new Date(queryDef.date_from))
-  if (queryDef.date_to) query = query.where('created_at', '<=', new Date(queryDef.date_to))
+  if (queryDef.status) query = query.where("status", queryDef.status);
+  if (queryDef.verifier) query = query.where("verifier", queryDef.verifier);
+  if (queryDef.amount_min)
+    query = query.where("amount", ">=", queryDef.amount_min);
+  if (queryDef.amount_max)
+    query = query.where("amount", "<=", queryDef.amount_max);
+  if (queryDef.date_from)
+    query = query.where("created_at", ">=", new Date(queryDef.date_from));
+  if (queryDef.date_to)
+    query = query.where("created_at", "<=", new Date(queryDef.date_to));
 
-  const sortField = queryDef.sort_by ?? 'created_at'
-  const sortOrder = (queryDef.sort_order ?? 'desc') as 'asc' | 'desc'
-  query = query.orderBy(sortField, sortOrder).orderBy('id', 'desc')
+  const sortField = queryDef.sort_by ?? "created_at";
+  const sortOrder = (queryDef.sort_order ?? "desc") as "asc" | "desc";
+  query = query.orderBy(sortField, sortOrder).orderBy("id", "desc");
 
-  const rows = await query.limit(limit)
-  return rows.map((r: { id: string }) => r.id)
+  const rows = await query.limit(limit);
+  return rows.map((r: { id: string }) => r.id);
 }
 
 export function hashResultSet(ids: string[]): string {
-  return createHash('sha256').update(JSON.stringify(ids)).digest('hex')
+  return createHash("sha256").update(JSON.stringify(ids)).digest("hex");
 }
 
 // ─── POST /api/orgs/:orgId/vault-searches ─────────────────────────────────────
 
 orgVaultsRouter.post(
-  '/:orgId/vault-searches',
+  "/:orgId/vault-searches",
   authenticate,
-  requireOrgAccess('owner', 'admin'),
+  requireOrgAccess("owner", "admin"),
   orgWriteRateLimiter,
-  async (req: Request, res: Response): Promise<void> => {
-    const { orgId } = req.params
-    const userId: string = (req.user as any)?.userId || (req.user as any)?.sub || ''
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const { orgId } = req.params;
+    const userId = getAuthenticatedUserId(req);
+    if (!userId) {
+      next(AppError.unauthorized("Authenticated user missing userId"));
+      return;
+    }
+    const {
+      name,
+      query_definition,
+      alerts_enabled,
+      alert_recipient,
+      alert_frequency_ms,
+    } = req.body;
 
-    const { name, query_definition, alerts_enabled, alert_recipient, alert_frequency_ms } = req.body
-
-    if (typeof name !== 'string' || name.trim().length === 0 || name.length > 255) {
-      res.status(400).json({ error: 'name must be a non-empty string (max 255 chars)' })
-      return
+    if (
+      typeof name !== "string" ||
+      name.trim().length === 0 ||
+      name.length > 255
+    ) {
+      res
+        .status(400)
+        .json({ error: "name must be a non-empty string (max 255 chars)" });
+      return;
     }
 
-    const validation = validateAndSanitizeQueryDefinition(query_definition)
+    const validation = validateAndSanitizeQueryDefinition(query_definition);
     if (!validation.valid) {
-      res.status(400).json({ error: 'Invalid query_definition', details: validation.errors })
-      return
+      res.status(400).json({
+        error: "Invalid query_definition",
+        details: validation.errors,
+      });
+      return;
     }
 
-    const alertsOn = Boolean(alerts_enabled)
+    const alertsOn = Boolean(alerts_enabled);
 
     if (alertsOn) {
-      if (typeof alert_recipient !== 'string' || alert_recipient.trim().length === 0) {
-        res.status(400).json({ error: 'alert_recipient is required when alerts_enabled is true' })
-        return
+      if (
+        typeof alert_recipient !== "string" ||
+        alert_recipient.trim().length === 0
+      ) {
+        res.status(400).json({
+          error: "alert_recipient is required when alerts_enabled is true",
+        });
+        return;
       }
 
-      const freqMs = alert_frequency_ms !== undefined ? Number(alert_frequency_ms) : MIN_ALERT_FREQUENCY_MS
+      const freqMs =
+        alert_frequency_ms !== undefined
+          ? Number(alert_frequency_ms)
+          : MIN_ALERT_FREQUENCY_MS;
       if (!Number.isInteger(freqMs) || freqMs < MIN_ALERT_FREQUENCY_MS) {
         res.status(400).json({
           error: `alert_frequency_ms must be an integer >= ${MIN_ALERT_FREQUENCY_MS} (1 hour)`,
-        })
-        return
+        });
+        return;
       }
     }
 
     try {
-      const countRow = await db('org_vault_searches')
+      const countRow = await db("org_vault_searches")
         .where({ org_id: orgId })
-        .count('id as n')
-        .first()
+        .count("id as n")
+        .first();
 
-      const currentCount = Number(countRow?.n ?? 0)
+      const currentCount = Number(countRow?.n ?? 0);
       if (currentCount >= MAX_SEARCHES_PER_ORG) {
         res.status(422).json({
           error: `Org has reached the maximum of ${MAX_SEARCHES_PER_ORG} saved searches`,
-        })
-        return
+        });
+        return;
       }
 
-      const [search] = await db('org_vault_searches')
+      const [search] = await db("org_vault_searches")
         .insert({
           org_id: orgId,
           name: name.trim(),
@@ -283,100 +360,102 @@ orgVaultsRouter.post(
           alerts_enabled: alertsOn,
           alert_recipient: alertsOn ? (alert_recipient as string).trim() : null,
           alert_frequency_ms: alertsOn
-            ? (alert_frequency_ms !== undefined ? Number(alert_frequency_ms) : MIN_ALERT_FREQUENCY_MS)
+            ? alert_frequency_ms !== undefined
+              ? Number(alert_frequency_ms)
+              : MIN_ALERT_FREQUENCY_MS
             : MIN_ALERT_FREQUENCY_MS,
           created_by: userId,
           created_at: new Date(),
           updated_at: new Date(),
         })
-        .returning('*')
+        .returning("*");
 
-      res.status(201).json({ search })
+      res.status(201).json({ search });
     } catch (error) {
-      console.error('Error creating saved search:', error)
-      res.status(500).json({ error: 'Internal server error' })
+      console.error("Error creating saved search:", error);
+      res.status(500).json({ error: "Internal server error" });
     }
   },
-)
+);
 
 // ─── GET /api/orgs/:orgId/vault-searches ──────────────────────────────────────
 
 orgVaultsRouter.get(
-  '/:orgId/vault-searches',
+  "/:orgId/vault-searches",
   authenticate,
-  requireOrgAccess('owner', 'admin', 'member'),
+  requireOrgAccess("owner", "admin", "member"),
   orgReadRateLimiter,
   async (req: Request, res: Response): Promise<void> => {
-    const { orgId } = req.params
+    const { orgId } = req.params;
 
     try {
-      const searches: OrgVaultSearch[] = await db('org_vault_searches')
+      const searches: OrgVaultSearch[] = await db("org_vault_searches")
         .where({ org_id: orgId })
-        .orderBy('created_at', 'desc')
+        .orderBy("created_at", "desc");
 
-      res.json({ searches })
+      res.json({ searches });
     } catch (error) {
-      console.error('Error listing saved searches:', error)
-      res.status(500).json({ error: 'Internal server error' })
+      console.error("Error listing saved searches:", error);
+      res.status(500).json({ error: "Internal server error" });
     }
   },
-)
+);
 
 // ─── GET /api/orgs/:orgId/vault-searches/:searchId ────────────────────────────
 
 orgVaultsRouter.get(
-  '/:orgId/vault-searches/:searchId',
+  "/:orgId/vault-searches/:searchId",
   authenticate,
-  requireOrgAccess('owner', 'admin', 'member'),
+  requireOrgAccess("owner", "admin", "member"),
   orgReadRateLimiter,
   async (req: Request, res: Response): Promise<void> => {
-    const { orgId, searchId } = req.params
+    const { orgId, searchId } = req.params;
 
     try {
-      const search: OrgVaultSearch | undefined = await db('org_vault_searches')
+      const search: OrgVaultSearch | undefined = await db("org_vault_searches")
         .where({ id: searchId, org_id: orgId })
-        .first()
+        .first();
 
       if (!search) {
-        res.status(404).json({ error: 'Saved search not found' })
-        return
+        res.status(404).json({ error: "Saved search not found" });
+        return;
       }
 
-      res.json({ search })
+      res.json({ search });
     } catch (error) {
-      console.error('Error fetching saved search:', error)
-      res.status(500).json({ error: 'Internal server error' })
+      console.error("Error fetching saved search:", error);
+      res.status(500).json({ error: "Internal server error" });
     }
   },
-)
+);
 
 // ─── DELETE /api/orgs/:orgId/vault-searches/:searchId ─────────────────────────
 
 orgVaultsRouter.delete(
-  '/:orgId/vault-searches/:searchId',
+  "/:orgId/vault-searches/:searchId",
   authenticate,
-  requireOrgAccess('owner', 'admin'),
+  requireOrgAccess("owner", "admin"),
   orgWriteRateLimiter,
   async (req: Request, res: Response): Promise<void> => {
-    const { orgId, searchId } = req.params
+    const { orgId, searchId } = req.params;
 
     try {
-      const deleted = await db('org_vault_searches')
+      const deleted = await db("org_vault_searches")
         .where({ id: searchId, org_id: orgId })
-        .delete()
+        .delete();
 
       if (deleted === 0) {
-        res.status(404).json({ error: 'Saved search not found' })
-        return
+        res.status(404).json({ error: "Saved search not found" });
+        return;
       }
 
-      res.status(204).end()
+      res.status(204).end();
     } catch (error) {
-      console.error('Error deleting saved search:', error)
-      res.status(500).json({ error: 'Internal server error' })
+      console.error("Error deleting saved search:", error);
+      res.status(500).json({ error: "Internal server error" });
     }
   },
-)
+);
 
 /**
  * GET /api/orgs/:orgId/vaults/search
@@ -397,135 +476,165 @@ orgVaultsRouter.delete(
  *   limit        - Page size (1–100, default 20)
  */
 orgVaultsRouter.get(
-  '/:orgId/vaults/search',
+  "/:orgId/vaults/search",
   authenticate,
-  requireOrgAccess('owner', 'admin', 'member'),
+  requireOrgAccess("owner", "admin", "member"),
   orgReadRateLimiter,
   queryParser({
-    allowedSortFields: ['created_at', 'amount', 'end_date', 'status'],
-    allowedFilterFields: ['status', 'verifier', 'amount_min', 'amount_max', 'date_from', 'date_to'],
+    allowedSortFields: ["created_at", "amount", "end_date", "status"],
+    allowedFilterFields: [
+      "status",
+      "verifier",
+      "amount_min",
+      "amount_max",
+      "date_from",
+      "date_to",
+    ],
   }),
   async (req: Request, res: Response): Promise<void> => {
-    const { orgId } = req.params
+    const { orgId } = req.params;
 
     // ── Raw search term ─────────────────────────────────────────────────────
     // Strip to plain text — no special characters that could be meaningful
     // to tsvector/ILIKE beyond the literal token.
-    const rawQ = typeof req.query.q === 'string' ? req.query.q.trim() : ''
+    const rawQ = typeof req.query.q === "string" ? req.query.q.trim() : "";
     // Sanitise: keep only alphanumeric, spaces, dots, hyphens, underscores
-    const q = rawQ.replace(/[^\w\s.\-]/g, '').substring(0, 200)
+    const q = rawQ.replace(/[^\w\s.\-]/g, "").substring(0, 200);
 
     // ── Pagination ──────────────────────────────────────────────────────────
-    const limit = Math.min(100, Math.max(1, parseInt(String(req.query.limit ?? '20'))))
-    const rawCursor = typeof req.query.cursor === 'string' ? req.query.cursor : undefined
+    const limit = Math.min(
+      100,
+      Math.max(1, parseInt(String(req.query.limit ?? "20"))),
+    );
+    const rawCursor =
+      typeof req.query.cursor === "string" ? req.query.cursor : undefined;
 
     try {
       // ── Base query — always scoped to the org and not soft-deleted ────────
-      let query = db('vaults')
-        .where('organization_id', orgId)
-        .whereNull('deleted_at')
+      let query = db("vaults")
+        .where("organization_id", orgId)
+        .whereNull("deleted_at");
 
       // ── Full-text search ─────────────────────────────────────────────────
       if (q) {
         // Check whether the tsvector column exists (migration may not have run yet)
-        const hasFtsColumn = await db('information_schema.columns')
+        const hasFtsColumn = await db("information_schema.columns")
           .where({
-            table_schema: 'public',
-            table_name: 'vaults',
-            column_name: 'search_vector',
+            table_schema: "public",
+            table_name: "vaults",
+            column_name: "search_vector",
           })
           .first()
-          .then(Boolean)
+          .then(Boolean);
 
         if (hasFtsColumn) {
           // GIN index path — injection-safe: q is bound via knex parameterisation
-          query = query.whereRaw(
-            `search_vector @@ to_tsquery('simple', ?)`,
-            [q.split(/\s+/).filter(Boolean).map(t => `${t}:*`).join(' & ')],
-          )
+          query = query.whereRaw(`search_vector @@ to_tsquery('simple', ?)`, [
+            q
+              .split(/\s+/)
+              .filter(Boolean)
+              .map((t) => `${t}:*`)
+              .join(" & "),
+          ]);
         } else {
           // Fallback ILIKE path (slower, but safe until migration runs)
           query = query.where(function () {
-            this.where('creator', 'ilike', `%${q}%`)
-              .orWhere('verifier', 'ilike', `%${q}%`)
-          })
+            this.where("creator", "ilike", `%${q}%`).orWhere(
+              "verifier",
+              "ilike",
+              `%${q}%`,
+            );
+          });
         }
       }
 
       // ── Structured filters ───────────────────────────────────────────────
-      const filters = req.filters ?? {}
+      const filters = req.filters ?? {};
 
       if (filters.status) {
-        const status = Array.isArray(filters.status) ? filters.status[0] : filters.status
-        query = query.where('status', status)
+        const status = Array.isArray(filters.status)
+          ? filters.status[0]
+          : filters.status;
+        query = query.where("status", status);
       }
 
       if (filters.verifier) {
-        const verifier = Array.isArray(filters.verifier) ? filters.verifier[0] : filters.verifier
-        query = query.where('verifier', verifier)
+        const verifier = Array.isArray(filters.verifier)
+          ? filters.verifier[0]
+          : filters.verifier;
+        query = query.where("verifier", verifier);
       }
 
       if (filters.amount_min) {
-        const min = Array.isArray(filters.amount_min) ? filters.amount_min[0] : filters.amount_min
-        query = query.where('amount', '>=', min)
+        const min = Array.isArray(filters.amount_min)
+          ? filters.amount_min[0]
+          : filters.amount_min;
+        query = query.where("amount", ">=", min);
       }
 
       if (filters.amount_max) {
-        const max = Array.isArray(filters.amount_max) ? filters.amount_max[0] : filters.amount_max
-        query = query.where('amount', '<=', max)
+        const max = Array.isArray(filters.amount_max)
+          ? filters.amount_max[0]
+          : filters.amount_max;
+        query = query.where("amount", "<=", max);
       }
 
       if (filters.date_from) {
-        const from = Array.isArray(filters.date_from) ? filters.date_from[0] : filters.date_from
-        query = query.where('created_at', '>=', new Date(from))
+        const from = Array.isArray(filters.date_from)
+          ? filters.date_from[0]
+          : filters.date_from;
+        query = query.where("created_at", ">=", new Date(from));
       }
 
       if (filters.date_to) {
-        const to = Array.isArray(filters.date_to) ? filters.date_to[0] : filters.date_to
-        query = query.where('created_at', '<=', new Date(to))
+        const to = Array.isArray(filters.date_to)
+          ? filters.date_to[0]
+          : filters.date_to;
+        query = query.where("created_at", "<=", new Date(to));
       }
 
       // ── Cursor pagination ────────────────────────────────────────────────
       // Stable sort: (created_at DESC, id DESC) — matches encodeCursor/decodeCursor contract
       if (rawCursor) {
         try {
-          const { timestamp, id } = decodeCursor(rawCursor)
+          const { timestamp, id } = decodeCursor(rawCursor);
           query = query.where(function () {
-            this.where('created_at', '<', timestamp)
-              .orWhere(function () {
-                this.where('created_at', '=', timestamp).andWhere('id', '<', id)
-              })
-          })
+            this.where("created_at", "<", timestamp).orWhere(function () {
+              this.where("created_at", "=", timestamp).andWhere("id", "<", id);
+            });
+          });
         } catch {
-          res.status(400).json({ error: 'Invalid cursor' })
-          return
+          res.status(400).json({ error: "Invalid cursor" });
+          return;
         }
       }
 
       // Enforce stable ordering
-      query = query.orderBy('created_at', 'desc').orderBy('id', 'desc')
+      query = query.orderBy("created_at", "desc").orderBy("id", "desc");
 
       // Fetch limit + 1 to detect whether a next page exists
-      const rows = await query.limit(limit + 1).select(
-        'id',
-        'creator',
-        'verifier',
-        'amount',
-        'status',
-        'organization_id',
-        'start_date',
-        'end_date',
-        'created_at',
-        'updated_at',
-      )
+      const rows = await query
+        .limit(limit + 1)
+        .select(
+          "id",
+          "creator",
+          "verifier",
+          "amount",
+          "status",
+          "organization_id",
+          "start_date",
+          "end_date",
+          "created_at",
+          "updated_at",
+        );
 
-      const hasMore = rows.length > limit
-      const results = rows.slice(0, limit)
+      const hasMore = rows.length > limit;
+      const results = rows.slice(0, limit);
 
-      let nextCursor: string | undefined
+      let nextCursor: string | undefined;
       if (hasMore && results.length > 0) {
-        const last = results[results.length - 1]
-        nextCursor = encodeCursor(new Date(last.created_at), last.id)
+        const last = results[results.length - 1];
+        nextCursor = encodeCursor(new Date(last.created_at), last.id);
       }
 
       res.json({
@@ -537,10 +646,10 @@ orgVaultsRouter.get(
           has_more: hasMore,
           count: results.length,
         },
-      })
+      });
     } catch (error) {
-      console.error('Error searching org vaults:', error)
-      res.status(500).json({ error: 'Internal server error' })
+      console.error("Error searching org vaults:", error);
+      res.status(500).json({ error: "Internal server error" });
     }
   },
-)
+);

--- a/src/tests/authMiddlewareConsolidation.test.ts
+++ b/src/tests/authMiddlewareConsolidation.test.ts
@@ -1,27 +1,42 @@
-﻿import { Request, Response, NextFunction } from 'express'
-import { requireUserAuth } from '../middleware/auth.js'
-import { jest, describe, it, expect } from '@jest/globals'
+﻿import { Request, Response, NextFunction } from "express";
+import { getAuthenticatedUserId, requireUserAuth } from "../middleware/auth.js";
+import { jest, describe, it, expect } from "@jest/globals";
 
-describe('Auth Middleware Consolidation', () => {
-    it('requireUserAuth sets authUser from x-user-id header', () => {
-        const req = { header: (name: string) => name === 'x-user-id' ? 'legacy-123' : undefined } as any
-        const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any
-        const next = jest.fn()
-        
-        requireUserAuth(req, res, next)
-        
-        expect(req.authUser.userId).toBe('legacy-123')
-        expect(next).toHaveBeenCalled()
-    })
+describe("Auth Middleware Consolidation", () => {
+  it("requireUserAuth sets authUser from x-user-id header", () => {
+    const req = {
+      header: (name: string) =>
+        name === "x-user-id" ? "legacy-123" : undefined,
+    } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    const next = jest.fn();
 
-    it('requireUserAuth rejects missing auth', () => {
-        const req = { header: () => undefined } as any
-        const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any
-        const next = jest.fn()
-        
-        requireUserAuth(req, res, next)
-        
-        expect(res.status).toHaveBeenCalledWith(401)
-        expect(next).not.toHaveBeenCalled()
-    })
-})
+    requireUserAuth(req, res, next);
+
+    expect(req.authUser.userId).toBe("legacy-123");
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("requireUserAuth rejects missing auth", () => {
+    const req = { header: () => undefined } as any;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+    const next = jest.fn();
+
+    requireUserAuth(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("getAuthenticatedUserId reads the legacy authUser fallback", () => {
+    const req = { authUser: { userId: "legacy-123" } } as any;
+
+    expect(getAuthenticatedUserId(req)).toBe("legacy-123");
+  });
+
+  it("getAuthenticatedUserId returns null when no identity is present", () => {
+    const req = {} as any;
+
+    expect(getAuthenticatedUserId(req)).toBeNull();
+  });
+});

--- a/src/tests/orgVaults.savedSearches.test.ts
+++ b/src/tests/orgVaults.savedSearches.test.ts
@@ -10,6 +10,7 @@ import express, { Request, Response, NextFunction } from 'express'
 import jwt from 'jsonwebtoken'
 import { setOrganizations, setOrgMembers } from '../models/organizations.js'
 import { requireOrgAccess } from '../middleware/orgAuth.js'
+import { AppError } from '../middleware/errorHandler.js'
 
 // ─── Validation unit tests ────────────────────────────────────────────────────
 
@@ -193,7 +194,12 @@ function buildApp() {
     requireOrgAccess('owner', 'admin'),
     (req: Request, res: Response): void => {
       const { orgId } = req.params
-      const userId: string = (req.user as any)?.userId ?? ''
+      const rawUserId = (req.user as any)?.userId || (req.user as any)?.sub
+      if (typeof rawUserId !== 'string' || rawUserId.trim().length === 0) {
+        res.status(401).json({ error: 'Unauthorized: Authenticated user missing userId' })
+        return
+      }
+      const userId = rawUserId.trim()
       const { name, query_definition, alerts_enabled, alert_recipient, alert_frequency_ms } = req.body
 
       if (typeof name !== 'string' || name.trim().length === 0 || name.length > 255) {
@@ -293,6 +299,16 @@ function buildApp() {
     },
   )
 
+  app.use((err: unknown, req: Request, res: Response, _next: NextFunction): void => {
+    if (err instanceof AppError) {
+      res.status(err.status).json({ error: err.message })
+      return
+    }
+
+    console.error('Unexpected error in test app:', err)
+    res.status(500).json({ error: 'Internal server error' })
+  })
+
   return app
 }
 
@@ -377,6 +393,17 @@ describe('POST /api/orgs/:orgId/vault-searches', () => {
 
     expect(res.status).toBe(400)
     expect(res.body.error).toMatch(/alert_recipient/)
+  })
+
+  it('returns 401 when authenticated token contains no userId or sub', async () => {
+    const token = jwt.sign({ orgId: ORG_A }, JWT_SECRET)
+    const res = await request(app)
+      .post(`/api/orgs/${ORG_A}/vault-searches`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'No identity', query_definition: {} })
+
+    expect(res.status).toBe(401)
+    expect(res.body.error).toMatch(/Unauthorized/)
   })
 
   it('returns 400 when alert_frequency_ms is below the 1-hour floor', async () => {


### PR DESCRIPTION
closes #1071 

Title: Validate authenticated user IDs for org vault saved-search flows

Description: ## Summary

centralize authenticated-user-id resolution so org access and saved-search creation consume the same identity fallback logic
ensure org vault saved-search creation rejects requests that lack a usable userId/sub claim instead of proceeding with an empty identity
add regression coverage for the legacy authUser fallback and for the missing-userId auth failure path
Testing
Verified with:
node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand src/tests/authMiddlewareConsolidation.test.ts
Notes
The broader saved-search Jest suite remains blocked by an unrelated repository ESM import issue (getOverallAnalytics duplicate declaration), which is separate from this auth fix.
Branch: fix/1071-validate-auth-userid → main

Repository: Disciplr-Org/Disciplr-backend