### PR TITLE
fix: type getMilestoneApprovals row and guard approval_status

### DIFF
--- a/src/services/verifiers.ts
+++ b/src/services/verifiers.ts
@@ -448,19 +448,35 @@ export const getMilestoneApprovals = async (
   rejected: MilestoneApproval[]
   pending: MilestoneApproval[]
 }> => {
-  const rows = await db('milestone_approvals')
+  interface MilestoneApprovalRow {
+    id: string
+    milestone_id: string
+    verifier_user_id: string
+    approval_status: unknown
+    created_at: string
+    updated_at: string
+  }
+
+  const rows = await db<MilestoneApprovalRow>('milestone_approvals')
     .where({ milestone_id: milestoneId })
     .orderBy('created_at', 'asc')
 
-  const grouped = {
-    approved: [] as MilestoneApproval[],
-    rejected: [] as MilestoneApproval[],
-    pending: [] as MilestoneApproval[],
+  const VALID_STATUSES = new Set<MilestoneApprovalStatus>(['approved', 'rejected', 'pending'])
+
+  const grouped: Record<MilestoneApprovalStatus, MilestoneApproval[]> = {
+    approved: [],
+    rejected: [],
+    pending: [],
   }
 
   rows.forEach((row) => {
-    const mapped = mapMilestoneApprovalRow(row)
-    grouped[row.approval_status].push(mapped)
+    const status = row.approval_status
+    if (typeof status !== 'string' || !VALID_STATUSES.has(status as MilestoneApprovalStatus)) {
+      // Unrecognised status from DB — route to pending rather than throw
+      grouped.pending.push(mapMilestoneApprovalRow(row))
+      return
+    }
+    grouped[status as MilestoneApprovalStatus].push(mapMilestoneApprovalRow(row))
   })
 
   return grouped


### PR DESCRIPTION
  Title: fix: type getMilestoneApprovals row and guard approval_status

  Description:

  Fixes TS7053 and a latent runtime crash in getMilestoneApprovals (src/services/verifiers.ts).

  Problem

  The Knex query returned untyped rows, so row.approval_status was implicitly any. Indexing
  grouped[row.approval_status] produced a TS7053 compiler error, and any unexpected value in the approval_status
  column (e.g. from a bad migration or manual DB edit) would cause grouped[x] to be undefined, making .push() throw a
  runtime TypeError.
    
  Changes
  
  - Added a MilestoneApprovalRow interface with approval_status: unknown so the compiler cannot assume the DB value
  is safe — it must be validated before use.
  - Typed the Knex query with db<MilestoneApprovalRow> to give each row a concrete shape and eliminate the implicit
  any.
  - Added a VALID_STATUSES Set guard that checks both typeof status === 'string' and membership in the
  MilestoneApprovalStatus union before indexing grouped.
  - Rows with an unrecognised status fall back to the pending bucket instead of throwing, keeping the record visible
  to callers rather than silently dropping it.
  
  Testing
  
  - tsc --noEmit reports no errors in verifiers.ts.
  - Pre-existing parse errors in src/db/index.ts, src/middleware/requireJson.ts, and src/routes/milestones.ts are
  unrelated to this change.\
closes #1000