### PR TITLE
fix(cors): wire corsOptions from config/cors.ts into app.ts (#1052)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import cors from 'cors'
 import express from 'express'
 import helmet from 'helmet'
 import { config } from './config/index.js'
+import { corsOptions } from './config/cors.js'
 import { privacyLogger } from './middleware/privacy-logger.js'
 import { csrfProtection } from './middleware/auth.js'
 import { AUTH_JSON_MAX_BYTES, JOBS_JSON_MAX_BYTES } from './middleware/requestBodyLimits.js'
@@ -125,36 +126,6 @@ app.use(
     xPermittedCrossDomainPolicies: { permittedPolicies: 'none' },
   }),
 )
-
-const corsOptions: cors.CorsOptions = {
-  origin: (origin, callback) => {
-    // Non-browser / server-to-server requests carry no Origin header — pass through
-    if (!origin) {
-      callback(null, true)
-      return
-    }
-
-    const allowed = config.corsOrigins
-    if (allowed === '*' || (Array.isArray(allowed) && allowed.includes(origin))) {
-      callback(null, true)
-    } else {
-      // Emit a structured log so rejected origins are observable in prod logs
-      console.log(
-        JSON.stringify({
-          level: 'warn',
-          event: 'security.cors_rejected',
-          service: 'disciplr-backend',
-          origin,
-          timestamp: new Date().toISOString(),
-        }),
-      )
-      callback(null, false)
-    }
-  },
-  methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'idempotency-key'],
-  credentials: true,
-}
 
 app.use(cors(corsOptions))
 


### PR DESCRIPTION
closes #1052

Replace the inline corsOptions definition in app.ts with an import from src/config/cors.ts. The inline version had three security issues compared to the config module:

- No null-origin block: untrusted 'null' origins were passed through
- Wildcard + credentials=true: credentials were always enabled, including when CORS_ORIGINS='*', which browsers reject and is unsafe
- No trailing-slash normalization on allowlist checks, causing valid origins with a trailing slash to be rejected

The config/cors.ts export already handles all three correctly and uses config.serviceName for structured CORS rejection logs rather than the hardcoded 'disciplr-backend' string.