### PR TITLE
Fix: webhookRotateSchema explicit empty-body, derive session expiry f…

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -28,8 +28,24 @@ export function csrfProtection(
 
   const authHeader = req.headers.authorization;
   if (authHeader && authHeader.startsWith("Bearer ")) {
-    next();
-    return;
+    const token = authHeader.slice(7).trim();
+    // Only treat bearer tokens as CSRF-safe when they are verifiable JWTs.
+    // This avoids trusting unsigned or mock "user:<id>" bearer tokens used by
+    // legacy/dev routers (see requireUserAuth) which are not resistant to CSRF.
+    try {
+      try {
+        verifyAccessToken(token)
+        next()
+        return
+      } catch (_) {
+        // fallback to legacy secret
+        jwt.verify(token, getJwtSecret())
+        next()
+        return
+      }
+    } catch {
+      // Token wasn't verifiable -> fall through to normal CSRF checks
+    }
   }
 
   const origin = req.headers.origin as string | undefined;
@@ -141,14 +157,35 @@ export async function signToken(
   const jti = randomUUID();
   const fullPayload = { ...payload, jti };
 
-  // Calculate expiration date
-  // Default matches 1h (1 hour)
-  const durationMs = 60 * 60 * 1000;
-  const expiresAt = new Date(Date.now() + durationMs);
+  // Derive the session expiry from the same `expiresIn` value passed to jwt.sign.
+  const parseExpiresInToMs = (val: string | number): number => {
+    if (typeof val === 'number') return val * 1000
+    // Accept formats like '30s', '15m', '1h', '2d' or a numeric string of seconds
+    const m = /^([0-9]+)(s|m|h|d)$/.exec(val)
+    if (m) {
+      const n = Number(m[1])
+      switch (m[2]) {
+        case 's':
+          return n * 1000
+        case 'm':
+          return n * 60 * 1000
+        case 'h':
+          return n * 60 * 60 * 1000
+        case 'd':
+          return n * 24 * 60 * 60 * 1000
+      }
+    }
+    if (/^[0-9]+$/.test(String(val))) return Number(val) * 1000
+    // Fallback to 1 hour if we cannot parse
+    return 60 * 60 * 1000
+  }
 
-  await recordSession(payload.userId, jti, expiresAt);
+  const durationMs = parseExpiresInToMs(expiresIn)
+  const expiresAt = new Date(Date.now() + durationMs)
 
-  return jwt.sign(fullPayload, getJwtSecret(), { expiresIn } as jwt.SignOptions);
+  await recordSession(payload.userId, jti, expiresAt)
+
+  return jwt.sign(fullPayload, getJwtSecret(), { expiresIn } as jwt.SignOptions)
 }
 
 export interface AuthenticatedRequest extends Request {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -84,7 +84,7 @@ const isValidReasonCode = (reason: unknown): reason is OverrideReasonCode =>
   typeof reason === 'string' && ValidOverrideReasonCodes.includes(reason as OverrideReasonCode)
 
 // Sanitize reason text to prevent PII/secrets leakage
-const sanitizeReasonText = (reason: string): string => {
+export const sanitizeReasonText = (reason: string): string => {
   // Remove potential secrets/PII patterns
   return reason
     .replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g, '[REDACTED_EMAIL]')

--- a/src/tests/sanitizeReasonText.test.ts
+++ b/src/tests/sanitizeReasonText.test.ts
@@ -1,0 +1,12 @@
+import { sanitizeReasonText } from '../routes/admin.js'
+
+describe('sanitizeReasonText combined-PII redaction', () => {
+  it('redacts email, token, IP, card and SSN when present together', () => {
+    const input = 'Email: alice@example.com token: abcdefghijklmnopqrstuvwxyzABCDEFG12345678 IP: 192.168.0.1 card: 4111-1111-1111-1111 SSN: 123-45-6789'
+    const out = sanitizeReasonText(input)
+
+    expect(out).toBe(
+      'Email: [REDACTED_EMAIL] token: [REDACTED_TOKEN] IP: [REDACTED_IP] card: [REDACTED_CARD] SSN: [REDACTED_SSN]'
+    )
+  })
+})

--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -22,7 +22,15 @@ export const webhookCreateSchema = z.object({
   active: z.boolean().optional().default(true),
 })
 
-export const webhookRotateSchema = z.object({}).strict()
+// Explicitly accept either no body (`undefined`) or an empty object.
+// This documents "no body expected" while still rejecting any extra properties.
+export const webhookRotateSchema = z.union([
+  z.undefined(),
+  z
+    .object({})
+    .strict()
+    .refine((obj) => Object.keys(obj).length === 0, { message: 'Request body must be empty' }),
+])
 
 export type WebhookCreateInput = z.infer<typeof webhookCreateSchema>
 export type WebhookRotateInput = z.infer<typeof webhookRotateSchema>


### PR DESCRIPTION
Summary: Fix four related issues: make webhook rotate schema explicit, derive session expiry from [expiresIn](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/), tighten CSRF handling for bearer tokens, and add a combined-PII redaction test.
Files changed: [webhook.ts](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/), [auth.ts](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/), [admin.ts](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/), [sanitizeReasonText.test.ts](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/)
Fixes:
#1242 ([webhookRotateSchema](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/)): [webhookRotateSchema](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/) now explicitly accepts [undefined](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/) or an empty object (rejects extra properties) to document “no body expected.”
#1243 ([signToken](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/)): [signToken](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/) computes [expiresAt](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/) from the same [expiresIn](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/) passed to [jwt.sign](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/) (parses s, [m](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/), h, d and numeric seconds) so session records match token lifetime.
#1244 ([csrfProtection](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/)): [csrfProtection](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/) only treats Bearer tokens as CSRF-safe when the token is a verifiable JWT (rejects unsigned/mock [Bearer user:](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/) tokens as CSRF-safe).
#1245 ([sanitizeReasonText](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/)): exported sanitizer and added a unit test exercising multiple PII types together to lock expected redaction behavior.
Tests: Added [sanitizeReasonText.test.ts](https://scaling-sniffle-qv97x7wpgrw424g9v.github.dev/) (passes locally).
Branch: fix/1242-1245-webhook-sign-csrf-sanitize
closes #1242 
closes #1243 
closes #1244 
closes #1245 