### PR TITLE
fix: guard ETL worker against silent Stellar testnet fallback in production

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,12 +23,16 @@ import {
   securityRateLimitMiddleware,
 } from "./security/abuse-monitor.js";
 import { initializeDatabase, closeDatabase } from "./db/database.js";
-import { etlWorker } from "./services/etlWorker.js";
+import { getEtlWorker } from "./services/etlWorker.js";
 import { createShutdownHandler } from "./server/shutdown.js";
 import { createNotificationService } from "./services/notifications/factory.js";
 
 const env = getEnv();
 const PORT = env.PORT;
+
+// Resolved eagerly so a testnet-fallback misconfiguration in production
+// aborts startup instead of surfacing after the server is already listening.
+const etlWorker = getEtlWorker();
 
 // Initialize distributed tracing (no-op when OTEL_EXPORTER_OTLP_ENDPOINT is unset)
 initTracing();

--- a/src/services/etlWorker.test.ts
+++ b/src/services/etlWorker.test.ts
@@ -4,8 +4,16 @@
  * Uses dependency injection (the optional third constructor argument) to avoid
  * jest.mock() hoisting, which is not supported in ts-jest ESM mode.
  */
+import '../tests/initTestEnv.js'
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals'
-import { ETLWorker, type ETLWorkerOptions } from './etlWorker.js'
+import {
+  ETLWorker,
+  resolveETLConfig,
+  TESTNET_HORIZON_URL,
+  TESTNET_NETWORK_PASSPHRASE,
+  type ETLWorkerOptions,
+} from './etlWorker.js'
+import { envSchema, type Env } from '../config/env.js'
 import type { TransactionETLService } from './transactionETL.js'
 import type { ETLBatchResult, ETLConfig } from '../types/transactions.js'
 
