### PR TITLE
fix: use redis for global webhook pause flag instead of filesystem

### DIFF
--- a/src/routes/adminWebhooks.ts
+++ b/src/routes/adminWebhooks.ts
@@ -235,8 +235,8 @@ adminWebhooksRouter.post(
  *
  * Returns the current delivery-pause state.
  */
-adminWebhooksRouter.get('/pause/status', (_req: Request, res: Response) => {
-  res.status(200).json({ paused: isPaused() })
+adminWebhooksRouter.get('/pause/status', async (_req: Request, res: Response) => {
+  res.status(200).json({ paused: await isPaused() })
 })
 
 /**
@@ -246,8 +246,8 @@ adminWebhooksRouter.get('/pause/status', (_req: Request, res: Response) => {
  * outbox and will be dispatched once the system is resumed.  Idempotent —
  * calling while already paused is a no-op.
  */
-adminWebhooksRouter.post('/pause', (req: Request, res: Response) => {
-  pauseDelivery()
+adminWebhooksRouter.post('/pause', async (req: Request, res: Response) => {
+  await pauseDelivery()
 
   createAuditLog({
     actor_user_id: req.user!.userId,
@@ -267,8 +267,8 @@ adminWebhooksRouter.post('/pause', (req: Request, res: Response) => {
  * backlog on its next tick, respecting existing backoff/breaker state.
  * Idempotent — calling while already resumed is a no-op.
  */
-adminWebhooksRouter.post('/resume', (req: Request, res: Response) => {
-  resumeDelivery()
+adminWebhooksRouter.post('/resume', async (req: Request, res: Response) => {
+  await resumeDelivery()
 
   createAuditLog({
     actor_user_id: req.user!.userId,

--- a/src/services/outboxRelay.ts
+++ b/src/services/outboxRelay.ts
@@ -14,7 +14,7 @@ const MAX_ATTEMPTS = 5
  * immediately, leaving all outbox rows untouched for later replay.
  */
 export async function relayOutboxBatch(batchSize = 50): Promise<number> {
-  if (isPaused()) {
+  if (await isPaused()) {
     return 0
   }
   return await db.transaction(async (trx) => {

--- a/src/services/pauseStore.ts
+++ b/src/services/pauseStore.ts
@@ -1,18 +1,61 @@
-import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs'
-import { join } from 'node:path'
-import { tmpdir } from 'node:os'
+import Redis from 'ioredis'
 
-const FLAG_FILE =
-  process.env.WEBHOOK_PAUSE_FLAG_FILE ?? join(tmpdir(), 'disciplr_webhook_pause.flag')
+const GLOBAL_PAUSE_KEY = 'webhook_delivery:global_pause'
 
-export const isPaused = (): boolean => existsSync(FLAG_FILE)
+let sharedRedisClient: Redis | undefined
 
-export const pauseDelivery = (): void =>
-  writeFileSync(FLAG_FILE, new Date().toISOString(), 'utf8')
+const getRedisClient = (): Redis | undefined => {
+  if (sharedRedisClient !== undefined) return sharedRedisClient
 
-export const resumeDelivery = (): void => {
-  if (existsSync(FLAG_FILE)) unlinkSync(FLAG_FILE)
+  const redisUrl = process.env.REDIS_URL
+  if (redisUrl) {
+    sharedRedisClient = new Redis(redisUrl, {
+      maxRetriesPerRequest: 1,
+      enableOfflineQueue: false,
+    })
+    return sharedRedisClient
+  }
+  return undefined
 }
 
-/** Exposed for tests to resolve the active flag path. */
-export const getPauseFlagFile = (): string => FLAG_FILE
+// In-memory fallback if Redis is not configured (e.g. for testing)
+let fallbackInMemoryFlag = false
+
+export const isPaused = async (): Promise<boolean> => {
+  const client = getRedisClient()
+  if (client) {
+    const val = await client.get(GLOBAL_PAUSE_KEY)
+    return val !== null
+  }
+  return fallbackInMemoryFlag
+}
+
+export const pauseDelivery = async (): Promise<void> => {
+  const client = getRedisClient()
+  if (client) {
+    await client.set(GLOBAL_PAUSE_KEY, new Date().toISOString())
+  } else {
+    fallbackInMemoryFlag = true
+  }
+}
+
+export const resumeDelivery = async (): Promise<void> => {
+  const client = getRedisClient()
+  if (client) {
+    await client.del(GLOBAL_PAUSE_KEY)
+  } else {
+    fallbackInMemoryFlag = false
+  }
+}
+
+/** Exposed for tests to reset the fallback memory flag */
+export const resetFallbackFlag = (): void => {
+  fallbackInMemoryFlag = false
+}
+
+export const closePauseStore = async (): Promise<void> => {
+  if (sharedRedisClient) {
+    await sharedRedisClient.quit()
+    sharedRedisClient = undefined
+  }
+}

--- a/src/tests/webhooks.globalPause.test.ts
+++ b/src/tests/webhooks.globalPause.test.ts
@@ -7,23 +7,16 @@
  *  - GET /pause/status, POST /pause, POST /resume route semantics
  *  - Non-admin requests are rejected with 403
  *  - Audit log written on pause and resume
- *  - Pause flag survives across module re-imports (file-backed persistence)
  */
 
 import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals'
-import { existsSync, unlinkSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
-import { tmpdir } from 'node:os'
 import express from 'express'
 import request from 'supertest'
 
-// ── Shared flag file for all tests ────────────────────────────────────────────
-const TEST_FLAG_FILE = join(tmpdir(), `disciplr_webhook_pause_test_${Date.now()}.flag`)
-process.env.WEBHOOK_PAUSE_FLAG_FILE = TEST_FLAG_FILE
-
-const cleanFlag = () => {
-  if (existsSync(TEST_FLAG_FILE)) unlinkSync(TEST_FLAG_FILE)
-}
+// Ensure we don't try to connect to a real Redis in these tests unless we want to,
+// but since we want predictable unit tests, we'll force the fallback memory flag.
+const originalRedisUrl = process.env.REDIS_URL
+process.env.REDIS_URL = ''
 
 // ── All mocks must be declared before any await import() ─────────────────────
 
@@ -85,6 +78,7 @@ jest.unstable_mockModule('../middleware/auth.js', () => ({
 // ── Module-level imports (after mocks, so mocks apply) ────────────────────────
 
 const { adminWebhooksRouter } = await import('../routes/adminWebhooks.js')
+const { resetFallbackFlag } = await import('../services/pauseStore.js')
 
 const app = express()
 app.use(express.json())
@@ -95,54 +89,43 @@ app.use('/api/admin/webhooks', adminWebhooksRouter)
 // ═════════════════════════════════════════════════════════════════════════════
 
 describe('pauseStore', () => {
-  beforeEach(cleanFlag)
-  afterEach(cleanFlag)
+  beforeEach(() => {
+    resetFallbackFlag()
+  })
+  afterEach(() => {
+    resetFallbackFlag()
+  })
 
-  it('isPaused returns false when flag file does not exist', async () => {
+  it('isPaused returns false initially', async () => {
     const { isPaused } = await import('../services/pauseStore.js')
-    expect(isPaused()).toBe(false)
+    expect(await isPaused()).toBe(false)
   })
 
-  it('pauseDelivery creates the flag file', async () => {
+  it('pauseDelivery sets the flag', async () => {
     const { isPaused, pauseDelivery } = await import('../services/pauseStore.js')
-    pauseDelivery()
-    expect(isPaused()).toBe(true)
-    expect(existsSync(TEST_FLAG_FILE)).toBe(true)
+    await pauseDelivery()
+    expect(await isPaused()).toBe(true)
   })
 
-  it('resumeDelivery removes the flag file', async () => {
+  it('resumeDelivery unsets the flag', async () => {
     const { isPaused, pauseDelivery, resumeDelivery } = await import('../services/pauseStore.js')
-    pauseDelivery()
-    expect(isPaused()).toBe(true)
-    resumeDelivery()
-    expect(isPaused()).toBe(false)
-    expect(existsSync(TEST_FLAG_FILE)).toBe(false)
+    await pauseDelivery()
+    expect(await isPaused()).toBe(true)
+    await resumeDelivery()
+    expect(await isPaused()).toBe(false)
   })
 
   it('resumeDelivery is idempotent when not paused', async () => {
     const { resumeDelivery, isPaused } = await import('../services/pauseStore.js')
-    expect(() => resumeDelivery()).not.toThrow()
-    expect(isPaused()).toBe(false)
+    await expect(resumeDelivery()).resolves.not.toThrow()
+    expect(await isPaused()).toBe(false)
   })
 
   it('pauseDelivery is idempotent when already paused', async () => {
     const { pauseDelivery, isPaused } = await import('../services/pauseStore.js')
-    pauseDelivery()
-    expect(() => pauseDelivery()).not.toThrow()
-    expect(isPaused()).toBe(true)
-  })
-
-  it('pause flag survives a re-import (file-backed persistence)', async () => {
-    const { pauseDelivery } = await import('../services/pauseStore.js')
-    pauseDelivery()
-    expect(existsSync(TEST_FLAG_FILE)).toBe(true)
-    const { isPaused: isPaused2 } = await import('../services/pauseStore.js')
-    expect(isPaused2()).toBe(true)
-  })
-
-  it('getPauseFlagFile returns the configured path', async () => {
-    const { getPauseFlagFile } = await import('../services/pauseStore.js')
-    expect(getPauseFlagFile()).toBe(TEST_FLAG_FILE)
+    await pauseDelivery()
+    await expect(pauseDelivery()).resolves.not.toThrow()
+    expect(await isPaused()).toBe(true)
   })
 })
 
@@ -151,11 +134,16 @@ describe('pauseStore', () => {
 // ═════════════════════════════════════════════════════════════════════════════
 
 describe('outboxRelay — paused state', () => {
-  beforeEach(cleanFlag)
-  afterEach(cleanFlag)
+  beforeEach(() => {
+    resetFallbackFlag()
+  })
+  afterEach(() => {
+    resetFallbackFlag()
+  })
 
   it('returns 0 and skips dispatch when paused', async () => {
-    writeFileSync(TEST_FLAG_FILE, new Date().toISOString(), 'utf8')
+    const { pauseDelivery } = await import('../services/pauseStore.js')
+    await pauseDelivery()
 
     const { relayOutboxBatch } = await import('../services/outboxRelay.js')
     const { dispatchWebhookEvent } = await import('../services/webhooks.js') as any
@@ -172,8 +160,12 @@ describe('outboxRelay — paused state', () => {
 // ═════════════════════════════════════════════════════════════════════════════
 
 describe('GET /api/admin/webhooks/pause/status', () => {
-  beforeEach(cleanFlag)
-  afterEach(cleanFlag)
+  beforeEach(() => {
+    resetFallbackFlag()
+  })
+  afterEach(() => {
+    resetFallbackFlag()
+  })
 
   it('returns paused: false when flag is absent', async () => {
     const res = await request(app)
@@ -184,7 +176,8 @@ describe('GET /api/admin/webhooks/pause/status', () => {
   })
 
   it('returns paused: true when flag is present', async () => {
-    writeFileSync(TEST_FLAG_FILE, new Date().toISOString(), 'utf8')
+    const { pauseDelivery } = await import('../services/pauseStore.js')
+    await pauseDelivery()
     const res = await request(app)
       .get('/api/admin/webhooks/pause/status')
       .set('Authorization', 'Bearer admin')
@@ -206,16 +199,17 @@ describe('GET /api/admin/webhooks/pause/status', () => {
 })
 
 describe('POST /api/admin/webhooks/pause', () => {
-  beforeEach(() => { cleanFlag(); createAuditLog.mockClear() })
-  afterEach(cleanFlag)
+  beforeEach(() => { resetFallbackFlag(); createAuditLog.mockClear() })
+  afterEach(() => { resetFallbackFlag() })
 
-  it('creates the flag file and returns paused: true', async () => {
+  it('creates the flag and returns paused: true', async () => {
     const res = await request(app)
       .post('/api/admin/webhooks/pause')
       .set('Authorization', 'Bearer admin')
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ paused: true })
-    expect(existsSync(TEST_FLAG_FILE)).toBe(true)
+    const { isPaused } = await import('../services/pauseStore.js')
+    expect(await isPaused()).toBe(true)
   })
 
   it('is idempotent — calling twice stays paused', async () => {
@@ -240,27 +234,30 @@ describe('POST /api/admin/webhooks/pause', () => {
     )
   })
 
-  it('rejects non-admin with 403 and does not create flag', async () => {
+  it('rejects non-admin with 403 and does not pause', async () => {
     const res = await request(app)
       .post('/api/admin/webhooks/pause')
       .set('Authorization', 'Bearer user')
     expect(res.status).toBe(403)
-    expect(existsSync(TEST_FLAG_FILE)).toBe(false)
+    const { isPaused } = await import('../services/pauseStore.js')
+    expect(await isPaused()).toBe(false)
   })
 })
 
 describe('POST /api/admin/webhooks/resume', () => {
-  beforeEach(() => { cleanFlag(); createAuditLog.mockClear() })
-  afterEach(cleanFlag)
+  beforeEach(() => { resetFallbackFlag(); createAuditLog.mockClear() })
+  afterEach(() => { resetFallbackFlag() })
 
-  it('removes the flag file and returns paused: false', async () => {
-    writeFileSync(TEST_FLAG_FILE, new Date().toISOString(), 'utf8')
+  it('removes the flag and returns paused: false', async () => {
+    const { pauseDelivery } = await import('../services/pauseStore.js')
+    await pauseDelivery()
     const res = await request(app)
       .post('/api/admin/webhooks/resume')
       .set('Authorization', 'Bearer admin')
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ paused: false })
-    expect(existsSync(TEST_FLAG_FILE)).toBe(false)
+    const { isPaused } = await import('../services/pauseStore.js')
+    expect(await isPaused()).toBe(false)
   })
 
   it('is idempotent — resuming when not paused is a no-op', async () => {
@@ -272,7 +269,8 @@ describe('POST /api/admin/webhooks/resume', () => {
   })
 
   it('writes an audit log entry on resume', async () => {
-    writeFileSync(TEST_FLAG_FILE, new Date().toISOString(), 'utf8')
+    const { pauseDelivery } = await import('../services/pauseStore.js')
+    await pauseDelivery()
     await request(app)
       .post('/api/admin/webhooks/resume')
       .set('Authorization', 'Bearer admin')
@@ -286,18 +284,20 @@ describe('POST /api/admin/webhooks/resume', () => {
   })
 
   it('rejects non-admin with 403 and leaves flag in place', async () => {
-    writeFileSync(TEST_FLAG_FILE, new Date().toISOString(), 'utf8')
+    const { pauseDelivery } = await import('../services/pauseStore.js')
+    await pauseDelivery()
     const res = await request(app)
       .post('/api/admin/webhooks/resume')
       .set('Authorization', 'Bearer user')
     expect(res.status).toBe(403)
-    expect(existsSync(TEST_FLAG_FILE)).toBe(true)
+    const { isPaused } = await import('../services/pauseStore.js')
+    expect(await isPaused()).toBe(true)
   })
 })
 
 describe('pause → resume → status cycle', () => {
-  beforeEach(cleanFlag)
-  afterEach(cleanFlag)
+  beforeEach(() => { resetFallbackFlag() })
+  afterEach(() => { resetFallbackFlag() })
 
   it('status transitions correctly through pause → resume', async () => {
     let res = await request(app)


### PR DESCRIPTION
Closes #1035 


Previously, the global webhook-delivery kill switch (isPaused, pauseDelivery, resumeDelivery in pauseStore.ts) was implemented using a flag file on the local filesystem. In horizontally scaled deployments, calling pauseDelivery() on one instance only created a flag file locally on that single container. This resulted in operators believing webhook delivery was fully paused, while other instances continued delivering normally.

Fix:
This PR transitions the global webhook pause switch to be backed by a shared cache (Redis), effectively resolving the multi-instance scaling issue. 

Changes Include:
- Refactored pauseStore.ts to use ioredis to manage a shared key (webhook_delivery:global_pause). An in-memory fallback acts as a failsafe when Redis is unavailable (e.g. for deterministic unit testing).
- pauseStore methods are now async, requiring updates to callers.
- Updated src/services/outboxRelay.ts and src/routes/adminWebhooks.ts to correctly await the new async pause store functions.
- Updated the test suite (src/tests/webhooks.globalPause.test.ts) to account for the async behavior and dropping fs-based assertions.