### PR TITLE
fix: replace blind type-cast in toPublicVault with explicit status mapping and fix rollup tie-break

### DIFF
--- a/docs/team-rollup.md
+++ b/docs/team-rollup.md
@@ -60,7 +60,7 @@ Requires authentication and `owner` or `admin` organization role (enforced by `r
 
 ## Deduplication
 
-Vaults are assigned to teams via the `memberships` table: a vault's `creator` is matched to a `memberships.user_id` with a non-null `team_id` within the same organization. When a vault creator belongs to multiple teams, each vault is assigned to exactly one team using `ROW_NUMBER()` partitioned by vault ID, ordered by team ID. This prevents double-counting of vault capital or counts across teams.
+Vaults are assigned to teams via the `memberships` table: a vault's `creator` is matched to a `memberships.user_id` with a non-null `team_id` within the same organization. When a vault creator belongs to multiple teams, each vault is assigned to exactly one team using `ROW_NUMBER()` partitioned by vault ID, ordered by `m.created_at DESC` (most recently joined team wins). This prevents double-counting of vault capital or counts across teams.
 
 ## Tenant Isolation
 

--- a/src/services/team.ts
+++ b/src/services/team.ts
@@ -62,7 +62,7 @@ const ROLLUP_SQL = `WITH deduped_team_vaults AS (
          v.amount,
          v.status,
          m.team_id,
-         ROW_NUMBER() OVER (PARTITION BY v.id ORDER BY m.team_id) AS rn
+         ROW_NUMBER() OVER (PARTITION BY v.id ORDER BY m.created_at DESC) AS rn
   FROM vaults v
   JOIN memberships m ON m.user_id = v.creator
     AND m.organization_id = ?

--- a/src/tests/mappers.test.ts
+++ b/src/tests/mappers.test.ts
@@ -50,7 +50,7 @@ describe('toPublicVault', () => {
     expect(dto.id).toBe('vault-001')
     expect(dto.creator).toBe('GCREATOR123')
     expect(dto.amount).toBe('1000')
-    expect(dto.status).toBe('ACTIVE')
+    expect(dto.status).toBe('active')
     expect(dto.successDestination).toBe('GSUCCESS789')
     expect(dto.failureDestination).toBe('GFAILURE000')
   })
@@ -92,22 +92,22 @@ describe('toPublicVault', () => {
 
   it('maps PENDING status correctly', () => {
     const dto = toPublicVault(makeVault({ status: VaultStatus.PENDING }))
-    expect(dto.status).toBe('PENDING')
+    expect(dto.status).toBe('pending')
   })
 
   it('maps COMPLETED status correctly', () => {
     const dto = toPublicVault(makeVault({ status: VaultStatus.COMPLETED }))
-    expect(dto.status).toBe('COMPLETED')
+    expect(dto.status).toBe('completed')
   })
 
   it('maps FAILED status correctly', () => {
     const dto = toPublicVault(makeVault({ status: VaultStatus.FAILED }))
-    expect(dto.status).toBe('FAILED')
+    expect(dto.status).toBe('failed')
   })
 
   it('maps CANCELLED status correctly', () => {
     const dto = toPublicVault(makeVault({ status: VaultStatus.CANCELLED }))
-    expect(dto.status).toBe('CANCELLED')
+    expect(dto.status).toBe('cancelled')
   })
 
   it('handles optional organization_id being absent', () => {

--- a/src/types/enterprise.ts
+++ b/src/types/enterprise.ts
@@ -4,7 +4,7 @@
  * ensuring internal database metadata is omitted.
  */
 
-export type VaultStatus = 'active' | 'completed' | 'failed' | 'cancelled';
+export type VaultStatus = 'pending' | 'active' | 'completed' | 'failed' | 'cancelled';
 export type MilestoneStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
 
 export interface EnterpriseVault {

--- a/src/utils/mappers.ts
+++ b/src/utils/mappers.ts
@@ -1,6 +1,14 @@
 import { Milestone } from '../types/horizonSync.js';
-import { Vault } from '../types/vault.js';
-import { EnterpriseVault, EnterpriseMilestone } from '../types/enterprise.js';
+import { Vault, VaultStatus as InternalVaultStatus } from '../types/vault.js';
+import { EnterpriseVault, EnterpriseMilestone, VaultStatus as PublicVaultStatus } from '../types/enterprise.js';
+
+const STATUS_MAP: Record<InternalVaultStatus, PublicVaultStatus> = {
+  [InternalVaultStatus.PENDING]: 'pending',
+  [InternalVaultStatus.ACTIVE]: 'active',
+  [InternalVaultStatus.COMPLETED]: 'completed',
+  [InternalVaultStatus.FAILED]: 'failed',
+  [InternalVaultStatus.CANCELLED]: 'cancelled',
+};
 
 /**
  * Maps an internal Vault model to a public EnterpriseVault DTO.
@@ -11,7 +19,7 @@ export function toPublicVault(vault: Vault): EnterpriseVault {
     id: vault.id,
     creator: vault.creator_address,
     amount: vault.amount,
-    status: vault.status as unknown as EnterpriseVault['status'],
+    status: STATUS_MAP[vault.status],
     startTimestamp: vault.created_at.toISOString(),
     endTimestamp: vault.deadline.toISOString(),
     successDestination: vault.success_destination,


### PR DESCRIPTION
## Summary

- **Issue #1087**: Replaces the `as unknown as EnterpriseVault['status']` double-cast in `toPublicVault` with a typed `STATUS_MAP` that explicitly translates each internal `VaultStatus` enum value to a valid lowercase public status. Adds `'pending'` to the public `VaultStatus` union in `enterprise.ts` so the `PENDING` internal state has a valid mapping target.

- **Issue #1109**: Changes the `getTeamRollup` SQL `ORDER BY` from the arbitrary `m.team_id` (UUID lexicographic ordering) to `m.created_at DESC` (most recently joined team wins), making the tie-break rule explicit and documented. Updated `docs/team-rollup.md` to reflect the new behavior.

## Changes

| File | Change |
|---|---|
| `src/types/enterprise.ts` | Added `'pending'` to `VaultStatus` union |
| `src/utils/mappers.ts` | Replaced blind double-cast with explicit `STATUS_MAP` lookup |
| `src/tests/mappers.test.ts` | Updated expected status values to lowercase |
| `src/services/team.ts` | Changed `ORDER BY m.team_id` → `ORDER BY m.created_at DESC` |
| `docs/team-rollup.md` | Documented the new deduplication tie-break rule |

Closes #1087
Closes #1109