### PR TITLE
getHealth in src/controllers/healthController.ts is dead code — never…

### DIFF
--- a/src/controllers/healthController.ts
+++ b/src/controllers/healthController.ts
@@ -1,6 +1,0 @@
-import type { Request, Response } from 'express'
-import { config } from '../config/index.js'
-
-export const getHealth = (_req: Request, res: Response) => {
-  res.json({ status: 'ok', service: config.serviceName, timestamp: new Date().toISOString() })
-}


### PR DESCRIPTION
Closes #1057

---

Close: #1057

## Resolution Complete: Deleted the dead healthController.ts
Action taken: Deleted healthController.ts . The orphan src/controllers/ directory (which contained only this file) is also gone.

Why deletion over wiring:

Signal Evidence 100% dead code Zero imports across src/ — no reference in app.ts , app-bootstrap.ts , or any route/test file. Pattern mismatch The project consistently uses a routes + services architecture. /api/health is served by createHealthRouter → healthService , not controllers. Wiring getHealth in would introduce an unused, inconsistent pattern. Live impl is strictly richer The live endpoint at routes/health.ts:13-22 calls healthService.buildHealthStatus(...) , which returns {status, timestamp, uptime, service, jobs.running, jobs.queueDepth, jobs.activeJobs} . The dead controller returned only {status, service, timestamp} — plugging it in would reduce observability. Footgun eliminated Contributors will no longer waste time editing a controller that has zero effect on /api/health .

Verification:

- GetDiagnostics → no type/lint errors.
- Grep for healthController / controllers/health → 0 matches, no dangling references.
- LS src/ confirms the controllers/ directory has been removed.