### PR TITLE
fix(vaults): wire dispute/resolve-dispute routes with verified-role authz

### DIFF
--- a/src/routes/vaults.test.ts
+++ b/src/routes/vaults.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, test } from 'node:test'
 import express from 'express'
 import request from 'supertest'
 import { app } from '../app.js'
-import { vaultsRouter } from './vaults.js'
+import { vaultsRouter, setVaults, type Vault } from './vaults.js'
 import { errorHandler } from '../middleware/errorHandler.js'
 import { resetIdempotencyStore } from '../services/idempotency.js'
 import { resetVaultStore, createVaultWithMilestones } from '../services/vaultStore.js'
@@ -23,6 +23,7 @@ testApp.use(errorHandler)
 const userToken = generateAccessToken({ userId: 'vault-test-user', role: UserRole.USER })
 const otherUserToken = generateAccessToken({ userId: 'other-vault-user', role: UserRole.USER })
 const listContractToken = generateAccessToken({ userId: 'vault-list-user', role: UserRole.USER })
+const adminToken = generateAccessToken({ userId: 'vault-admin-user', role: UserRole.ADMIN })
 
 let baseUrl = ''
 let server: ReturnType<typeof testApp.listen> | null = null
@@ -55,6 +56,7 @@ const validPayload = () => ({
 beforeEach(async () => {
   resetVaultStore()
   resetIdempotencyStore()
+  setVaults([])
 
   server = testApp.listen(0)
   await new Promise<void>((resolve) => {
@@ -997,6 +999,124 @@ describe('GET /api/vaults - List Contract', () => {
         assert.ok(item.amount)
         assert.ok(item.status)
       }
+    })
+  })
+})
+
+describe('Vault dispute workflow', () => {
+  const seedVault = (overrides: Partial<Vault> = {}): Vault => {
+    const vault: Vault = {
+      id: `vault-${Math.random().toString(36).slice(2, 10)}`,
+      creator: 'vault-test-user',
+      amount: '100.00',
+      status: 'active',
+      startTimestamp: new Date(Date.now() - 10000).toISOString(),
+      endTimestamp: new Date(Date.now() + 3600000).toISOString(),
+      successDestination: stellar(),
+      failureDestination: stellar(),
+      createdAt: new Date().toISOString(),
+      ...overrides,
+    }
+    setVaults([vault])
+    return vault
+  }
+
+  describe('POST /api/vaults/:id/dispute', () => {
+    test('returns 401 without an auth token', async () => {
+      const vault = seedVault()
+      const res = await request(testApp).post(`/api/vaults/${vault.id}/dispute`)
+      assert.equal(res.status, 401)
+    })
+
+    test('returns 403 for a non-admin user, even if they are the vault creator', async () => {
+      const vault = seedVault({ creator: 'vault-test-user' })
+      const res = await request(testApp)
+        .post(`/api/vaults/${vault.id}/dispute`)
+        .set('Authorization', `Bearer ${userToken}`)
+
+      assert.equal(res.status, 403)
+    })
+
+    test('allows an admin to place an active vault into disputed', async () => {
+      const vault = seedVault({ status: 'active' })
+      const res = await request(testApp)
+        .post(`/api/vaults/${vault.id}/dispute`)
+        .set('Authorization', `Bearer ${adminToken}`)
+
+      assert.equal(res.status, 200)
+      assert.equal(vault.status, 'disputed')
+    })
+
+    test('returns 409 when the vault cannot be disputed from its current status', async () => {
+      const vault = seedVault({ status: 'draft' })
+      const res = await request(testApp)
+        .post(`/api/vaults/${vault.id}/dispute`)
+        .set('Authorization', `Bearer ${adminToken}`)
+
+      assert.equal(res.status, 409)
+      assert.equal(vault.status, 'draft')
+    })
+
+    test('returns 404 for an unknown vault id', async () => {
+      const res = await request(testApp)
+        .post('/api/vaults/does-not-exist/dispute')
+        .set('Authorization', `Bearer ${adminToken}`)
+
+      assert.equal(res.status, 404)
+    })
+  })
+
+  describe('POST /api/vaults/:id/resolve-dispute', () => {
+    test('returns 401 without an auth token', async () => {
+      const vault = seedVault({ status: 'disputed' })
+      const res = await request(testApp)
+        .post(`/api/vaults/${vault.id}/resolve-dispute`)
+        .send({ target: 'active' })
+      assert.equal(res.status, 401)
+    })
+
+    test('returns 403 for a non-admin user', async () => {
+      const vault = seedVault({ status: 'disputed' })
+      const res = await request(testApp)
+        .post(`/api/vaults/${vault.id}/resolve-dispute`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({ target: 'active' })
+
+      assert.equal(res.status, 403)
+      assert.equal(vault.status, 'disputed')
+    })
+
+    test('returns 400 for a missing or invalid target', async () => {
+      const vault = seedVault({ status: 'disputed' })
+      const res = await request(testApp)
+        .post(`/api/vaults/${vault.id}/resolve-dispute`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ target: 'cancelled' })
+
+      assert.equal(res.status, 400)
+      assert.equal(vault.status, 'disputed')
+    })
+
+    test('allows an admin to resolve a disputed vault back to active', async () => {
+      const vault = seedVault({ status: 'disputed' })
+      const res = await request(testApp)
+        .post(`/api/vaults/${vault.id}/resolve-dispute`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ target: 'active' })
+
+      assert.equal(res.status, 200)
+      assert.equal(vault.status, 'active')
+    })
+
+    test('returns 409 when the vault is not currently disputed', async () => {
+      const vault = seedVault({ status: 'active' })
+      const res = await request(testApp)
+        .post(`/api/vaults/${vault.id}/resolve-dispute`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ target: 'active' })
+
+      assert.equal(res.status, 409)
+      assert.equal(vault.status, 'active')
     })
   })
 })

