### PR TITLE
fix(types): refactor EnterpriseResponse to discriminated union (#1114)

### DIFF
--- a/src/tests/enterpriseResponse.test.ts
+++ b/src/tests/enterpriseResponse.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from '@jest/globals'
+import type { EnterpriseResponse } from '../types/enterprise.js'
+
+describe('EnterpriseResponse Discriminated Union', () => {
+  it('narrows wrapped response using wrapped discriminant key', () => {
+    const wrappedRes: EnterpriseResponse<string> = {
+      wrapped: true,
+      data: 'hello world',
+    }
+
+    if (wrappedRes.wrapped) {
+      expect(wrappedRes.data).toBe('hello world')
+    } else {
+      throw new Error('Should have narrowed to wrapped: true')
+    }
+  })
+
+  it('narrows unwrapped response using wrapped discriminant key', () => {
+    const unwrappedRes: EnterpriseResponse<number> = {
+      wrapped: false,
+      value: 42,
+    }
+
+    if (!unwrappedRes.wrapped) {
+      expect(unwrappedRes.value).toBe(42)
+    } else {
+      throw new Error('Should have narrowed to wrapped: false')
+    }
+  })
+
+  it('enforces compile-time exhaustiveness checking via discriminant', () => {
+    function unwrap<T>(res: EnterpriseResponse<T>): T {
+      switch (res.wrapped) {
+        case true:
+          return res.data
+        case false:
+          return res.value
+      }
+    }
+
+    const wrapped: EnterpriseResponse<string> = { wrapped: true, data: 'wrapped_payload' }
+    const unwrapped: EnterpriseResponse<string> = { wrapped: false, value: 'unwrapped_payload' }
+
+    expect(unwrap(wrapped)).toBe('wrapped_payload')
+    expect(unwrap(unwrapped)).toBe('unwrapped_payload')
+  })
+})

--- a/src/types/enterprise.ts
+++ b/src/types/enterprise.ts
@@ -29,7 +29,9 @@ export interface EnterpriseMilestone {
   status: MilestoneStatus;
 }
 
-export type EnterpriseResponse<T> = T | { data: T };
+export type EnterpriseResponse<T> =
+  | { wrapped: true; data: T }
+  | { wrapped: false; value: T };
 
 export interface Organization {
   id: string;


### PR DESCRIPTION
### ## What
Refactored `EnterpriseResponse<T>` to a discriminated union using `wrapped` property discriminant.

### ## Why
Closes #1114. The previous definition `T | { data: T }` was an ambiguous union requiring unsafe runtime duck-typing (`'data' in res`). A discriminated union enables TypeScript compile-time exhaustiveness checking and narrowing without runtime ambiguity.

### ## How
- `src/types/enterprise.ts`: Replaced `T | { data: T }` with `{ wrapped: true; data: T } | { wrapped: false; value: T }`.
- `src/tests/enterpriseResponse.test.ts`: Added unit tests verifying type narrowing, exhaustiveness checking, and runtime structure.

### ## Testing
- `npm run build` / `npx tsc --noEmit` (TypeScript typecheck): PASS
- `npm test -- src/tests/enterpriseResponse.test.ts`: PASS