### PR TITLE
fix(enqueueOptions): validate input for delayMs and maxAttempts in pa…

### DIFF
--- a/src/jobs/enqueueOptions.ts
+++ b/src/jobs/enqueueOptions.ts
@@ -5,9 +5,45 @@ export interface EnqueueOptionInput {
   maxAttempts?: number
 }
 
-export const parseEnqueueOptions = (input: EnqueueOptionInput): EnqueueOptions => {
+const isValidMaxAttempts = (maxAttempts: unknown): maxAttempts is number => {
+  return (
+    typeof maxAttempts === 'number' &&
+    Number.isInteger(maxAttempts) &&
+    maxAttempts >= 1 &&
+    maxAttempts <= 10
+  )
+}
+
+export const parseEnqueueOptions = (input: EnqueueOptionInput): EnqueueOptions | null => {
+  const delayMs = input.delayMs
+  if (delayMs !== undefined) {
+    if (typeof delayMs !== 'number' || !Number.isFinite(delayMs)) {
+      return null
+    }
+
+    const normalizedDelayMs = Math.floor(delayMs)
+    if (normalizedDelayMs < 0) {
+      return null
+    }
+
+    const maxAttempts = input.maxAttempts
+    if (maxAttempts !== undefined && !isValidMaxAttempts(maxAttempts)) {
+      return null
+    }
+
+    return {
+      delayMs: normalizedDelayMs,
+      maxAttempts,
+    }
+  }
+
+  const maxAttempts = input.maxAttempts
+  if (maxAttempts !== undefined && !isValidMaxAttempts(maxAttempts)) {
+    return null
+  }
+
   return {
-    delayMs: input.delayMs !== undefined ? Math.floor(input.delayMs) : undefined,
-    maxAttempts: input.maxAttempts,
+    delayMs: undefined,
+    maxAttempts,
   }
 }

--- a/src/tests/enqueueOptions.test.ts
+++ b/src/tests/enqueueOptions.test.ts
@@ -6,6 +6,7 @@ import { generateAccessToken } from '../lib/auth-utils.js'
 import { UserRole } from '../types/user.js'
 import { createJobsRouter } from '../routes/jobs.js'
 import { BackgroundJobSystem } from '../jobs/system.js'
+import { parseEnqueueOptions } from '../jobs/enqueueOptions.js'
 
 const noopLimiter = (_req: Request, _res: Response, next: NextFunction) => next()
 
@@ -153,4 +154,15 @@ describe('Jobs API Zod Validation - POST /api/jobs/enqueue', () => {
 
     expect(resAbove.body.success).toBe(false)
     expect(resAbove.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns null for invalid enqueue option values', () => {
+    expect(parseEnqueueOptions({ delayMs: -1 })).toBeNull()
+    expect(parseEnqueueOptions({ delayMs: NaN })).toBeNull()
+    expect(parseEnqueueOptions({ maxAttempts: 0 })).toBeNull()
+    expect(parseEnqueueOptions({ maxAttempts: 11 })).toBeNull()
+    expect(parseEnqueueOptions({ maxAttempts: 3.5 })).toBeNull()
+    expect(parseEnqueueOptions({ delayMs: 1000, maxAttempts: 5 })).toEqual({ delayMs: 1000, maxAttempts: 5 })
+  })
+})
  


### PR DESCRIPTION
Closes #1027 

This pull request updates `parseEnqueueOptions` to perform the validation described by its documented behavior and the API error messages. Previously, the function accepted all input values without validation, allowing invalid enqueue options such as negative delays or out-of-range retry counts to pass through. The implementation now enforces the expected constraints before returning parsed options.

## Changes
- Added validation to ensure `delayMs` is greater than or equal to `0`.
- Added validation to ensure `maxAttempts` is an integer between `1` and `10` (inclusive).
- Updated `parseEnqueueOptions` to return `null` when validation fails, allowing the route handler to respond with the existing `400 Bad Request` error.
- Aligned the implementation with the documented API contract and error messaging.

## Benefits
- Prevents invalid enqueue requests from entering the job queue.
- Ensures API behavior matches its documented validation rules.
- Improves input validation and overall reliability.
- Makes the validation logic predictable for contributors and API consumers.

## Testing
- ✅ Valid enqueue options are accepted.
- ✅ Negative `delayMs` values are rejected.
- ✅ Non-integer `maxAttempts` values are rejected.
- ✅ `maxAttempts` values outside the range `1–10` are rejected.
- ✅ Invalid input triggers the existing `400 Bad Request` response.
```