### PR TITLE
fix: use shared resolveETLConfig in admin ETL endpoints

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -48,6 +48,7 @@ import { runReindexBatches, EMBEDDING_REINDEX_JOB_NAME } from '../services/evide
 import { MilestoneRepository } from '../repositories/milestoneRepository.js'
 import { BackfillCursorStore } from '../services/backfillCursorStore.js'
 import { TransactionETLService } from '../services/transactionETL.js'
+import { resolveETLConfig } from '../services/etlWorker.js'
 
 export const adminRouter = Router()
 
@@ -652,7 +653,8 @@ adminRouter.post('/overrides/vaults/:id/cancel', requireStepUp(), async (req, re
 
 adminRouter.get('/transaction-etl/drift-report', async (req, res) => {
   try {
-    const etl = new TransactionETLService({ horizonUrl: process.env.HORIZON_URL || 'https://horizon-testnet.stellar.org', batchSize: Number(req.query.batchSize) || 50 })
+    const config = resolveETLConfig()
+    const etl = new TransactionETLService({ ...config, batchSize: Number(req.query.batchSize) || 50 })
     const report = await etl.reconcileVaults()
     res.status(200).json(report)
   } catch (error) {
@@ -664,7 +666,8 @@ adminRouter.get('/transaction-etl/drift-report', async (req, res) => {
 adminRouter.post('/vaults/:id/auto-repair', requireStepUp(), async (req, res) => {
   try {
     const { id } = req.params
-    const etl = new TransactionETLService({ horizonUrl: process.env.HORIZON_URL || 'https://horizon-testnet.stellar.org', batchSize: 50 })
+    const config = resolveETLConfig()
+    const etl = new TransactionETLService({ ...config, batchSize: 50 })
     
     const result = await etl.autoRepairVault(id, req.user!.userId)
     


### PR DESCRIPTION

What changed:

GET /transaction-etl/drift-report now builds its config from resolveETLConfig(), overriding only batchSize from the query param.

POST /vaults/:id/auto-repair does the same, overriding batchSize to 50.

Both endpoints now always get networkPassphrase and maxRetries from the same source as the ETL worker, so there's one place this config can be defined, not two.

Only src/routes/admin.ts changed, 5 insertions and 2 deletions. etlWorker.ts didn't need any changes since resolveETLConfig() was already exported and correct.

Testing:

tsc --noEmit no longer reports the TS2345 errors at either call site.

npm test: I did a direct before/after comparison against main to be sure this change introduces no regressions. Numbers are identical on both branches: 66 suites passed, 149 failed, 4 skipped, 1226 tests passed, 211 failed, 39 skipped. The failures are pre-existing and unrelated to this fix, mostly a mix of a parser error in a few unrelated files and about 18 files written for Bun's test runner that don't work under Jest. Neither exists because of this change.

npm run build fails with the same 7 pre-existing parser errors that exist on main, unrelated to this fix.

Closes #995




[Claude is](https://support.anthropic.com/en/articles/8525154-claude-is-providing-incorrect-or-misleading-responses-what-s-going-on)