### PR TITLE
drain window configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,3 +148,8 @@ WEBHOOK_CIRCUIT_BREAKER_WINDOW_MS=60000
 
 # Circuit breaker: time before an OPEN breaker transitions to HALF_OPEN (default: 30000).
 WEBHOOK_CIRCUIT_BREAKER_HALF_OPEN_TIMEOUT_MS=30000
+
+# ── Graceful shutdown ──────────────────────────────────────────────────────────
+# How long (ms) to wait for in-flight HTTP requests to finish before
+# force-destroying sockets during SIGTERM shutdown (default: 30000).
+SHUTDOWN_DRAIN_MS=30000

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -246,6 +246,11 @@ export const envSchema = z
     HTTP_HEADERS_TIMEOUT_MS: positiveInt(61_000),
     HTTP_REQUEST_TIMEOUT_MS: positiveInt(120_000),
 
+    // ── Graceful shutdown ──────────────────────────────────
+    // Maximum time (ms) to wait for in-flight HTTP requests to
+    // complete before force-destroying sockets during shutdown.
+    SHUTDOWN_DRAIN_MS: positiveInt(30_000),
+
     // ── OpenTelemetry / Tracing ───────────────────────────────────
     OTEL_EXPORTER_OTLP_ENDPOINT: z.string().optional(),
     OTEL_SERVICE_NAME: z.string().optional(),

--- a/src/server/shutdown.ts
+++ b/src/server/shutdown.ts
@@ -64,7 +64,7 @@ export function createShutdownHandler(options: ShutdownOptions) {
       // 1.5 Enter HTTP drain mode: stop accepting new requests at middleware level
       try {
         const env = getEnv();
-        const drainMs = env.SHUTDOWN_DRAIN_MS ?? 30_000;
+        const drainMs = env.SHUTDOWN_DRAIN_MS;
         console.log(
           `[Shutdown] Entering HTTP drain mode (waiting up to ${drainMs}ms for in-flight requests)`,
         );

--- a/src/tests/serverShutdown.test.ts
+++ b/src/tests/serverShutdown.test.ts
@@ -1,10 +1,18 @@
+import { _resetEnvForTesting, initEnv } from '../config/env.js'
 import supertest from 'supertest'
 import { app } from '../app.js'
 import { createShutdownHandler } from '../server/shutdown.js'
 
+beforeAll(() => {
+  _resetEnvForTesting()
+  initEnv({
+    DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/postgres',
+    SHUTDOWN_DRAIN_MS: '1000',
+  })
+})
+
 describe('shutdown drain', () => {
   test('waits for in-flight request to complete before closing', async () => {
-    process.env.SHUTDOWN_DRAIN_MS = '1000'
 
     // Simple long-running handler
     app.get('/__test_long', (_req, res) => {


### PR DESCRIPTION
Closes #1008 
1. src/config/env.ts:249-252 — SHUTDOWN_DRAIN_MS added as positiveInt(30_000) in a new "Graceful shutdown" section after the HTTP timeouts
2. src/server/shutdown.ts:67 — No longer has ?? 30_000 fallback; reads env.SHUTDOWN_DRAIN_MS directly
3. src/tests/serverShutdown.test.ts:1-12 — Imports _resetEnvForTesting/initEnv, calls them in beforeAll with a minimal env including SHUTDOWN_DRAIN_MS='1000'
4. .env.example:152-155 — Documented with comment explaining the default and purpose