### PR TITLE
fix: resolve TS2304 missing type imports in soroban.ts

### DIFF
--- a/src/services/soroban.ts
+++ b/src/services/soroban.ts
@@ -1,4 +1,4 @@
-import type { CreateVaultInput, PersistedVault, VaultCreateResponse } from '../types/vaults.js'
+import type { CreateVaultInput, PersistedVault, VaultCreateResponse, StakeInput, StakeResponse, StakeWithMemoInput, StakeWithMemoResponse } from '../types/vaults.js'
 import { retryWithBackoff, sleep, type RetryConfig } from '../utils/retry.js'
 import { StrKey } from '@stellar/stellar-sdk'
 import { AppError, SorobanTimeoutError } from '../middleware/errorHandler.js'


### PR DESCRIPTION
Resolves a build failure where stake-related types were referenced but not imported in src/services/soroban.ts.

Appended StakeInput, StakeResponse, StakeWithMemoInput, and StakeWithMemoResponse to the existing ../types/vaults.js import.

Verified successful build with npx tsc --noEmit.

Closes #976