### PR TITLE
Schedule milestone reminder jobs in BackgroundJobSystem

### DIFF
--- a/.delete_task1085_placeholder
+++ b/.delete_task1085_placeholder
@@ -1,0 +1,1 @@
+placeholder

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -175,6 +175,9 @@ export const envSchema = z
     JOB_QUEUE_POLL_INTERVAL_MS: positiveInt(250),
     JOB_HISTORY_LIMIT: positiveInt(50),
     ENABLE_JOB_SCHEDULER: z.string().optional(),
+    MILESTONE_REMINDERS_INTERVAL_MS: positiveInt(15 * 60_000),
+    MILESTONE_REMINDERS_DIGEST_INTERVAL_MS: positiveInt(15 * 60_000),
+    MILESTONE_REMINDERS_DEFERRED_INTERVAL_MS: positiveInt(5 * 60_000),
     NOTIFICATION_PROVIDER: z.enum(["email", "console"]).default("console"),
 
     // ── SMTP / Email provider ────────────────────────────────────

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -26,19 +26,16 @@ const knexConfig = {
 
 export const db = knex(knexConfig)
 
-const sslEnabled = process.env.NODE_ENV === 'production' || process.env.DATABASE_SSL === 'true'
+const sslEnabled = getEnv().NODE_ENV === 'production' || process.env.DATABASE_SSL === 'true'
 const rejectUnauthorized = process.env.DATABASE_SSL_REJECT_UNAUTHORIZED !== 'false'
 
-export const pool = new pg.Pool({
-    connectionString: process.env.DATABASE_URL,
-    ssl: sslEnabled
-      ? rejectUnauthorized
-        ? { rejectUnauthorized: true }
-        : { rejectUnauthorized: false }
-      : false,
 export const pool = new Pool({
-    connectionString: getEnv().DATABASE_URL,
-    ssl: getEnv().NODE_ENV === 'production' ? { rejectUnauthorized: true } : false
+  connectionString: getEnv().DATABASE_URL,
+  ssl: sslEnabled
+    ? rejectUnauthorized
+      ? { rejectUnauthorized: true }
+      : { rejectUnauthorized: false }
+    : false,
 })
 
 export default db

--- a/src/jobs/system.ts
+++ b/src/jobs/system.ts
@@ -312,6 +312,18 @@ export class BackgroundJobSystem {
       process.env.ANALYTICS_REPORT_INTERVAL_MS,
       24 * 60 * 60_000, // 24 hours
     )
+    const milestoneRemindersIntervalMs = parsePositiveInteger(
+      process.env.MILESTONE_REMINDERS_INTERVAL_MS,
+      15 * 60_000, // 15 minutes
+    )
+    const milestoneRemindersDigestIntervalMs = parsePositiveInteger(
+      process.env.MILESTONE_REMINDERS_DIGEST_INTERVAL_MS,
+      15 * 60_000, // 15 minutes
+    )
+    const milestoneRemindersDeferredIntervalMs = parsePositiveInteger(
+      process.env.MILESTONE_REMINDERS_DEFERRED_INTERVAL_MS,
+      5 * 60_000, // 5 minutes
+    )
 
     this.schedulerRegistry.registerJob({
       name: 'deadline.check',
@@ -401,6 +413,36 @@ export class BackgroundJobSystem {
       immediate: false,
       execute: () => {
         this.enqueue('saved-search.evaluate', {})
+      },
+    })
+
+    this.schedulerRegistry.registerJob({
+      name: 'milestone.reminders',
+      intervalMs: milestoneRemindersIntervalMs,
+      immediate: true,
+      initialDelayMs: 5_000,
+      execute: () => {
+        this.enqueue('milestone.reminders', {})
+      },
+    })
+
+    this.schedulerRegistry.registerJob({
+      name: 'milestone.reminders.digest',
+      intervalMs: milestoneRemindersDigestIntervalMs,
+      immediate: true,
+      initialDelayMs: 10_000,
+      execute: () => {
+        this.enqueue('milestone.reminders.digest', {})
+      },
+    })
+
+    this.schedulerRegistry.registerJob({
+      name: 'milestone.reminders.deferred',
+      intervalMs: milestoneRemindersDeferredIntervalMs,
+      immediate: true,
+      initialDelayMs: 15_000,
+      execute: () => {
+        this.enqueue('milestone.reminders.deferred', {})
       },
     })
 

--- a/src/services/organization.ts
+++ b/src/services/organization.ts
@@ -19,3 +19,7 @@ export const getOrganizationById = async (id: string): Promise<Organization | nu
 export const getOrganizationBySlug = async (slug: string): Promise<Organization | null> => {
   return db('organizations').where({ slug }).first()
 }
+
+export const listOrganizations = async (): Promise<Organization[]> => {
+  return db('organizations').select('*')
+}

--- a/src/tests/jobs.scheduler.test.ts
+++ b/src/tests/jobs.scheduler.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { initEnv } from '../config/env.js'
+
+process.env.NODE_ENV = 'test'
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://localhost/test'
+process.env.DOWNLOAD_SECRET = process.env.DOWNLOAD_SECRET || 'test-download-secret'
+process.env.ENABLE_JOB_SCHEDULER = 'true'
+initEnv(process.env)
+
+const { BackgroundJobSystem } = await import('../jobs/system.js')
+
+describe('BackgroundJobSystem scheduler registration', () => {
+  beforeEach(() => {
+    process.env.MILESTONE_REMINDERS_INTERVAL_MS = '900000'
+    process.env.MILESTONE_REMINDERS_DIGEST_INTERVAL_MS = '900000'
+    process.env.MILESTONE_REMINDERS_DEFERRED_INTERVAL_MS = '300000'
+  })
+
+  afterEach(() => {
+    delete process.env.MILESTONE_REMINDERS_INTERVAL_MS
+    delete process.env.MILESTONE_REMINDERS_DIGEST_INTERVAL_MS
+    delete process.env.MILESTONE_REMINDERS_DEFERRED_INTERVAL_MS
+  })
+
+  it('registers milestone reminder jobs when the scheduler is enabled', () => {
+    const system = new BackgroundJobSystem()
+
+    // @ts-ignore Access private scheduler initialization helper for testing.
+    ;(system as any).scheduleRecurringJobs()
+
+    const scheduledJobs = (system as any).schedulerRegistry.scheduledJobs as Map<string, unknown>
+
+    expect(Array.from(scheduledJobs.keys())).toEqual(
+      expect.arrayContaining([
+        'milestone.reminders',
+        'milestone.reminders.digest',
+        'milestone.reminders.deferred',
+      ]),
+    )
+  })
+})


### PR DESCRIPTION
Close #1085 

PR Summary
What changed

    Registered recurring scheduler jobs for:
        [milestone.reminders](https://supreme-lamp-7vqgg9gqgpr7fr9wx.github.dev/)
        [milestone.reminders.digest](https://supreme-lamp-7vqgg9gqgpr7fr9wx.github.dev/)
        [milestone.reminders.deferred](https://supreme-lamp-7vqgg9gqgpr7fr9wx.github.dev/)
    Added environment schema support for milestone reminder scheduler intervals:
        [MILESTONE_REMINDERS_INTERVAL_MS](https://supreme-lamp-7vqgg9gqgpr7fr9wx.github.dev/)
        [MILESTONE_REMINDERS_DIGEST_INTERVAL_MS](https://supreme-lamp-7vqgg9gqgpr7fr9wx.github.dev/)
        [MILESTONE_REMINDERS_DEFERRED_INTERVAL_MS](https://supreme-lamp-7vqgg9gqgpr7fr9wx.github.dev/)
    Added regression coverage confirming milestone reminder jobs are registered when scheduler is enabled.

Testing

    [npm test -- --runInBand src/tests/jobs.scheduler.test.ts](https://supreme-lamp-7vqgg9gqgpr7fr9wx.github.dev/)

Notes

    This change enables milestone reminder delivery to actually schedule and fire in production.
    The fix also included minor test environment support adjustments needed to validate the scheduler behavior.