### PR TITLE
fix(vaultValidation): surface getClassicAddress decode failure to pre…

### DIFF
--- a/src/services/vaultValidation.test.ts
+++ b/src/services/vaultValidation.test.ts
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+import { getClassicAddress } from './vaultValidation.js'
+
+describe('getClassicAddress', () => {
+  it('returns original address for valid classic address', () => {
+    const classic = 'GAP3SREQTGBQADRB5QUVLWC4RZZ62MFMQZ5CCEYMMCVQF7GFREISGZGL'
+    expect(getClassicAddress(classic)).toBe(classic)
+  })
+
+  it('decodes and returns classic address for valid muxed address', () => {
+    const muxed = 'MAP3SREQTGBQADRB5QUVLWC4RZZ62MFMQZ5CCEYMMCVQF7GFREISHLPU'
+    const expectedClassic = 'GAP3SREQTGBQADRB5QUVLWC4RZZ62MFMQZ5CCEYMMCVQF7GFREISGZGL'
+    expect(getClassicAddress(muxed)).toBe(expectedClassic)
+  })
+
+  it('throws an error for malformed muxed address', () => {
+    const malformed = 'M1234567890'
+    expect(() => getClassicAddress(malformed)).toThrow('Invalid muxed address format')
+  })
+
+  it('returns original string for non-muxed, non-classic unrecognized strings', () => {
+    const randomStr = 'random_string'
+    expect(getClassicAddress(randomStr)).toBe(randomStr)
+  })
+})

--- a/src/services/vaultValidation.ts
+++ b/src/services/vaultValidation.ts
@@ -20,13 +20,13 @@ export const VAULT_MILESTONES_MIN = 1
 export const VAULT_MILESTONES_MAX = 20
 
 export function getClassicAddress(address: string): string {
-  try {
-    if (StrKey.isValidMed25519PublicKey(address)) {
+  if (address.startsWith('M')) {
+    try {
       const decoded = StrKey.decodeMed25519PublicKey(address)
       return StrKey.encodeEd25519PublicKey(decoded.slice(0, 32))
+    } catch {
+      throw new Error(`Invalid muxed address format`);
     }
-  } catch {
-    // ignore
   }
   return address
 }


### PR DESCRIPTION
# Fix: Prevent Malformed Muxed Addresses from Bypassing Memo Checks

## Resolves
Fixes #1289: `getClassicAddress` silently returns original address on decode error, masking malformed input.

## Description
This pull request addresses a validation flaw in `src/services/vaultValidation.ts` where the `getClassicAddress` function attempted to decode a muxed (`M...`) address down to its underlying classic (`G...`) key, but silently fell through and returned the original string if any decoding exceptions occurred (e.g., throwing a malformed string check).

Because the resulting string was blindly used as a lookup against `MEMO_REQUIRED_EXCHANGES.has(...)`, a maliciously malformed muxed address string that deliberately failed decoding could completely bypass the exchange-memo-requirement check entirely (as a raw muxed string would never match a stored classic exchange address).

### Changes
*   **Fail-Fast Validation**: Modified `getClassicAddress` to throw a strict `Error('Invalid muxed address format')` if a string starting with an `M` throws any exception during `StrKey.decodeMed25519PublicKey`. 
*   **Regression Tests Added**: Added `vaultValidation.test.ts` implementing a full matrix of verification tests ensuring:
    1.  Valid classic (`G...`) addresses decode untouched.
    2.  Valid muxed (`M...`) addresses securely unpack into classic addresses.
    3.  **Malformed muxed addresses correctly throw surface-level validation errors.**
    4.  Arbitrary/non-crypto string flows securely bypass decoding logic gracefully.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing Checklist
- [x] Regression tests added for `getClassicAddress` validating muxed bypass prevention.
- [x] `npm run test:vault-validation` successfully passes without checksum anomalies.
- [x] Checked that linter and types compile successfully locally.

Closes #1289