### PR TITLE
fix: restore syntax error in requireJson middleware

### DIFF
--- a/src/middleware/requireJson.ts
+++ b/src/middleware/requireJson.ts
@@ -5,16 +5,6 @@ export interface RequireJsonOptions {
   maxBytes?: number
 }
 
-  const contentLength = req.headers['content-length']
-  const transferEncoding = req.headers['transfer-encoding']
-  const hasBody = (contentLength && parseInt(contentLength, 10) > 0) || 
-                   (transferEncoding && transferEncoding.toLowerCase() !== 'identity')
-  const contentType = req.headers['content-type']
-  
-  if (!contentType) {
-    return res.status(415).json({
-      error: 'Unsupported Media Type: Content-Type must be application/json'
-    })
 const bodylessMethods = new Set(['GET', 'HEAD', 'OPTIONS'])
 
 const parseContentLength = (contentLength: string | string[] | undefined): number | null => {


### PR DESCRIPTION
Fixes #1068

Removed an orphaned, unclosed code block in `requireJson.ts` that was
causing a TS1005 syntax error and breaking app startup. The duplicate
logic was already correctly implemented inside `buildRequireJsonMiddleware`.

Verified: `auth.loginBypass.test.ts` now passes (2/2)