### PR TITLE
fix(organization): remove unused listOrganizations dead code (#1045)

### DIFF
--- a/src/services/organization.ts
+++ b/src/services/organization.ts
@@ -19,7 +19,3 @@ export const getOrganizationById = async (id: string): Promise<Organization | nu
 export const getOrganizationBySlug = async (slug: string): Promise<Organization | null> => {
   return db('organizations').where({ slug }).first()
 }
-
-export const listOrganizations = async (): Promise<Organization[]> => {
-  return db('organizations').select('*')
-}


### PR DESCRIPTION
Closes #1045. Removed dead/unreachable `listOrganizations` function from `src/services/organization.ts` to reduce surface area.