### PR TITLE
fix: preserve tuple typing in backfill progress samples

### DIFF
--- a/src/services/backfillCursorStore.ts
+++ b/src/services/backfillCursorStore.ts
@@ -115,7 +115,8 @@ export class BackfillCursorStore {
       const prev: number = Number(row.processed ?? 0)
       processed = prev + count
       const prevSamples: Array<[number, number]> = row.samples ? JSON.parse(row.samples as string) : []
-      samples = [...prevSamples, [now.getTime(), processed]].slice(-MAX_SAMPLES)
+      const sample: [number, number] = [now.getTime(), processed]
+      samples = [...prevSamples, sample].slice(-MAX_SAMPLES)
     }
 
     await this.db('backfill_cursors')

--- a/src/tests/backfillCursorStore.test.ts
+++ b/src/tests/backfillCursorStore.test.ts
@@ -247,6 +247,24 @@ describe('BackfillCursorStore.resetCursor', () => {
 })
 
 // ---------------------------------------------------------------------------
+// recordProgress
+// ---------------------------------------------------------------------------
+
+describe('BackfillCursorStore.recordProgress', () => {
+  it('stores tuple-shaped throughput samples when progress is recorded', async () => {
+    const db = makeMockDb()
+    const store = new BackfillCursorStore(db)
+
+    await store.recordProgress('job-a', 3)
+
+    const insertArg = db._qb.insert.mock.calls[0][0] as Record<string, unknown>
+    expect(insertArg.processed).toBe(3)
+    expect(insertArg.samples).toEqual(expect.stringContaining('3'))
+    expect(insertArg.samples).toEqual(expect.stringContaining('['))
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Resumption continuity (stateful)
 //
 // Core invariant: a process resuming from cursor C must claim the range


### PR DESCRIPTION
## Summary
Closes #1004

Fixes the tuple inference issue in backfill progress sampling by explicitly typing the newly created sample before it is spread into the existing samples array. This preserves the expected `[number, number]` tuple shape and resolves the TypeScript build error reported for `recordProgress`.

## What changed

- Updated [src/services/backfillCursorStore.ts](src/services/backfillCursorStore.ts) to create an explicit tuple value for each new progress sample before appending it.
- Added a regression test in [src/tests/backfillCursorStore.test.ts](src/tests/backfillCursorStore.test.ts) covering the `recordProgress` path.

## Verification

- `npm test -- --runInBand src/tests/backfillCursorStore.test.ts` ✅
  - 32/32 tests passed
- `npm run build` ✅
  - TypeScript build completed successfully

## Notes
