### PR TITLE
fix: clamp user list limit to 100

### DIFF
--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -30,7 +30,8 @@ export interface DeleteResult {
 
 export class UserService {
   async listUsers(filters: UserFilters = {}): Promise<PaginatedUsers> {
-    const { role, status, search, limit = 20, offset = 0, includeDeleted = false } = filters
+    const { role, status, search, offset = 0, includeDeleted = false } = filters
+    const limit = Math.min(100, filters.limit ?? 20)
 
     let query = db('users')
 


### PR DESCRIPTION
Closes #1084


This pull request addresses a missing pagination constraint in the UserService.listUsers endpoint. 

Problem:
The listUsers method in src/services/user.service.ts previously destructured the limit parameter directly from caller-supplied filters (defaulting to 20) and passed it to the database query without any upper boundary. Unlike other paginated endpoints in the codebase which use a Math.min clamp, this allowed callers to theoretically request an infinitely large page size. Doing so could result in returning the entire users table in a single payload, risking severe performance degradation and excessive memory usage.

Solution:
A bounding clamp was added to the limit variable in src/services/user.service.ts. The limit logic was updated to use Math.min(100, filters.limit ?? 20). This ensures the page size for this endpoint never exceeds 100 records per request, making it strictly consistent with the pagination caps used throughout the rest of the application.

Changes Made:
- Modified src/services/user.service.ts to isolate the limit destructuring and apply a Math.min constraint of 100 before passing it to the database query limit.