--- a/src/routes/vaults.ts
+++ b/src/routes/vaults.ts
@@ -1,9 +1,11 @@
 import { Router, type Request, type Response, type NextFunction } from 'express'
 import { authenticate } from '../middleware/auth.js'
+import { requireAdmin } from '../middleware/rbac.js'
 import { requireScopes } from '../middleware/apiKeyAuth.js'
 import { ApiScope } from '../types/auth.js'
 import { UserRole } from '../types/user.js'
 import { VaultService } from '../services/vault.service.js'
+import { disputeVault, resolveDispute } from '../services/vaultTransitions.js'
 import { applyFilters, applySort, paginateArray } from '../utils/pagination.js'
 import { updateAnalyticsSummary } from '../services/analytics.service.js'
 import { createAuditLog } from '../lib/audit-logs.js'
@@ -36,7 +38,7 @@ export interface Vault {
   id: string
   creator: string
   amount: string
-  status: 'draft' | 'active' | 'completed' | 'failed' | 'cancelled'
+  status: 'draft' | 'active' | 'disputed' | 'completed' | 'failed' | 'cancelled'
   startTimestamp: string
   endTimestamp: string
   successDestination: string
@@ -287,6 +289,53 @@ vaultsRouter.post('/:id/cancel', authenticate, async (req, res) => {
 
   updateAnalyticsSummary()
   res.status(200).json({ message: 'Vault cancelled', id: req.params.id })
+})
+
+// POST /api/vaults/:id/dispute
+// Admin-only: places an `active` vault into `disputed`, blocking slash/claim until resolved.
+// `requireAdmin` derives the caller's role from the verified JWT (req.user.role), not
+// from anything supplied in the request body — see vaultTransitions.ts for details.
+vaultsRouter.post('/:id/dispute', authenticate, requireAdmin, (req: Request, res: Response) => {
+  const result = disputeVault(req.params.id, req.user!.userId, req.user!.role)
+
+  if (!result.success) {
+    const status = result.error === 'Vault not found' ? 404 : 409
+    res.status(status).json({ error: result.error })
+    return
+  }
+
+  updateAnalyticsSummary()
+  res.status(200).json({ message: 'Vault placed into disputed state', id: req.params.id })
+})
+
+const DISPUTE_RESOLUTION_TARGETS = ['active', 'completed', 'failed'] as const
+type DisputeResolutionTarget = (typeof DISPUTE_RESOLUTION_TARGETS)[number]
+
+const isDisputeResolutionTarget = (value: unknown): value is DisputeResolutionTarget =>
+  typeof value === 'string' && (DISPUTE_RESOLUTION_TARGETS as readonly string[]).includes(value)
+
+// POST /api/vaults/:id/resolve-dispute
+// Admin-only: resolves a `disputed` vault back to `active`, or directly to `completed` / `failed`.
+vaultsRouter.post('/:id/resolve-dispute', authenticate, requireAdmin, (req: Request, res: Response) => {
+  const { target } = (req.body ?? {}) as { target?: unknown }
+
+  if (!isDisputeResolutionTarget(target)) {
+    res.status(400).json({
+      error: `target is required and must be one of: ${DISPUTE_RESOLUTION_TARGETS.join(', ')}`,
+    })
+    return
+  }
+
+  const result = resolveDispute(req.params.id, req.user!.userId, req.user!.role, target)
+
+  if (!result.success) {
+    const status = result.error === 'Vault not found' ? 404 : 409
+    res.status(status).json({ error: result.error })
+    return
+  }
+
+  updateAnalyticsSummary()
+  res.status(200).json({ message: 'Vault dispute resolved', id: req.params.id, status: target })
 })
 
 // GET /api/vaults/user/:address 

--- a/src/services/vaultTransitions.ts
+++ b/src/services/vaultTransitions.ts
@@ -1,6 +1,7 @@
 import { vaults, type Vault } from '../routes/vaults.js';
 import { allMilestonesVerified } from './milestones.js';
 import { type Knex } from 'knex';
+import { UserRole } from '../types/user.js';
 
 type TerminalStatus = 'completed' | 'failed' | 'cancelled';
 
@@ -174,9 +175,19 @@ export const activateVault = (vaultId: string): TransitionResult => {
 /**
  * Places an `active` vault into `disputed`, blocking slash and claim until resolved.
  * Only callable by an admin/guardian.
+ *
+ * Authorization is derived from `requesterRole`, which callers must populate from a
+ * verified source (e.g. `req.user.role` set by the `authenticate` middleware from a
+ * signed JWT) — never from a client-supplied value. This function does not accept a
+ * caller-supplied "admin id" to compare against, since that pattern is trivially
+ * bypassed if a caller ever sources both ids from the same untrusted input.
  */
-export const disputeVault = (vaultId: string, requesterId: string, adminId: string): TransitionResult => {
-  if (requesterId !== adminId) {
+export const disputeVault = (
+  vaultId: string,
+  requesterId: string,
+  requesterRole: UserRole,
+): TransitionResult => {
+  if (requesterRole !== UserRole.ADMIN) {
     return { success: false, error: 'Only an admin can place a vault into disputed state' };
   }
   const vault = findVault(vaultId);
@@ -194,14 +205,17 @@ type DisputeResolution = 'active' | 'completed' | 'failed';
 /**
  * Resolves a `disputed` vault back to `active`, or directly to `completed` / `failed`.
  * Only callable by an admin/guardian.
+ *
+ * See `disputeVault` above: authorization comes from a verified `requesterRole`,
+ * not a caller-supplied "admin id".
  */
 export const resolveDispute = (
   vaultId: string,
   requesterId: string,
-  adminId: string,
+  requesterRole: UserRole,
   target: DisputeResolution,
 ): TransitionResult => {
-  if (requesterId !== adminId) {
+  if (requesterRole !== UserRole.ADMIN) {
     return { success: false, error: 'Only an admin can resolve a disputed vault' };
   }
   const vault = findVault(vaultId);

--- a/src/tests/vaultTransitions.test.ts
+++ b/src/tests/vaultTransitions.test.ts
@@ -11,9 +11,12 @@ import {
   cancelVault,
   checkExpiredVaults,
   completeVault,
+  disputeVault,
   failVault,
+  resolveDispute,
 } from "../services/vaultTransitions.js";
 import { setVaults, type Vault } from "../routes/vaults.js";
+import { UserRole } from "../types/user.js";
 
 type VaultAction =
   | "activate"
@@ -257,5 +260,86 @@ describe("Vault transition invariants", () => {
       }),
       { numRuns: 100 },
     );
+  });
+});
+
+describe("disputeVault / resolveDispute", () => {
+  beforeEach(() => {
+    setVaults([]);
+    resetMilestonesTable();
+  });
+
+  it("rejects a non-admin requester regardless of the requesterId supplied", () => {
+    const vault = makeVault({ status: "active" });
+    setVaults([vault]);
+
+    const result = disputeVault(vault.id, "user-1", UserRole.USER);
+    expect(result.success).toBe(false);
+    expect(vault.status).toBe("active");
+  });
+
+  it("rejects a requester whose id happens to equal the vault creator's id but whose role is not admin", () => {
+    const vault = makeVault({ status: "active", creator: "same-id" });
+    setVaults([vault]);
+
+    // Regression guard for the original bug: authorization must come from a verified
+    // role, not from comparing requesterId to a second caller-supplied id.
+    const result = disputeVault(vault.id, "same-id", UserRole.USER);
+    expect(result.success).toBe(false);
+    expect(vault.status).toBe("active");
+  });
+
+  it("allows an admin to place an active vault into disputed", () => {
+    const vault = makeVault({ status: "active" });
+    setVaults([vault]);
+
+    const result = disputeVault(vault.id, "admin-1", UserRole.ADMIN);
+    expect(result.success).toBe(true);
+    expect(vault.status).toBe("disputed");
+  });
+
+  it("refuses to dispute a vault not in a disputable status", () => {
+    const vault = makeVault({ status: "draft" });
+    setVaults([vault]);
+
+    const result = disputeVault(vault.id, "admin-1", UserRole.ADMIN);
+    expect(result.success).toBe(false);
+    expect(vault.status).toBe("draft");
+  });
+
+  it("returns an error for an unknown vault id", () => {
+    const result = disputeVault("does-not-exist", "admin-1", UserRole.ADMIN);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Vault not found");
+  });
+
+  it("rejects a non-admin from resolving a disputed vault", () => {
+    const vault = makeVault({ status: "disputed" });
+    setVaults([vault]);
+
+    const result = resolveDispute(vault.id, "user-1", UserRole.USER, "active");
+    expect(result.success).toBe(false);
+    expect(vault.status).toBe("disputed");
+  });
+
+  it.each(["active", "completed", "failed"] as const)(
+    "allows an admin to resolve a disputed vault to %s",
+    (target) => {
+      const vault = makeVault({ status: "disputed" });
+      setVaults([vault]);
+
+      const result = resolveDispute(vault.id, "admin-1", UserRole.ADMIN, target);
+      expect(result.success).toBe(true);
+      expect(vault.status).toBe(target);
+    },
+  );
+
+  it("refuses to resolve a vault that is not currently disputed", () => {
+    const vault = makeVault({ status: "active" });
+    setVaults([vault]);
+
+    const result = resolveDispute(vault.id, "admin-1", UserRole.ADMIN, "active");
+    expect(result.success).toBe(false);
+    expect(vault.status).toBe("active");
   });
 });


### PR DESCRIPTION
Expose disputeVault/resolveDispute via admin-gated HTTP routes and close
the adminId-comparison authz bug.

- Add POST /api/vaults/:id/dispute and POST /api/vaults/:id/resolve-dispute,
  guarded by authenticate + requireAdmin (role read from the verified JWT).
- Change disputeVault/resolveDispute signature from (vaultId, requesterId,
  adminId) to (vaultId, requesterId, requesterRole: UserRole); authorize
  off requesterRole === UserRole.ADMIN instead of comparing two
  caller-supplied ids, which was trivially bypassable if a future caller
  sourced both ids from the same value (e.g. req.user.userId).
- Add 'disputed' to the Vault status union in routes/vaults.ts so the
  functions type-check against a real Vault.
- Add unit tests for disputeVault/resolveDispute (role gating, valid/
  invalid transitions, regression test for the old id-collision bypass)
  and route-level tests for both new endpoints (401/403/200/409/400/404).

Closes #1095