### PR TITLE
fix: propagate database errors from VaultService instead of swallowing them

### DIFF
--- a/src/services/vault.service.ts
+++ b/src/services/vault.service.ts
@@ -25,20 +25,12 @@ export class VaultService {
   }
 
   static async getVaultById(id: string): Promise<Vault | null> {
-    try {
-      const result = await pool.query('SELECT * FROM vaults WHERE id = $1', [id]);
-      return result.rows[0] ?? null;
-    } catch {
-      return null;
-    }
+    const result = await pool.query('SELECT * FROM vaults WHERE id = $1', [id]);
+    return result.rows[0] ?? null;
   }
 
   static async updateVaultStatus(id: string, status: VaultStatus | string): Promise<void> {
-    try {
-      await pool.query('UPDATE vaults SET status = $1 WHERE id = $2', [status, id]);
-    } catch (error) {
-      console.error('Error updating vault status:', error);
-    }
+    await pool.query('UPDATE vaults SET status = $1 WHERE id = $2', [status, id]);
   }
 
   static async getVaultsByUser(address: string): Promise<Vault[]> {


### PR DESCRIPTION
## Summary

Removes silent error swallowing from `VaultService.getVaultById` and `VaultService.updateVaultStatus` so database errors propagate to callers.

## Problem

**`getVaultById`** (lines 27-32) caught all errors and returned `null`, conflating a genuine database failure with a legitimate "vault doesn't exist" result. Callers had no way to distinguish the two cases.

**`updateVaultStatus`** (lines 36-40) caught errors and only called `console.error`, so the Promise always resolved successfully regardless of whether the UPDATE actually happened. Callers after a successful on-chain claim/slash had no way to detect that the corresponding local status update silently failed.

## Change

Removed the try/catch from both methods:

- **`getVaultById`** now lets database errors propagate. It still returns `null` when no rows match (the legitimate "not found" case).
- **`updateVaultStatus`** now lets database errors propagate. Callers can wrap calls in try/catch to handle failures.

Callers can now distinguish:
- `null` return means vault genuinely does not exist
- Thrown error means database failure (retryable / alertable)

The existing caller in `src/routes/vaults.ts` (line 282) already wraps `updateVaultStatus` in a try/catch with a non-fatal comment, so it remains unaffected.

Closes #1036