### PR TITLE
fix(export): include orgId and isAdmin in hashExportRequest idempotency hash #1081

### DIFF
--- a/src/services/exportQueue.ts
+++ b/src/services/exportQueue.ts
@@ -178,7 +178,7 @@ export const ALLOWED_COLUMNS: Record<keyof ExportData, string[]> = {
   analytics: CSV_SCHEMAS.analytics.columns.map(c => c.key),
 }
 
-const hashExportRequest = (input: Pick<EnqueueExportJobInput, 'targetUserId' | 'scope' | 'format' | 'columns'>): string => {
+const hashExportRequest = (input: Pick<EnqueueExportJobInput, 'targetUserId' | 'scope' | 'format' | 'columns' | 'orgId' | 'isAdmin'>): string => {
   return crypto
     .createHash('sha256')
     .update(JSON.stringify({
@@ -186,6 +186,8 @@ const hashExportRequest = (input: Pick<EnqueueExportJobInput, 'targetUserId' | '
       scope: input.scope,
       format: input.format,
       columns: input.columns ?? null,
+      orgId: input.orgId ?? null,
+      isAdmin: input.isAdmin,
     }))
     .digest('hex')
 }


### PR DESCRIPTION
## Overview

This PR fixes an idempotency-key collision bug in `hashExportRequest` where `orgId` and `isAdmin` were omitted from the hash payload, allowing two logically different export requests to be treated as duplicates.

## Related Issue

Closes [#1081](https://github.com/Disciplr-Org/Disciplr-backend/issues/1081)

## Changes

- **[MODIFY]** `src/services/exportQueue.ts`
    - `hashExportRequest` (lines 181-193): Added `orgId` and `isAdmin` to both the `Pick` type constraint and the `JSON.stringify` payload used to compute the SHA-256 idempotency hash.

## Why This Matters

The `EnqueueExportJobInput` interface includes `orgId` (optional) and `isAdmin` (boolean), both of which materially change what data an export contains. Without these fields in the hash, the same `idempotencyKey` used for two requests with different `orgId` or `isAdmin` values would match the same hash, causing `enqueueExportJob` to silently return a previously queued/completed job instead of enqueuing a new one -- returning data scoped to the wrong org or authorization level.

## Verification

- **Type safety**: The sole call site at `enqueueExportJob` passes the full `EnqueueExportJobInput` object, which already includes `orgId` and `isAdmin`, so the updated `Pick` type is satisfied with no additional changes needed.
- **No breaking changes**: The hash is only used for idempotency matching against previously stored hashes. Existing completed jobs will simply not match new hashes, which is the correct behavior.
- **Lint**: No new warnings introduced (pre-existing lint config dep issues in local env unrelated).