### PR TITLE
fix(notification): make default UserNotificationPreferences id nullable

### DIFF
--- a/src/services/userNotificationPreferences.service.ts
+++ b/src/services/userNotificationPreferences.service.ts
@@ -16,7 +16,7 @@ const TABLE = 'user_notification_preferences'
 export function getDefaultPreferences(userId: string): UserNotificationPreferences {
   const now = new Date().toISOString()
   return {
-    id: '',
+    id: null,
     user_id: userId,
     timezone: 'UTC',
     quiet_hours_enabled: false,

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -49,7 +49,7 @@ export interface NotificationListResult {
 
 // User notification preferences for quiet-hours windowing
 export interface UserNotificationPreferences {
-  id: string
+  id: string | null
   user_id: string
   timezone: string
   quiet_hours_enabled: boolean


### PR DESCRIPTION
Closes #1307

### Description of Work Done
- Updated `UserNotificationPreferences` type in `src/types/notification.ts` so `id` is `string | null`.
- Updated `getDefaultPreferences` in `src/services/userNotificationPreferences.service.ts` to return `id: null` instead of an empty string `id: ''`.
- Prevents downstream callers from mistaking synthesized default preference objects for persisted database records.