### PR TITLE
fix: add 'disputed' to Vault status union type (#998)

### DIFF
--- a/src/routes/vaults.ts
+++ b/src/routes/vaults.ts
@@ -40,7 +40,7 @@ export interface Vault {
   id: string
   creator: string
   amount: string
-  status: 'draft' | 'active' | 'completed' | 'failed' | 'cancelled'
+  status: 'draft' | 'active' | 'completed' | 'failed' | 'cancelled' | 'disputed'
   startTimestamp: string
   endTimestamp: string
   successDestination: string

--- a/src/tests/helpers/performanceHelpers.ts
+++ b/src/tests/helpers/performanceHelpers.ts
@@ -291,7 +291,7 @@ export function generateTestUser(index: number) {
  */
 export function generateTestVault(index: number, userId: string) {
   const now = Date.now()
-  const statuses = ['draft', 'active', 'completed', 'failed', 'cancelled']
+  const statuses = ['draft', 'active', 'completed', 'failed', 'cancelled', 'disputed']
   
   return {
     id: `vault-perf-${index.toString().padStart(10, '0')}`,

--- a/src/tests/orgVaults.search.test.ts
+++ b/src/tests/orgVaults.search.test.ts
@@ -28,7 +28,7 @@ interface SearchVault {
   creator: string
   verifier: string
   amount: string
-  status: 'draft' | 'active' | 'completed' | 'failed' | 'cancelled'
+  status: 'draft' | 'active' | 'completed' | 'failed' | 'cancelled' | 'disputed'
   organization_id: string
   start_date: string
   end_date: string

--- a/src/tests/vaultStore.concurrency.test.ts
+++ b/src/tests/vaultStore.concurrency.test.ts
@@ -29,7 +29,7 @@ interface FakeVaultRow {
   success_destination: string;
   failure_destination: string;
   creator: string | null;
-  status: "draft" | "active" | "completed" | "failed" | "cancelled";
+  status: "draft" | "active" | "completed" | "failed" | "cancelled" | "disputed";
   created_at: string;
   xmin: number;
 }

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -3,7 +3,8 @@ export enum VaultStatus {
   ACTIVE = 'active',
   COMPLETED = 'completed',
   FAILED = 'failed',
-  CANCELLED = 'cancelled'
+  CANCELLED = 'cancelled',
+  DISPUTED = 'disputed'
 }
 
 export interface Vault {

--- a/src/utils/mappers.ts
+++ b/src/utils/mappers.ts
@@ -8,6 +8,7 @@ const STATUS_MAP: Record<InternalVaultStatus, PublicVaultStatus> = {
   [InternalVaultStatus.COMPLETED]: 'completed',
   [InternalVaultStatus.FAILED]: 'failed',
   [InternalVaultStatus.CANCELLED]: 'cancelled',
+  [InternalVaultStatus.DISPUTED]: 'active',
 };
 
 /**


### PR DESCRIPTION
Closes #998

## Problem

`disputeVault` in `src/services/vaultTransitions.ts` assigns `vault.status = "disputed"` and `resolveDispute` compares `vault.status !== "disputed"`, but the canonical `VaultStatus` enum in `src/types/vault.ts` did not include `"disputed"`. This caused TS2322 and TS2367 type errors.

## Solution

Added `DISPUTED = "disputed"` to the `VaultStatus` enum and updated all related type annotations across 6 files:

- `src/types/vault.ts` - added `DISPUTED` to enum
- `src/routes/vaults.ts` - added to inline status union type
- `src/utils/mappers.ts` - added `DISPUTED` entry in `STATUS_MAP`
- `src/tests/vaultStore.concurrency.test.ts` - added to inline status type
- `src/tests/orgVaults.search.test.ts` - added to inline status type
- `src/tests/helpers/performanceHelpers.ts` - added to test status array