### PR TITLE
fix: add missing notification categories to ALLOWED_CATEGORIES

### DIFF
--- a/src/models/notificationPreferences.ts
+++ b/src/models/notificationPreferences.ts
@@ -4,7 +4,13 @@ import db from '../db/index.js'
 // represent a whole-channel opt-out without one row per known category.
 const ALL_CATEGORIES = ''
 
-export const ALLOWED_CATEGORIES = ['vault_failure', 'milestone_reminder'] as const
+export const ALLOWED_CATEGORIES = [
+  'vault_failure',
+  'milestone_reminder',
+  'milestone_reminder_deferred',
+  'milestone_reminder_processed',
+  'milestone_digest',
+] as const
 export type NotificationCategory = (typeof ALLOWED_CATEGORIES)[number]
 
 export const ALLOWED_CHANNELS = ['email'] as const


### PR DESCRIPTION
Closes #1106

## Problem

\ALLOWED_CATEGORIES\ in \src/models/notificationPreferences.ts\ was hardcoded to \['vault_failure', 'milestone_reminder']\, but \aultExpiry.service.ts\ actively dispatches three additional notification types:

- \milestone_reminder_deferred\
- \milestone_reminder_processed\
- \milestone_digest\

Because \setOrgNotificationPreferences\ throws \UnknownPreferenceKeyError\ for any category not in the allowlist, org admins could never configure notification preferences for these three real, actively-dispatched notification types via the \PUT /api/orgs/:orgId/notification-preferences\ endpoint. They always fall back to default behavior with no way to opt out.

## Fix

Added the three missing category values to \ALLOWED_CATEGORIES\, allowing organizations to configure notification preferences for each notification type via the API endpoint.