@@ -368,5 +376,91 @@ describe('ETLWorker', () => {
       expect(capturedSignal.aborted).toBe(false)
       await worker.stop()
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveETLConfig
+// ---------------------------------------------------------------------------
+
+describe('resolveETLConfig', () => {
+  const baseVars = { DATABASE_URL: 'postgres://localhost/test' }
+
+  function makeEnv(overrides: Record<string, string | undefined> = {}): Env {
+    return envSchema.parse({ ...baseVars, ...overrides })
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('uses HORIZON_URL and STELLAR_NETWORK_PASSPHRASE from the validated env', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const config = resolveETLConfig(
+      makeEnv({
+        HORIZON_URL: 'https://horizon.stellar.org',
+        STELLAR_NETWORK_PASSPHRASE: 'Public Global Stellar Network ; September 2015',
+      }),
+    )
+
+    expect(config.horizonUrl).toBe('https://horizon.stellar.org')
+    expect(config.networkPassphrase).toBe(
+      'Public Global Stellar Network ; September 2015',
+    )
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to testnet defaults outside production with an explicit warning', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const config = resolveETLConfig(makeEnv())
+
+    expect(config.horizonUrl).toBe(TESTNET_HORIZON_URL)
+    expect(config.networkPassphrase).toBe(TESTNET_NETWORK_PASSPHRASE)
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const logged = JSON.parse(warnSpy.mock.calls[0][0] as string)
+    expect(logged.event).toBe('config.testnet_default')
+    expect(logged.variables).toEqual(['HORIZON_URL', 'STELLAR_NETWORK_PASSPHRASE'])
+  })
+
+  it('warns only about the variable that actually fell back', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    resolveETLConfig(makeEnv({ HORIZON_URL: 'https://horizon.stellar.org' }))
+
+    const logged = JSON.parse(warnSpy.mock.calls[0][0] as string)
+    expect(logged.variables).toEqual(['STELLAR_NETWORK_PASSPHRASE'])
+  })
+
+  it('fails closed in production when the testnet fallback would be used', () => {
+    expect(() => resolveETLConfig(makeEnv({ NODE_ENV: 'production' }))).toThrow(
+      /Refusing to start in production/,
+    )
+  })
+
+  it('starts normally in production when both variables are set', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const config = resolveETLConfig(
+      makeEnv({
+        NODE_ENV: 'production',
+        HORIZON_URL: 'https://horizon.stellar.org',
+        STELLAR_NETWORK_PASSPHRASE: 'Public Global Stellar Network ; September 2015',
+      }),
+    )
+
+    expect(config.horizonUrl).toBe('https://horizon.stellar.org')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('parses backfill bounds from the validated env', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const config = resolveETLConfig(
+      makeEnv({
+        ETL_BACKFILL_FROM: '2026-01-01T00:00:00Z',
+        ETL_BACKFILL_TO: '2026-02-01T00:00:00Z',
+      }),
+    )
+
+    expect(config.backfillFrom).toEqual(new Date('2026-01-01T00:00:00Z'))
+    expect(config.backfillTo).toEqual(new Date('2026-02-01T00:00:00Z'))
   })
 })

--- a/src/services/etlWorker.ts
+++ b/src/services/etlWorker.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { getEnv, type Env } from '../config/env.js'
 import { TransactionETLService } from '../services/transactionETL.js'
 import type { ETLBatchResult, ETLConfig } from '../types/transactions.js'
 
@@ -144,7 +145,7 @@ export class ETLWorker {
     const { signal } = this.abortController
 
     this.activeRun = this.etlService
-      .runETL()
+      .runETL(signal, batchId)
       .then(() => {
         console.log(`[ETLWorker] Batch ${batchId} completed`)
       })
@@ -167,18 +168,69 @@ export class ETLWorker {
 // Default singleton
 // ---------------------------------------------------------------------------
 
-const defaultConfig: ETLConfig = {
-  horizonUrl: process.env.HORIZON_URL ?? 'https://horizon-testnet.stellar.org',
-  networkPassphrase:
-    process.env.STELLAR_NETWORK_PASSPHRASE ?? 'Test SDF Network ; September 2015',
-  batchSize: 100,
-  maxRetries: 3,
-  backfillFrom: process.env.ETL_BACKFILL_FROM
-    ? new Date(process.env.ETL_BACKFILL_FROM)
-    : undefined,
-  backfillTo: process.env.ETL_BACKFILL_TO
-    ? new Date(process.env.ETL_BACKFILL_TO)
-    : undefined,
+export const TESTNET_HORIZON_URL = 'https://horizon-testnet.stellar.org'
+export const TESTNET_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015'
+
+/**
+ * Build the default {@link ETLConfig} from the validated environment.
+ *
+ * `HORIZON_URL` / `STELLAR_NETWORK_PASSPHRASE` fall back to Stellar's public
+ * testnet only outside production. In production the fallback is a
+ * misconfiguration that would silently sync testnet data into mainnet
+ * tables, so we fail closed instead of starting the worker.
+ *
+ * @param env  Defaults to the validated env — pass a custom record in tests.
+ */
+export function resolveETLConfig(env: Env = getEnv()): ETLConfig {
+  const fallbacks: string[] = []
+  if (!env.HORIZON_URL) fallbacks.push('HORIZON_URL')
+  if (!env.STELLAR_NETWORK_PASSPHRASE) fallbacks.push('STELLAR_NETWORK_PASSPHRASE')
+
+  if (fallbacks.length > 0) {
+    if (env.NODE_ENV === 'production') {
+      throw new Error(
+        `[ETLWorker] Refusing to start in production: ${fallbacks.join(', ')} ` +
+          'not set — the ETL worker would silently sync from the Stellar ' +
+          'TESTNET. Set HORIZON_URL and STELLAR_NETWORK_PASSPHRASE to ' +
+          'mainnet values (or explicitly to testnet if that is intended).',
+      )
+    }
+
+    console.warn(
+      JSON.stringify({
+        level: 'warn',
+        event: 'config.testnet_default',
+        service: 'disciplr-backend',
+        variables: fallbacks,
+        message: `ETL worker falling back to Stellar testnet defaults for: ${fallbacks.join(', ')}`,
+        timestamp: new Date().toISOString(),
+      }),
+    )
+  }
+
+  return {
+    horizonUrl: env.HORIZON_URL || TESTNET_HORIZON_URL,
+    networkPassphrase: env.STELLAR_NETWORK_PASSPHRASE || TESTNET_NETWORK_PASSPHRASE,
+    batchSize: 100,
+    maxRetries: 3,
+    backfillFrom: env.ETL_BACKFILL_FROM ? new Date(env.ETL_BACKFILL_FROM) : undefined,
+    backfillTo: env.ETL_BACKFILL_TO ? new Date(env.ETL_BACKFILL_TO) : undefined,
+  }
 }
 
-export const etlWorker = new ETLWorker(defaultConfig)
+let defaultWorker: ETLWorker | null = null
+
+/**
+ * Lazily constructed default worker.
+ *
+ * Static imports are hoisted ahead of `initEnv()` in src/index.ts, so the
+ * worker cannot be built at module load time — `getEnv()` would throw.
+ * Deferring construction to first use lets the config come from the
+ * centralized, validated environment.
+ */
+export function getEtlWorker(): ETLWorker {
+  if (defaultWorker === null) {
+    defaultWorker = new ETLWorker(resolveETLConfig())
+  }
+  return defaultWorker
+}

--- a/src/services/transactionETL.ts
+++ b/src/services/transactionETL.ts
@@ -17,10 +17,14 @@ export class TransactionETLService {
   /**
    * Run the full ETL process - backfill and incremental sync.
    * Pass an AbortSignal to allow the caller to cancel a long-running run.
+   * The optional batchId identifies the scheduler tick that triggered the
+   * run so retries of the same tick can be correlated in logs.
    */
-  async runETL(signal?: AbortSignal): Promise<void> {
+  async runETL(signal?: AbortSignal, batchId?: string): Promise<void> {
     TransactionETLService.checkAbort(signal)
-    console.log('Starting Transaction ETL process...')
+    console.log(
+      `Starting Transaction ETL process...${batchId ? ` (batch ${batchId})` : ''}`,
+    )
 
     try {
       // Run backfill if configured

--- a/src/tests/initTestEnv.ts
+++ b/src/tests/initTestEnv.ts
@@ -1,0 +1,14 @@
+/**
+ * Side-effect import that initializes the validated env before any module
+ * with import-time `getEnv()` calls (e.g. src/db/index.ts) is evaluated.
+ *
+ * Import this FIRST in suites whose import graph reaches such modules —
+ * ESM evaluates dependencies in declaration order, so this module's body
+ * runs before the modules imported after it.
+ */
+import { initEnv } from '../config/env.js'
+
+process.env.DATABASE_URL ??=
+  'postgresql://postgres:postgres@localhost:5432/postgres'
+
+initEnv()


### PR DESCRIPTION
closes #1046

## Problem

The default `ETLConfig` singleton in `src/services/etlWorker.ts` read `HORIZON_URL` and `STELLAR_NETWORK_PASSPHRASE` directly from `process.env`, bypassing the centralized, validated `getEnv()` config, and silently fell back to Stellar's public testnet (`https://horizon-testnet.stellar.org` / `Test SDF Network ; September 2015`) when either variable was unset. A production deployment that forgot to set these vars would start syncing transaction data from testnet instead of mainnet with no error and no log line — unlike `src/config/env.ts`, which emits an explicit `config.insecure_default` warning for sentinel secrets.

## Changes

### Route the ETL config through the validated environment

- New `resolveETLConfig(env = getEnv())` builds the default `ETLConfig` from the validated env (`HORIZON_URL`, `STELLAR_NETWORK_PASSPHRASE`, `ETL_BACKFILL_FROM`, `ETL_BACKFILL_TO`), replacing the raw `process.env` reads. Empty-string values are treated the same as unset, matching how the rest of the config layer handles blanks.
- **Outside production**, falling back to the testnet defaults now emits a structured `config.testnet_default` warning listing exactly which variables fell back, in the same JSON log shape as the existing `config.insecure_default` event.
- **In `NODE_ENV=production`**, the fallback fails closed: `resolveETLConfig` throws with an actionable message, and `src/index.ts` resolves the worker eagerly right after `getEnv()`, so a misconfigured deployment aborts at startup before the server begins listening — instead of silently syncing testnet data.

### Lazy default singleton

The old module-level `export const etlWorker = new ETLWorker(defaultConfig)` could never have used `getEnv()`: static imports are hoisted, so `etlWorker.ts` was evaluated before the `initEnv()` call in `src/index.ts`. The singleton is now constructed lazily via `getEtlWorker()` (memoized), and `src/index.ts` resolves it explicitly after env initialization. `ETLWorker` itself and the shutdown handler API are unchanged.

### Test suite repair (required to test this change)

`src/services/etlWorker.test.ts` failed to load on `main` (`Env not initialized`): its import graph reaches `src/db/index.ts`, which calls `getEnv()` at import time, and nothing initialized the env first. This PR:

- adds `src/tests/initTestEnv.ts`, a side-effect bootstrap imported first so the validated env exists before modules with import-time `getEnv()` calls are evaluated;
- wires the `AbortSignal` and batch ID through `executeRun()` to `TransactionETLService.runETL(signal, batchId)`, which the five pre-existing `AbortSignal`/`batchId` tests already expected (the worker previously called `runETL()` with no arguments; the mismatch was masked by the suite failing to load). `runETL`'s new `batchId` parameter is optional and only used for log correlation, so no other caller changes.

## New tests

`resolveETLConfig` is covered for: passthrough of explicitly configured values, testnet fallback with warning contents (`config.testnet_default`, exact variable list), partial fallback (only the missing variable is reported), fail-closed throw in production, clean startup in production when both variables are set, and backfill date parsing.

## Verification

- `npx jest src/services/etlWorker.test.ts`: 28/28 pass (on `main` this suite fails to load).
- `npx tsc --noEmit`: no new errors (the two pre-existing syntax errors in `src/middleware/requireJson.ts` and `src/routes/milestones.ts` exist on `main` and are untouched here).

## Notes for reviewers

- Operators intentionally running against testnet in production must now set `HORIZON_URL` and `STELLAR_NETWORK_PASSPHRASE` explicitly — that is the intended behavior change.
- If a hard startup abort is considered too strict, the production branch can be downgraded to a `level: error` log; the issue explicitly offered fail-closed, which seemed safer for a misconfiguration that corrupts synced data.
