### PR TITLE
fix: add SDK constructor check and per-row decryption error handling

### DIFF
--- a/src/repositories/webhookSubscriberRepository.ts
+++ b/src/repositories/webhookSubscriberRepository.ts
@@ -1,7 +1,7 @@
 import { Knex } from 'knex'
 import type { WebhookSubscriber, BreakerState, BreakerStateValue } from '../services/webhooks.js'
 import { FieldPolicy, parseFieldPolicy, DEFAULT_FIELD_POLICY } from '../utils/webhookFieldMasking.js'
-import { encryptField, decryptField, isEncrypted } from '../lib/encryption.js'
+import { encryptField, decryptField, isEncrypted, DecryptionError } from '../lib/encryption.js'
 
 export interface DeliveryStats {
   attempt_count: number
@@ -56,13 +56,36 @@ function decryptSecretColumn(value: string | null): string | null {
 }
 
 function toSubscriber(row: SubscriberRow): WebhookSubscriber {
+  let secret: string
+  try {
+    secret = decryptSecretColumn(row.secret)!
+  } catch (err) {
+    if (err instanceof DecryptionError) {
+      console.error(`[WebhookSubscriberRepo] Decryption failed for subscriber ${row.id}, using sentinel value`, err)
+      secret = '[DECRYPTION_FAILED]'
+    } else {
+      throw err
+    }
+  }
+
+  let previousSecret: string | null
+  try {
+    previousSecret = decryptSecretColumn(row.previous_secret)
+  } catch (err) {
+    if (err instanceof DecryptionError) {
+      console.error(`[WebhookSubscriberRepo] previous_secret decryption failed for subscriber ${row.id}, setting null`, err)
+      previousSecret = null
+    } else {
+      throw err
+    }
+  }
+
   return {
     id: row.id,
     organizationId: row.organization_id,
     url: row.url,
-    // Decrypted only here, in memory, at read time.
-    secret: decryptSecretColumn(row.secret)!,
-    previousSecret: decryptSecretColumn(row.previous_secret),
+    secret,
+    previousSecret,
     rotatedAt: row.rotated_at instanceof Date
       ? row.rotated_at.toISOString()
       : (row.rotated_at ? String(row.rotated_at) : null),

--- a/src/services/monitor.ts
+++ b/src/services/monitor.ts
@@ -62,6 +62,11 @@ export function getLatestListenerLag(): number | undefined {
  */
 export const checkListenerLag = async (): Promise<void> => {
   try {
+    if (typeof HorizonServer !== 'function') {
+      console.error('[Monitor] Failed to resolve Horizon Server constructor from @stellar/stellar-sdk. Neither Horizon.Server nor Server export is available. Check SDK version compatibility.')
+      return
+    }
+
     const config = getValidatedConfig()
     const server = new HorizonServer(config.horizonUrl)
     


### PR DESCRIPTION
## Problem

Two independent issues in the backend:

1. **Issue #1278** — `checkListenerLag` in `monitor.ts` resolves `HorizonServer` via `(StellarSdk as any).Horizon?.Server ?? (StellarSdk as any).Server`. If neither path resolves (SDK version mismatch, future export change), `HorizonServer` silently becomes `undefined` and the subsequent `new HorizonServer(...)` throws a generic `TypeError` with no actionable context for debugging.

2. **Issue #1249** — `toSubscriber` in `webhookSubscriberRepository.ts` calls `decryptSecretColumn(row.secret)!` unconditionally. If decryption fails (rotated keys, corrupt row), the `DecryptionError` propagates and kills the entire batch query — meaning a single corrupted subscriber blocks all webhook processing.

## Fix

**Issue #1278:** Added an explicit `typeof HorizonServer !== function` guard at the start of `checkListenerLag` with a descriptive `console.error` and early return. This gives operators a clear message pointing to the SDK compatibility issue instead of a generic `TypeError`.

**Issue #1249:** Modified `toSubscriber` to catch `DecryptionError` individually on both `secret` and `previousSecret` fields. When decryption fails:
- Logs the subscriber ID and the original error
- Sets the failed field to a sentinel `"[DECRYPTION_FAILED]"` or `null` for `previousSecret`
- Continues processing the row and other rows in the batch
- Re-throws non-decryption exceptions as before

Fixes #1278
Fixes #1249