### PR TITLE
fix: use named Redis import in rateLimiter.ts (#984)

### DIFF
--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -2,7 +2,7 @@ import rateLimit, { ipKeyGenerator } from 'express-rate-limit'
 import type { Request, Response, NextFunction } from 'express'
 import { redactApiKeyForLogs } from '../services/apiKeys.js'
 import { getEnv } from '../config/index.js'
-import Redis from 'ioredis'
+import { Redis } from 'ioredis'
 import { RedisStore } from './rateLimitStore.js'
 
 export interface RateLimitConfig {


### PR DESCRIPTION
closes #984 
Replace default import 'import Redis from ioredis' with named import 'import { Redis } from ioredis' to fix TS2709, TS2351, and TS2322 under NodeNext module resolution. Consistent with the same fix in src/lib/cache.ts and src/middleware/rateLimitStore.ts.