### PR TITLE
fix: move metricsInitialized = true inside try block to allow retry on transient failure

### DIFF
--- a/src/services/boundedWebhookDispatcher.ts
+++ b/src/services/boundedWebhookDispatcher.ts
@@ -37,7 +37,6 @@ let metricsInitialized = false
 
 async function ensureMetrics() {
   if (metricsInitialized) return
-  metricsInitialized = true
 
   try {
     const client = await import('prom-client')
@@ -56,6 +55,9 @@ async function ensureMetrics() {
         registers: [metricsRegistry],
       })
     }
+
+    // Only mark as initialized after all gauge registrations succeed
+    metricsInitialized = true
   } catch (e) {
     // Metrics not available, use no-op gauges
     webhookInFlightGauge = { set: () => {} }


### PR DESCRIPTION
Closes #1108 

Issue #1108: ensureMetrics() set metricsInitialized = true before the try block, so a transient failure (e.g. startup ordering issue) would permanently disable the disciplr_webhook_dispatch_in_flight and disciplr_webhook_dispatch_queue_depth gauges for the lifetime of the process.

Moved metricsInitialized = true inside the try block, after all gauge registrations succeed. On failure, the flag remains false so the next call to ensureMetrics() will retry initialization.