### PR TITLE
fix: enforce bounce suppression by checking hasBounced before sending

### DIFF
--- a/src/services/notifications/email.provider.ts
+++ b/src/services/notifications/email.provider.ts
@@ -1,6 +1,6 @@
 import { NotificationProvider } from './provider.js'
 import { retryWithBackoff, DEFAULT_RETRY_CONFIG, isRetryable } from '../../utils/retry.js'
-import { recordBounce } from './bounceStore.js'
+import { recordBounce, hasBounced } from './bounceStore.js'
 import nodemailer from 'nodemailer'
 import type { Transporter } from 'nodemailer'
 import { getEnv } from '../../config/index.js'
@@ -103,6 +103,11 @@ export class EmailNotificationProvider implements NotificationProvider {
   }
 
   async send(recipient: string, subject: string, body: string): Promise<void> {
+    if (hasBounced(recipient)) {
+      console.warn(`[EmailProvider] Skipping send to ${recipient} — address has previously bounced`)
+      return
+    }
+
     // Wrap the actual send operation in the shared retry utility
     const operation = async () => {
       await this.performSend(recipient, subject, body)


### PR DESCRIPTION
## Summary

Adds a `hasBounced(recipient)` check at the top of `EmailNotificationProvider.send` to short-circuit delivery to previously-bounced addresses.

## Problem

`hasBounced(recipient)` was exported from `bounceStore.ts` and `recordBounce` was correctly called on permanent bounces, but nothing in the send pipeline ever checked `hasBounced` before attempting delivery. This meant bounce suppression only recorded bounces but never prevented re-sending to a known-bad address on subsequent notifications.

## Change

Import `hasBounced` from `bounceStore.js` in `EmailNotificationProvider` and add an early return at the top of the `send` method:

```ts
if (hasBounced(recipient)) {
  console.warn(`[EmailProvider] Skipping send to ${recipient} — address has previously bounced`)
  return
}
```

This ensures that once an address is recorded as bounced, future sends to that address are silently skipped with a warning log, completing the bounce-suppression feature.

Closes #1030