### PR TITLE
fix(notifications): make getProvider an instance method

### DIFF
--- a/src/services/notifications/factory.ts
+++ b/src/services/notifications/factory.ts
@@ -1,7 +1,6 @@
 import { NotificationProvider } from './provider.js'
 import { EmailNotificationProvider } from './email.provider.js'
 import { ConsoleNotificationProvider } from './console.provider.js'
-import { getEnv } from '../../config/index.js'
 
 export class NotificationService {
   constructor(
@@ -11,8 +10,8 @@ export class NotificationService {
     this.assertProviderExists(defaultProviderName)
   }
 
-  static getProvider(name?: string): NotificationProvider {
-    const providerName = name || getEnv().NOTIFICATION_PROVIDER || 'console'
+  getProvider(name?: string): NotificationProvider {
+    const providerName = name ?? this.defaultProviderName
     const provider = this.providers[providerName]
 
     if (!provider) {

--- a/src/tests/notification.factory.test.ts
+++ b/src/tests/notification.factory.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, jest } from '@jest/globals'
-import { NotificationService } from '../services/notifications/factory.js'
+import {
+  NotificationService,
+  createNotificationService,
+} from '../services/notifications/factory.js'
 import type { NotificationProvider } from '../services/notifications/provider.js'
 
 describe('NotificationService factory behavior', () => {
@@ -20,5 +23,87 @@ describe('NotificationService factory behavior', () => {
     await expect(service.send('user@example.com', 'subject', 'body', 'email')).rejects.toThrow(
       'Unknown notification provider "email"',
     )
+  })
+})
+
+// ─── End-to-end: NotificationService.send() ───────────────────────────────────
+//
+// These tests exercise the full path:
+//   createNotificationService → NotificationService constructor
+//     → send() → getProvider() (instance method, reads this.providers)
+//     → provider.send()
+//
+// Before the bug fix, getProvider was `static`, so this.providers did not
+// exist on the static context and every send() call threw a TS2339/TypeError
+// at runtime. These tests would have failed with
+// "Cannot read properties of undefined (reading '<providerName>')" or
+// "this.getProvider is not a function".
+
+describe('NotificationService.send() — end-to-end', () => {
+  const makeStub = (name: string): NotificationProvider => ({
+    name,
+    send: jest.fn<NotificationProvider['send']>().mockResolvedValue(undefined),
+  })
+
+  // Helper to extract the Jest mock from a provider's send function.
+  const asMock = (p: NotificationProvider) =>
+    p.send as jest.MockedFunction<NotificationProvider['send']>
+
+  it('routes to the named provider via createNotificationService', async () => {
+    const emailStub = makeStub('email')
+    const consoleStub = makeStub('console')
+    const service = createNotificationService('console', { email: emailStub, console: consoleStub })
+
+    await service.send('alice@example.com', 'Hello', 'World', 'email')
+
+    expect(asMock(emailStub)).toHaveBeenCalledTimes(1)
+    expect(asMock(emailStub)).toHaveBeenCalledWith('alice@example.com', 'Hello', 'World')
+    expect(asMock(consoleStub)).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the default provider when no override is given', async () => {
+    const emailStub = makeStub('email')
+    const consoleStub = makeStub('console')
+    const service = createNotificationService('console', { email: emailStub, console: consoleStub })
+
+    await service.send('bob@example.com', 'Subject', 'Body')
+
+    expect(asMock(consoleStub)).toHaveBeenCalledTimes(1)
+    expect(asMock(consoleStub)).toHaveBeenCalledWith('bob@example.com', 'Subject', 'Body')
+    expect(asMock(emailStub)).not.toHaveBeenCalled()
+  })
+
+  it('resolves successfully (does not throw) for a valid send call', async () => {
+    const consoleStub = makeStub('console')
+    const service = createNotificationService('console', { console: consoleStub })
+
+    await expect(
+      service.send('carol@example.com', 'Test', 'Test body'),
+    ).resolves.toBeUndefined()
+  })
+
+  it('propagates errors thrown by the underlying provider', async () => {
+    const broken = makeStub('console')
+    asMock(broken).mockRejectedValue(new Error('SMTP timeout'))
+    const service = createNotificationService('console', { console: broken })
+
+    await expect(
+      service.send('dave@example.com', 'Oops', 'Will fail'),
+    ).rejects.toThrow('SMTP timeout')
+  })
+
+  it('getProvider is an instance method — callable from send() without TypeError', async () => {
+    // This is the regression guard: if getProvider were still static,
+    // `this.getProvider` would be undefined and send() would throw
+    // "this.getProvider is not a function" before even reaching the provider.
+    const consoleStub = makeStub('console')
+    const service = createNotificationService('console', { console: consoleStub })
+
+    // Must not throw "this.getProvider is not a function"
+    await expect(
+      service.send('eve@example.com', 'Regression', 'guard'),
+    ).resolves.toBeUndefined()
+
+    expect(asMock(consoleStub)).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
getProvider was declared static, causing two runtime errors:
- this.providers did not exist on the static context (TS2339 x2)
- send() could not call this.getProvider() from an instance (TS2576)

Fixes:
- Remove 'static' from getProvider so it reads this.providers and this.defaultProviderName correctly
- Replace getEnv().NOTIFICATION_PROVIDER fallback with this.defaultProviderName — the instance already holds the resolved default, and getEnv() throws in test environments before init

Adds five end-to-end tests covering named-provider routing, default fallback, successful resolve, error propagation, and a regression guard confirming getProvider is reachable as an instance method from send().

closes #1001