### PR TITLE
fix(webhooks): define missing EgressAllowlistEntry interface

### DIFF
--- a/src/services/webhooks.ts
+++ b/src/services/webhooks.ts
@@ -47,6 +47,13 @@ export interface WebhookSubscriber {
   fieldPolicy: FieldPolicy
 }
 
+export interface EgressAllowlistEntry {
+  id: string
+  organizationId: string
+  host: string
+  createdAt: string
+}
+
 export const DEFAULT_MAX_REPLAY_EVENTS = 500
 export const LATEST_SCHEMA_VERSION = 2
 export const DEFAULT_SCHEMA_VERSION = 1


### PR DESCRIPTION
Closes #980 
This PR resolves a TypeScript compilation error where EgressAllowlistEntry was used as a type annotation for addEgressAllowlistEntry and listEgressAllowlist in src/services/webhooks.ts but was never defined or imported in the file (or anywhere else in the repository).

Changes
Added the EgressAllowlistEntry interface definition to 
src/services/webhooks.ts
:
typescript


export interface EgressAllowlistEntry {
  id: string
  organizationId: string
  host: string
  createdAt: string
}
This interface matches the structure of the object literal returned by the egress allowlist functions.