### PR TITLE
fix(security): normalize key separators in shouldRedact for snake_case variants

### DIFF
--- a/src/middleware/privacy-logger.ts
+++ b/src/middleware/privacy-logger.ts
@@ -33,9 +33,19 @@ const SENSITIVE_KEYS = new Set([
 const EMAIL_RE = /[^@\s]+@[^@\s]+\.[^@\s]+/
 const JWT_RE = /^[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+$/
 
+/** Normalize a key by lowering case and stripping separators. */
+function normalizeKey(key: string): string {
+  return key.toLowerCase().replace(/[_\-]/g, '')
+}
+
+/** Pre-normalized set for fast lookup. */
+const NORMALIZED_SENSITIVE_KEYS = new Set(
+  [...SENSITIVE_KEYS].map(normalizeKey),
+)
+
 /** Returns true when a field name should always be redacted. */
 export function shouldRedact(key: string): boolean {
-  return SENSITIVE_KEYS.has(key.toLowerCase())
+  return NORMALIZED_SENSITIVE_KEYS.has(normalizeKey(key))
 }
 
 export const ALLOWLIST_KEYS = new Set([

--- a/src/tests/privacy-logger.redaction.test.ts
+++ b/src/tests/privacy-logger.redaction.test.ts
@@ -47,6 +47,14 @@ describe('redact()', () => {
     }
   })
 
+  it('redacts client_secret in snake_case (RFC 6749 OAuth body)', () => {
+    const body = { grant_type: 'authorization_code', client_id: 'public', client_secret: 's3cret' }
+    const result = redact(body) as Record<string, unknown>
+    expect(result.client_secret).toBe(REDACTED)
+    expect(result.grant_type).toBe('authorization_code')
+    expect(result.client_id).toBe('public')
+  })
+
   it('leaves non-sensitive fields unchanged', () => {
     expect(redact({ id: 'abc', amount: 100 })).toEqual({ id: 'abc', amount: 100 })
   })
@@ -111,6 +119,17 @@ describe('shouldRedact()', () => {
     expect(shouldRedact('email')).toBe(true)
     expect(shouldRedact('token')).toBe(true)
     expect(shouldRedact('cookie')).toBe(true)
+  })
+
+  it('returns true for snake_case and kebab-case variants of sensitive keys', () => {
+    expect(shouldRedact('client_secret')).toBe(true)
+    expect(shouldRedact('CLIENT_SECRET')).toBe(true)
+    expect(shouldRedact('api_key')).toBe(true)
+    expect(shouldRedact('access_token')).toBe(true)
+    expect(shouldRedact('refresh_token')).toBe(true)
+    expect(shouldRedact('credit_card')).toBe(true)
+    expect(shouldRedact('x-api-key')).toBe(true)
+    expect(shouldRedact('x-auth-token')).toBe(true)
   })
 
   it('returns false for safe keys', () => {


### PR DESCRIPTION
## Summary

`shouldRedact()` in `src/middleware/privacy-logger.ts` did `SENSITIVE_KEYS.has(key.toLowerCase())` — an exact-match against a fixed `Set` that included `'clientsecret'` and `'apikey'` (no separators) but not `'client_secret'` or `'x_api_key'`. Since `.toLowerCase()` alone doesn't strip underscores or hyphens, any object key using snake_case for one of these sensitive names (e.g. `{ client_secret: '...' }`, exactly what `src/routes/oauth.ts` produces) passed through `redact()` unredacted.

This also affected `src/lib/audit-logs.ts`'s `exportAuditLogsForOrganization`, which calls `redact()` on audit log rows.

## Changes

- [ADD] `src/middleware/privacy-logger.ts` — `normalizeKey()` strips `_`/`-` and lowercases; `NORMALIZED_SENSITIVE_KEYS` pre-computed at module load; `shouldRedact()` now normalizes both the Set entries and the lookup key
- [ADD] `src/tests/privacy-logger.redaction.test.ts` — `shouldRedact()` test for 8 snake_case/kebab-case variants (`client_secret`, `CLIENT_SECRET`, `api_key`, `access_token`, `refresh_token`, `credit_card`, `x-api-key`, `x-auth-token`); `redact()` integration test for RFC 6749 OAuth body with `client_secret`

## Verification

| Check | Result |
|-------|--------|
| `jest src/tests/privacy-logger.redaction.test.ts` | ✅ 43/43 passed |

## Related

- Fixes #1047
- Complements `8a1cd91` `fix(security): add snake_case OAuth/webhook secrets to Pino redact paths` which fixed the same gap in `src/middleware/logger.ts` (Pino config)
