### PR TITLE
fix(admin-webhooks): clamp dead-letters limit to max 100

### DIFF
--- a/src/routes/adminWebhooks.ts
+++ b/src/routes/adminWebhooks.ts
@@ -29,7 +29,8 @@ adminWebhooksRouter.use(requireAdmin)
 
 adminWebhooksRouter.get('/dead-letters', async (req: Request, res: Response) => {
   try {
-    const limit = req.query.limit ? Number(req.query.limit) : 50
+    const rawLimit = req.query.limit ? parseInt(String(req.query.limit), 10) : 50
+    const limit = Math.min(100, Number.isNaN(rawLimit) || rawLimit < 1 ? 50 : rawLimit)
     const offset = req.query.offset ? Number(req.query.offset) : 0
 
     const query = db('webhook_dead_letters').orderBy('failed_at', 'desc')

--- a/src/tests/adminWebhooks.replay.test.ts
+++ b/src/tests/adminWebhooks.replay.test.ts
@@ -506,3 +506,66 @@ describe('POST /api/admin/webhooks/:id/replay', () => {
     )
   })
 })
+
+describe('GET /api/admin/webhooks/dead-letters', () => {
+  beforeEach(() => {
+    resetStores()
+    jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('caps an over-large ?limit= at the maximum of 100', async () => {
+    const sub = addTestSubscriber()
+    addDeadLetter(sub.id)
+
+    const res = await request(app)
+      .get('/api/admin/webhooks/dead-letters')
+      .query({ limit: 999999 })
+      .set('Authorization', 'Bearer admin')
+
+    expect(res.status).toBe(200)
+    expect(res.body.limit).toBe(100)
+  })
+
+  it('falls back to the default limit for non-numeric input', async () => {
+    const sub = addTestSubscriber()
+    addDeadLetter(sub.id)
+
+    const res = await request(app)
+      .get('/api/admin/webhooks/dead-letters')
+      .query({ limit: 'not-a-number' })
+      .set('Authorization', 'Bearer admin')
+
+    expect(res.status).toBe(200)
+    expect(res.body.limit).toBe(50)
+  })
+
+  it('falls back to the default limit for negative input', async () => {
+    const sub = addTestSubscriber()
+    addDeadLetter(sub.id)
+
+    const res = await request(app)
+      .get('/api/admin/webhooks/dead-letters')
+      .query({ limit: -5 })
+      .set('Authorization', 'Bearer admin')
+
+    expect(res.status).toBe(200)
+    expect(res.body.limit).toBe(50)
+  })
+
+  it('respects a valid limit within the allowed range', async () => {
+    const sub = addTestSubscriber()
+    addDeadLetter(sub.id)
+
+    const res = await request(app)
+      .get('/api/admin/webhooks/dead-letters')
+      .query({ limit: 10 })
+      .set('Authorization', 'Bearer admin')
+
+    expect(res.status).toBe(200)
+    expect(res.body.limit).toBe(10)
+  })
+})


### PR DESCRIPTION
req.query.limit was passed straight through to Number() with no upper bound, letting a caller request an unbounded number of rows. Clamp it the same way src/routes/transactions.ts clamps its cursor-pagination limit (Math.min against a max of 100), and fall back to the default of 50 for non-numeric or non-positive input since this route has no upstream queryParser validation to rely on.

Closes #1025