### PR TITLE
fix: resolve issues #1253 #1255 #1256 #1257

### DIFF
--- a/src/app-bootstrap.ts
+++ b/src/app-bootstrap.ts
@@ -36,6 +36,7 @@ import {
   securityRateLimitMiddleware,
 } from "./security/abuse-monitor.js";
 import inFlightMiddleware from "./middleware/inFlightRequests.js";
+import { mountVersionedRoute } from './middleware/versioning.js'
 
 type BootstrapOptions = {
   notificationService?: NotificationService;
@@ -60,34 +61,40 @@ export function bootstrapApp(options: BootstrapOptions = {}) {
   app.use(inFlightMiddleware);
   app.use(withRequestPrisma);
 
-  app.use('/api/health', healthRateLimiter, createHealthRouter(jobSystem, privacyAbuseMonitor))
-  app.use('/api/jobs', createJobsRouter(jobSystem))
-  app.use('/api/vaults', vaultsRateLimiter, vaultsRouter)
-  app.use('/api/vaults/:vaultId/milestones', milestonesRouter)
-  app.use('/api/auth', authRateLimiter, authRouter)
-  app.use('/api/exports', createExportRouter(jobSystem))
-  app.use('/api/transactions', transactionsRouter)
-  app.use('/api/analytics', analyticsRouter)
-  app.use('/api/privacy', privacyRouter)
-  app.use('/api/organizations', orgVaultsRouter)
-  app.use('/api/organizations', orgAnalyticsRouter)
-  app.use('/api/orgs', orgAnalyticsRouter)
-  app.use('/api/organizations', orgMembersRouter)
-  app.use('/api/orgs', orgAnalyticsRouter)
-  app.use('/api/orgs', orgMembersRouter)
-  app.use('/api/orgs', notificationPreferencesRouter)
-  app.use('/api/organizations/:orgId/graphql', graphqlRouter)
-  // /api/admin is mounted in app.ts at module load time; no re-mount needed here.
-  app.use('/api/admin/verifiers', adminVerifiersRouter)
-  app.use('/api/admin/webhooks', adminWebhooksRouter)
-  app.use('/api/admin/vaults', adminVaultReplayRouter)
-  app.use('/api/verifications', verificationsRouter)
+  // Mount all routes through mountVersionedRoute so that:
+  //   /api/v1/<resource>  — canonical versioned path (no deprecation headers)
+  //   /api/<resource>     — legacy alias (Deprecation + Sunset + Link headers)
+  // This satisfies issue #1257: legacy routes now emit the RFC 8594 warning
+  // headers that versioning.ts was built to provide, and clients have a
+  // /api/v1/... surface to migrate to.
+  mountVersionedRoute(app, '/api/health', '/api/v1/health', healthRateLimiter, createHealthRouter(jobSystem, privacyAbuseMonitor))
+  mountVersionedRoute(app, '/api/jobs', '/api/v1/jobs', createJobsRouter(jobSystem))
+  mountVersionedRoute(app, '/api/vaults', '/api/v1/vaults', vaultsRateLimiter, vaultsRouter)
+  mountVersionedRoute(app, '/api/vaults/:vaultId/milestones', '/api/v1/vaults/:vaultId/milestones', milestonesRouter)
+  mountVersionedRoute(app, '/api/auth', '/api/v1/auth', authRateLimiter, authRouter)
+  mountVersionedRoute(app, '/api/exports', '/api/v1/exports', createExportRouter(jobSystem))
+  mountVersionedRoute(app, '/api/transactions', '/api/v1/transactions', transactionsRouter)
+  mountVersionedRoute(app, '/api/analytics', '/api/v1/analytics', analyticsRouter)
+  mountVersionedRoute(app, '/api/privacy', '/api/v1/privacy', privacyRouter)
+  mountVersionedRoute(app, '/api/organizations', '/api/v1/organizations', orgVaultsRouter)
+  mountVersionedRoute(app, '/api/organizations', '/api/v1/organizations', orgAnalyticsRouter)
+  mountVersionedRoute(app, '/api/orgs', '/api/v1/orgs', orgAnalyticsRouter)
+  mountVersionedRoute(app, '/api/organizations', '/api/v1/organizations', orgMembersRouter)
+  mountVersionedRoute(app, '/api/orgs', '/api/v1/orgs', orgMembersRouter)
+  mountVersionedRoute(app, '/api/orgs', '/api/v1/orgs', notificationPreferencesRouter)
+  mountVersionedRoute(app, '/api/organizations/:orgId/graphql', '/api/v1/organizations/:orgId/graphql', graphqlRouter)
+  // /api/admin is mounted in app.ts at module load time; not needed here.
+  mountVersionedRoute(app, '/api/admin/verifiers', '/api/v1/admin/verifiers', adminVerifiersRouter)
+  mountVersionedRoute(app, '/api/admin/webhooks', '/api/v1/admin/webhooks', adminWebhooksRouter)
+  mountVersionedRoute(app, '/api/admin/vaults', '/api/v1/admin/vaults', adminVaultReplayRouter)
+  mountVersionedRoute(app, '/api/verifications', '/api/v1/verifications', verificationsRouter)
   app.get('/api/orgs/:orgId/api-keys/usage', authenticate, requireOrgAccess('owner', 'admin'), getApiKeyUsageHandler)
-  app.use('/api/api-keys', apiKeysRouter)
-  app.use('/api/oauth', oauthRouter)
-  // /api/notifications is mounted in app.ts at module load time; no re-mount needed here.
-  app.use('/api/users/me/notification-preferences', notificationPreferencesRouter)
-  // /api/webhooks is mounted in app.ts at module load time; no re-mount needed here.
+  app.get('/api/v1/orgs/:orgId/api-keys/usage', authenticate, requireOrgAccess('owner', 'admin'), getApiKeyUsageHandler)
+  mountVersionedRoute(app, '/api/api-keys', '/api/v1/api-keys', apiKeysRouter)
+  mountVersionedRoute(app, '/api/oauth', '/api/v1/oauth', oauthRouter)
+  // /api/notifications is mounted in app.ts at module load time; not needed here.
+  mountVersionedRoute(app, '/api/users/me/notification-preferences', '/api/v1/users/me/notification-preferences', notificationPreferencesRouter)
+  // /api/webhooks is mounted in app.ts at module load time; not needed here.
 
   // Catch-all 404 and uniform error shape – must be registered after all routes.
   app.use(notFound);

--- a/src/services/soroban.ts
+++ b/src/services/soroban.ts
@@ -245,8 +245,16 @@ export class SorobanRpcPool {
   }
 
   private async _probeDownEndpoints(): Promise<void> {
+    // Probe both 'down' and 'degraded' endpoints.
+    //
+    // 'degraded' endpoints are deprioritised by getOrderedUrls(), so they stop
+    // receiving organic traffic once healthier alternatives exist. Without
+    // explicit probing here they have no path back to 'healthy': organic
+    // calls won't reach them (ordering steers requests elsewhere) and the
+    // background job previously only checked 'down'. Including 'degraded'
+    // ensures recovery is possible for any non-healthy endpoint.
     const probes = this.states
-      .filter((s) => s.status === 'down')
+      .filter((s) => s.status === 'down' || s.status === 'degraded')
       .map(async (state) => {
         state.lastProbeAt = Date.now()
         const healthy = await this.probeFn(state.url, this.probeTimeoutMs)

--- a/src/services/vault.service.ts
+++ b/src/services/vault.service.ts
@@ -8,17 +8,28 @@ export interface TimelineItem {
 
 export class VaultService {
   static async createVault(data: CreateVaultDTO): Promise<Vault> {
+    // Column names match the actual schema from migrations:
+    //   initial_baseline: id, creator, amount, start_date, end_date,
+    //                     success_destination, failure_destination, status, created_at
+    //   fix_vault_schema:  adds verifier, updated_at; renames start/end_timestamp → start/end_date
     const query = `
       INSERT INTO vaults (
-        contract_id, creator_address, amount, milestone_hash,
-        verifier_address, success_destination, failure_destination, deadline
+        id, creator, amount, start_date, end_date,
+        verifier, success_destination, failure_destination, status
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
       RETURNING *;
     `;
     const values = [
-      data.contractId, data.creatorAddress, data.amount, data.milestoneHash,
-      data.verifierAddress, data.successDestination, data.failureDestination, data.deadline
+      data.id,
+      data.creator,
+      data.amount,
+      data.startDate,
+      data.endDate,
+      data.verifier ?? null,
+      data.successDestination,
+      data.failureDestination,
+      data.status ?? 'draft',
     ];
     try {
       const result = await pool.query(query, values);
@@ -35,14 +46,17 @@ export class VaultService {
   }
 
   static async updateVaultStatus(id: string, status: VaultStatus | string): Promise<void> {
-    await pool.query('UPDATE vaults SET status = $1 WHERE id = $2', [status, id]);
+    await pool.query(
+      'UPDATE vaults SET status = $1, updated_at = NOW() WHERE id = $2',
+      [status, id],
+    );
   }
 
-  static async getVaultsByUser(address: string): Promise<Vault[]> {
+  static async getVaultsByUser(creator: string): Promise<Vault[]> {
     try {
       const result = await pool.query(
-        'SELECT * FROM vaults WHERE creator_address = $1',
-        [address]
+        'SELECT * FROM vaults WHERE creator = $1',
+        [creator],
       );
       return result.rows;
     } catch {

--- a/src/services/verifiers.ts
+++ b/src/services/verifiers.ts
@@ -192,15 +192,25 @@ export const listVerifierProfiles = async (): Promise<VerifierProfile[]> => {
   return rows.map(mapVerifierRow)
 }
 
+/**
+ * @deprecated Use `transitionVerifier` directly.
+ *
+ * This wrapper exists only for backward-compatibility. It delegates to
+ * `transitionVerifier` so that every status change goes through the full
+ * validation pipeline: `canTransition` check, `db.transaction`, and
+ * `createVerifierAuditLog`. Callers should migrate to `transitionVerifier`
+ * and pass an explicit `VerifierMutationContext`.
+ *
+ * A synthetic system context is used here because the legacy signature did
+ * not accept an actor/reason. Audit logs created via this path will carry
+ * `actor_user_id: 'system'` to make the bypass-free path visible.
+ */
 export const setVerifierStatus = async (
   userId: string,
   status: VerifierStatus,
 ): Promise<VerifierProfile | null> => {
-  const row = await db('verifiers').where({ user_id: userId }).first()
-  if (!row) return null
-
-  const [updated] = await db('verifiers').where({ user_id: userId }).update(mapStatusToUpdates(status)).returning('*')
-  return mapVerifierRow(updated)
+  const result = await transitionVerifier(userId, status, { actorUserId: 'system' })
+  return result?.after ?? null
 }
 
 export const recordVerification = async (

--- a/src/tests/vault.service.test.ts
+++ b/src/tests/vault.service.test.ts
@@ -20,14 +20,15 @@ jest.unstable_mockModule('../db/index.js', () => ({
 const { VaultService } = await import('../services/vault.service.js')
 
 const mockVaultData = {
-  contractId: 'CTEST',
-  creatorAddress: 'GBX...',
+  id: 'test-uuid-1',
+  creator: 'GBX...',
   amount: '100000000',
-  milestoneHash: 'abc123hash',
-  verifierAddress: 'GAX...',
+  startDate: new Date().toISOString(),
+  endDate: new Date().toISOString(),
+  verifier: 'GAX...',
   successDestination: 'GBX...',
   failureDestination: 'GAX...',
-  deadline: new Date().toISOString(),
+  status: VaultStatus.DRAFT,
 }
 
 describe('VaultService', () => {

--- a/src/types/vault.ts
+++ b/src/types/vault.ts
@@ -6,36 +6,38 @@ export enum VaultStatus {
   CANCELLED = 'cancelled'
 }
 
+/**
+ * Matches the real vaults table schema after all migrations:
+ *   initial_baseline: id, creator, amount, start_date (was start_timestamp),
+ *                     end_date (was end_timestamp), success_destination,
+ *                     failure_destination, status, created_at
+ *   fix_vault_schema:  adds verifier, updated_at
+ */
 export interface Vault {
   id: string;
-  contract_id: string | null;
-  creator_address: string;
-  amount: string; 
-  milestone_hash: string;
-  verifier_address: string;
+  creator: string;
+  amount: string;
+  start_date: Date;
+  end_date: Date;
+  verifier: string | null;
   success_destination: string;
   failure_destination: string;
   status: VaultStatus;
   organization_id?: string;
-  deadline: Date;
   created_at: Date;
   updated_at: Date;
-  // Legacy fields for compatibility with in-memory logic
-  creator?: string;
-  startTimestamp?: string;
-  endTimestamp?: string;
-  createdAt?: string;
 }
 
 export type CreateVaultDTO = {
-  contractId?: string;
-  creatorAddress: string;
+  id: string;
+  creator: string;
   amount: string;
-  milestoneHash: string;
-  verifierAddress: string;
+  startDate: Date | string;
+  endDate: Date | string;
+  verifier?: string | null;
   successDestination: string;
   failureDestination: string;
-  deadline: Date | string;
+  status?: VaultStatus;
 };
 
 export interface VaultAnalytics {


### PR DESCRIPTION
#1253 VaultService: rewrite SQL to use real migrated column names
- createVault: replace contract_id/creator_address/milestone_hash/ verifier_address/deadline with creator/start_date/end_date/verifier matching initial_baseline + fix_vault_schema migrations
- getVaultsByUser: query creator instead of creator_address
- updateVaultStatus: also set updated_at = NOW()
- CreateVaultDTO/Vault types updated to match actual schema
- Test mockVaultData updated to corrected field names

#1255 SorobanRpcPool: probe both 'down' and 'degraded' endpoints
- _probeDownEndpoints filter extended to include s.status === 'degraded'
- Degraded endpoints depriorised by getOrderedUrls stop getting organic traffic; without probing they had no path back to 'healthy'

#1256 setVerifierStatus: delegate to transitionVerifier
- Previously did a raw db update bypassing canTransition, db.transaction, and createVerifierAuditLog
- Now delegates to transitionVerifier with actorUserId:'system' so all status changes go through the same guarded pipeline
- Marked @deprecated with migration note for callers

#1257 versioning middleware: wire mountVersionedRoute in bootstrapApp
- All app.use('/api/...') route mounts replaced with mountVersionedRoute
- Every route now served at both /api/v1/<resource> (canonical) and /api/<resource> (legacy with Deprecation/Sunset/Link headers)
- Fulfils the RFC 8594 contract that versioning.ts/config/versions.ts document but previously never activated
closes #1253 
closes #1255 
closes #1256 
closes #1257 