### PR TITLE
fix(security): require authenticate on milestones list and approval-s…

### DIFF
--- a/src/routes/milestones.ts
+++ b/src/routes/milestones.ts
@@ -63,8 +63,8 @@ milestonesRouter.post('/', authenticate, requireUser, (req: Request, res: Respon
 })
 
 // GET /api/vaults/:vaultId/milestones
-milestonesRouter.get('/', async (req: Request, res: Response) => {
-milestonesRouter.get('/', (req: Request, res: Response, next: NextFunction) => {
+milestonesRouter.get('/', authenticate, async (req: Request, res: Response) => {
+milestonesRouter.get('/', authenticate, (req: Request, res: Response, next: NextFunction) => {
   const { vaultId } = req.params
   const vault = vaults.find((v) => v.id === vaultId)
 
@@ -259,7 +259,7 @@ milestonesRouter.post('/:id/approve', authenticate, requireVerifier, async (req:
 
 // GET /api/vaults/:vaultId/milestones/:id/approval-status
 // Get detailed approval status for a milestone
-milestonesRouter.get('/:id/approval-status', async (req: Request, res: Response, next: NextFunction) => {
+milestonesRouter.get('/:id/approval-status', authenticate, async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { vaultId, id } = req.params
 


### PR DESCRIPTION
…tatus GET endpoints

Two GET routes in src/routes/milestones.ts had no auth middleware despite being mounted under /api/vaults/:vaultId/milestones with no parent-level auth, letting unauthenticated callers enumerate milestone descriptions and per-milestone verifier-approval progress for any vault ID by guessing vaultId.

- milestonesRouter.get('/') — add authenticate
- milestonesRouter.get('/:id/approval-status') — add authenticate

Both routes now align with the access-control baseline used by every other handler in the file.


Closes #1022 