### PR TITLE
fix: protect enterprise vault routes

### DIFF
--- a/src/routes/enterpriseRoutes.ts
+++ b/src/routes/enterpriseRoutes.ts
@@ -2,6 +2,8 @@ import { Router, Request, Response } from 'express';
 import { db } from '../db/knex.js';
 import { toPublicVault, toPublicMilestone } from '../utils/mappers.js';
 import { maskPii } from '../utils/privacy.js';
+import { authenticate } from '../middleware/auth.js';
+import { enterpriseGuard } from '../middleware/enterpriseGuard.js';
 
 const debug = (msg: string, ...args: unknown[]) => { if (process.env.DEBUG) console.debug(msg, ...args) };
 const router = Router();
@@ -10,7 +12,7 @@ const router = Router();
  * @route GET /api/v1/enterprise/vaults/:id
  * @desc Fetches a vault by ID with strict exposure audit applied.
  */
-router.get('/vaults/:id', async (req: Request, res: Response) => {
+router.get('/vaults/:id', authenticate, enterpriseGuard, async (req: Request, res: Response) => {
   const { id } = req.params;
   
   try {
@@ -37,7 +39,7 @@ router.get('/vaults/:id', async (req: Request, res: Response) => {
  * @route GET /api/v1/enterprise/vaults/:id/milestones
  * @desc Fetches milestones for a vault with strict exposure audit.
  */
-router.get('/vaults/:id/milestones', async (req: Request, res: Response) => {
+router.get('/vaults/:id/milestones', authenticate, enterpriseGuard, async (req: Request, res: Response) => {
   const { id } = req.params;
   
   try {

--- a/src/tests/enterpriseRoutes.authorization.test.ts
+++ b/src/tests/enterpriseRoutes.authorization.test.ts
@@ -1,0 +1,43 @@
+import express from 'express'
+import jwt from 'jsonwebtoken'
+import request from 'supertest'
+import enterpriseRoutes from '../routes/enterpriseRoutes.js'
+import { UserRole } from '../types/user.js'
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'change-me-in-production'
+
+function buildApp() {
+  const app = express()
+  app.use(enterpriseRoutes)
+  return app
+}
+
+function nonEnterpriseToken() {
+  return jwt.sign(
+    { userId: 'user-1', role: UserRole.USER, isEnterprise: false },
+    JWT_SECRET,
+    { expiresIn: '1h' },
+  )
+}
+
+describe('enterprise vault routes authorization', () => {
+  const protectedPaths = [
+    '/vaults/vault-123',
+    '/vaults/vault-123/milestones',
+  ]
+
+  test.each(protectedPaths)('rejects unauthenticated requests to %s', async (path) => {
+    const response = await request(buildApp()).get(path)
+
+    expect(response.status).toBe(401)
+  })
+
+  test.each(protectedPaths)('rejects non-enterprise users from %s', async (path) => {
+    const response = await request(buildApp())
+      .get(path)
+      .set('Authorization', `Bearer ${nonEnterpriseToken()}`)
+
+    expect(response.status).toBe(403)
+    expect(response.body.error).toBe('Forbidden')
+  })
+})


### PR DESCRIPTION
close #1017

Secured enterprise vault endpoints against unauthenticated and non-enterprise access.

Both `GET /vaults/:id` and `GET /vaults/:id/milestones` now require a valid bearer token and enterprise authorization before querying or returning vault/milestone data. Added tests confirming both endpoints return `401` without authentication and `403` for non-enterprise users.