### PR TITLE
fix(milestones): reuse single milestone reference in approve handler

### DIFF
--- a/src/routes/milestones.ts
+++ b/src/routes/milestones.ts
@@ -184,9 +184,8 @@ milestonesRouter.post('/:id/approve', authenticate, requireVerifier, async (req:
     }
 
     // Reject late votes on already-settled milestones
-    const milestone_record = getMilestoneById(id)
-    const approvalThreshold = (milestone_record as any)?.approvalThreshold || 1
-    const totalVerifiers = (milestone_record as any)?.totalVerifiers as number | undefined
+    const approvalThreshold = (milestone as any)?.approvalThreshold || 1
+    const totalVerifiers = (milestone as any)?.totalVerifiers as number | undefined
 
     const priorProgress = await getMilestoneApprovalProgress(id, approvalThreshold, totalVerifiers)
     if (priorProgress.isComplete || priorProgress.isRejected) {


### PR DESCRIPTION
## Summary

Removes the redundant second `getMilestoneById(id)` call in `POST /:id/approve` and reuses the single `milestone` variable already fetched earlier in the handler.

## Changes

- **`src/routes/milestones.ts`** — Removed `const milestone_record = getMilestoneById(id)` at line ~187. Changed `approvalThreshold` and `totalVerifiers` to read from the existing `milestone` variable instead of `milestone_record`.

## Why

The handler called `getMilestoneById(id)` twice for the same request:
1. Line 168: `const milestone = getMilestoneById(id)` — validates existence
2. Line 187: `const milestone_record = getMilestoneById(id)` — reads threshold/verifiers

This is wasteful and risks silent divergence if the store is mutated between calls (e.g., after database migration). The `milestone` variable from line 168 is already in scope and carries the same data.

Fixes #1250