### PR TITLE
fix: validate parsed Date in decodeCursor before returning

### DIFF
--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -52,7 +52,9 @@ export function decodeCursor(cursor: string): { timestamp: Date; id: string } {
     const decoded = Buffer.from(cursor, 'base64url').toString('utf8')
     const [timestampStr, id] = decoded.split('|')
     if (!timestampStr || !id) throw new Error('Invalid cursor format')
-    return { timestamp: new Date(timestampStr), id }
+    const timestamp = new Date(timestampStr)
+    if (Number.isNaN(timestamp.getTime())) throw new Error('Invalid cursor format')
+    return { timestamp, id }
   } catch (error) {
     throw new Error('Invalid cursor')
   }


### PR DESCRIPTION
## Summary

Adds validation that the parsed `Date` in `decodeCursor` is actually valid before returning it.

## Problem

A malformed cursor like `base64("not-a-date|123")` passes the `!timestampStr || !id` guard (both are non-empty strings) and produces `{ timestamp: Invalid Date, id: "123" }` without throwing. Callers in `src/routes/transactions.ts` feed this directly into a Knex `.where("stellar_timestamp", "<", timestamp)` clause, where an `Invalid Date` serializes to something Postgres rejects — surfacing as an uncaught 500 instead of the intended clean 400 `{ error: "Invalid cursor" }` response.

## Change

Added a `Number.isNaN(timestamp.getTime())` check after constructing the `Date` object:

```ts
const timestamp = new Date(timestampStr)
if (Number.isNaN(timestamp.getTime())) throw new Error("Invalid cursor format")
```

This ensures malformed date strings are caught and converted to the existing `{ error: "Invalid cursor" }` 400 response via the surrounding try/catch.

Closes #1028