### PR TITLE
fix(encryption): add key-id extraction and key rotation audit helper

### DIFF
--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -272,3 +272,51 @@ export const encryptNullable = (plaintext: string | null | undefined): string | 
  */
 export const decryptNullable = (stored: string | null | undefined): string | null =>
   stored === null || stored === undefined ? null : decryptField(stored)
+
+export interface KeyUsageAuditReport {
+  countsByKid: Record<string, number>
+  unencryptedCount: number
+  unknownKidCount: number
+  totalCount: number
+}
+
+/**
+ * Extracts the key ID (`kid`) from a ciphertext string produced by `encryptField`.
+ * Returns `null` if the value is not encrypted under a valid v1 scheme.
+ */
+export function getKeyId(stored: string): string | null {
+  if (!isEncrypted(stored)) return null
+  return stored.split(':')[1] ?? null
+}
+
+/**
+ * Audits a collection of stored field values to count how many rows are encrypted under
+ * each key ID (`kid`), how many are unencrypted, and how many use unknown/unconfigured key IDs.
+ */
+export function auditKeyUsage(records: (string | null | undefined)[]): KeyUsageAuditReport {
+  const configuredKids = new Set(resolveKeys().map((k) => k.kid))
+  const countsByKid: Record<string, number> = {}
+  let unencryptedCount = 0
+  let unknownKidCount = 0
+  let totalCount = 0
+
+  for (const record of records) {
+    if (record === null || record === undefined) continue
+    totalCount++
+    if (!isEncrypted(record)) {
+      unencryptedCount++
+      continue
+    }
+    const kid = getKeyId(record)
+    if (kid === null) {
+      unencryptedCount++
+    } else {
+      countsByKid[kid] = (countsByKid[kid] ?? 0) + 1
+      if (!configuredKids.has(kid)) {
+        unknownKidCount++
+      }
+    }
+  }
+
+  return { countsByKid, unencryptedCount, unknownKidCount, totalCount }
+}

--- a/src/tests/encryption.test.ts
+++ b/src/tests/encryption.test.ts
@@ -21,6 +21,8 @@ import {
   encryptNullable,
   decryptNullable,
   isEncrypted,
+  getKeyId,
+  auditKeyUsage,
   resolveKeys,
   DecryptionError,
   EncryptionKeyError,
@@ -316,5 +318,51 @@ describe('encryptNullable / decryptNullable', () => {
     expect(encrypted).not.toBeNull()
     expect(isEncrypted(encrypted!)).toBe(true)
     expect(decryptNullable(encrypted)).toBe('present')
+  })
+})
+
+// ─── Key Rotation Auditing ───────────────────────────────────────────────────────
+
+describe('getKeyId and auditKeyUsage', () => {
+  beforeEach(() => useSingleKey())
+
+  it('getKeyId extracts kid from encrypted string and returns null for unencrypted string', () => {
+    const encrypted = encryptField('test-secret')
+    expect(getKeyId(encrypted)).toBe('default')
+    expect(getKeyId('unencrypted-plaintext')).toBeNull()
+  })
+
+  it('auditKeyUsage counts records by kid, unencrypted rows, and unknown kids', () => {
+    const k1 = genKey()
+    const k2 = genKey()
+    delete process.env.FIELD_ENCRYPTION_KEY
+    process.env.FIELD_ENCRYPTION_KEYS = JSON.stringify([
+      { kid: 'k1', key: k1 },
+      { kid: 'k2', key: k2 },
+    ])
+
+    const encK1 = encryptField('data1')
+    const encK1_2 = encryptField('data2')
+
+    // Write under k2
+    process.env.FIELD_ENCRYPTION_KEYS = JSON.stringify([
+      { kid: 'k2', key: k2 },
+      { kid: 'k1', key: k1 },
+    ])
+    const encK2 = encryptField('data3')
+
+    const fakeUnknownKidEnc = 'v1:retired_kid:iv:tag:cipher'
+
+    const records = [encK1, encK1_2, encK2, 'plaintext_secret', fakeUnknownKidEnc, null, undefined]
+
+    const report = auditKeyUsage(records)
+    expect(report.totalCount).toBe(5)
+    expect(report.unencryptedCount).toBe(1)
+    expect(report.unknownKidCount).toBe(1)
+    expect(report.countsByKid).toEqual({
+      k1: 2,
+      k2: 1,
+      retired_kid: 1,
+    })
   })
 })


### PR DESCRIPTION
Closes #1305

### Description of Work Done
- Added `getKeyId` helper function in `src/lib/encryption.ts` to extract the `kid` from ciphertext headers.
- Added `auditKeyUsage` report function to aggregate counts of stored records per key ID, unencrypted rows, and unknown key IDs.
- Added comprehensive unit tests in `src/tests/encryption.test.ts` covering key extraction and usage auditing.