### PR TITLE
Add pagination to listVerifierProfiles and GET /api/admin/verifiers

### DIFF
--- a/src/routes/adminVerifiers.ts
+++ b/src/routes/adminVerifiers.ts
@@ -11,7 +11,7 @@ import {
   listVerifierProfiles,
   InvalidVerifierStatusTransitionError,
   transitionVerifier,
-  updateVerifierProfile, 
+  updateVerifierProfile,
 } from '../services/verifiers.js'
 import { isValidStellarAddress } from '../services/vaultValidation.js'
 import { AppError } from '../middleware/errorHandler.js'
@@ -21,7 +21,10 @@ export const adminVerifiersRouter = Router()
 adminVerifiersRouter.use(authenticate, requireAdmin)
 
 adminVerifiersRouter.get('/', async (_req: Request, res: Response) => {
-  const profiles = await listVerifierProfiles()
+  const limit = getStringQuery(_req.query.limit) ? Number(getStringQuery(_req.query.limit)) : 100
+  const offset = getStringQuery(_req.query.offset) ? Number(getStringQuery(_req.query.offset)) : 0
+
+  const profiles = await listVerifierProfiles({ limit, offset })
   const withStats = await Promise.all(profiles.map(async (p) => ({ profile: p, stats: await getVerifierStats(p.userId) })))
   res.json({ verifiers: withStats })
 })
@@ -257,4 +260,7 @@ const createOrGetAndTransitionStatus = async (req: Request, res: Response, userI
 
   await transitionStatus(req, res, userId, status)
 }
+
+const getStringQuery = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() !== '' ? value : undefined
 

--- a/src/services/verifiers.ts
+++ b/src/services/verifiers.ts
@@ -187,8 +187,17 @@ export const getVerifierProfile = async (userId: string): Promise<VerifierProfil
   return mapVerifierRow(row)
 }
 
-export const listVerifierProfiles = async (): Promise<VerifierProfile[]> => {
-  const rows = await db('verifiers').select('*').orderBy('created_at', 'desc')
+export interface ListVerifierProfilesOptions {
+  limit?: number
+  offset?: number
+}
+
+export const listVerifierProfiles = async (opts: ListVerifierProfilesOptions = {}): Promise<VerifierProfile[]> => {
+  const parsedLimit = Number(opts.limit)
+  const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.floor(parsedLimit) : 100
+  const parsedOffset = Number(opts.offset)
+  const offset = Number.isFinite(parsedOffset) && parsedOffset >= 0 ? Math.floor(parsedOffset) : 0
+  const rows = await db('verifiers').select('*').orderBy('created_at', 'desc').limit(limit).offset(offset)
   return rows.map(mapVerifierRow)
 }
 


### PR DESCRIPTION
Closes #1279

---

Adds `limit` and `offset` query parameters to `listVerifierProfiles` in `src/services/verifiers.ts` and threads them through `GET /api/admin/verifiers` in `src/routes/adminVerifiers.ts`.

The unbounded `db('verifiers').select('*').orderBy('created_at', 'desc')` query now applies DB-level `.limit()`/`.offset()` with sanitized inputs (defaults: limit=100, offset=0), matching the pattern used by `listAuditLogs` and other paginated endpoints in the codebase.