### PR TITLE
fix: remove unused COUNT(*) query from GET /api/transactions

### DIFF
--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -60,10 +60,6 @@ transactionsRouter.get(
         query = query.orderBy('stellar_timestamp', 'desc')
       }
 
-      // Get total count for pagination
-      const totalCount = await query.clone().count('* as total').first()
-      const total = parseInt(String(totalCount?.total || '0'))
-
       // Apply pagination (Cursor-based)
       const limit = Math.min(100, parseInt(String(req.cursorPagination?.limit || '20')))
       const cursor = req.cursorPagination?.cursor


### PR DESCRIPTION
## Summary

Removes the dead `totalCount`/`total` computation in `src/routes/transactions.ts` (previously lines 63–65).

## Problem

Every call to `GET /api/transactions` was cloning the (potentially heavily filtered) base query and running an extra `COUNT(*)` aggregate. The result was assigned to `total` but **never referenced** — the `response.pagination` object only uses `limit`, `cursor`, `next_cursor`, `has_more`, and `count`. This added avoidable database load with zero user-facing benefit.

## Change

Removed the unused lines:
```ts
const totalCount = await query.clone().count("* as total").first()
const total = parseInt(String(totalCount?.total || "0"))
```

No other logic was affected. The cursor-based pagination continues to work exactly as before.

Closes #1023