### PR TITLE
fix: shared milestone validation, OpenAPI drift check, IPv6 allowlist…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Typecheck OpenAPI docs
         run: npm run openapi:typecheck
 
+      - name: Check OpenAPI spec is up-to-date
+        run: npm run openapi:check
+
       - name: Apply migrations
         run: npm run migrate:latest
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "openapi:generate": "tsx src/docs/generate-spec.ts",
     "openapi:typecheck": "tsc --noEmit -p tsconfig.docs.json",
     "openapi:lint": "redocly lint docs/openapi.yaml",
-    "openapi:validate": "redocly stats docs/openapi.yaml"
+    "openapi:validate": "redocly stats docs/openapi.yaml",
+    "openapi:check": "tsx src/docs/generate-spec.ts --check"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1094.0",

--- a/src/docs/generate-spec.ts
+++ b/src/docs/generate-spec.ts
@@ -19,15 +19,79 @@ function stripFunctions(obj: unknown): unknown {
   return result
 }
 
+/**
+ * Produce a human-readable unified diff between two strings.
+ * Returns an empty string when they are identical.
+ */
+function simpleDiff(committed: string, generated: string): string {
+  if (committed === generated) return ''
+
+  const committedLines = committed.split('\n')
+  const generatedLines = generated.split('\n')
+  const lines: string[] = []
+
+  const maxLen = Math.max(committedLines.length, generatedLines.length)
+  let diffCount = 0
+  for (let i = 0; i < maxLen; i++) {
+    const a = committedLines[i]
+    const b = generatedLines[i]
+    if (a !== b) {
+      if (a !== undefined) lines.push(`- ${a}`)
+      if (b !== undefined) lines.push(`+ ${b}`)
+      diffCount++
+      if (diffCount >= 40) {
+        lines.push(`... (truncated — ${maxLen - i} more lines differ)`)
+        break
+      }
+    }
+  }
+  return lines.join('\n')
+}
+
 async function main() {
-  console.log('Generating OpenAPI specification...')
+  const checkMode = process.argv.includes('--check')
+
+  console.log(
+    checkMode
+      ? 'Checking OpenAPI specification for drift...'
+      : 'Generating OpenAPI specification...',
+  )
+
   const spec = generateOpenApiSpec()
   const cleanSpec = stripFunctions(spec) as object
-  const yamlSpec = stringify(cleanSpec)
+  const generatedYaml = stringify(cleanSpec)
+
   const outputDir = path.resolve(__dirname, '../../docs')
-  if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true })
   const outputPath = path.join(outputDir, 'openapi.yaml')
-  fs.writeFileSync(outputPath, yamlSpec, 'utf8')
+
+  if (checkMode) {
+    // In check mode: compare generated output against the committed file and
+    // fail with a non-zero exit code when they differ.
+    if (!fs.existsSync(outputPath)) {
+      console.error(
+        `ERROR: ${outputPath} does not exist.\nRun 'npm run openapi:generate' to create it.`,
+      )
+      process.exit(1)
+    }
+
+    const committed = fs.readFileSync(outputPath, 'utf8')
+    if (committed === generatedYaml) {
+      console.log('✓ docs/openapi.yaml is up-to-date.')
+      process.exit(0)
+    }
+
+    const diff = simpleDiff(committed, generatedYaml)
+    console.error(
+      `ERROR: docs/openapi.yaml is out of sync with the current routes.\n` +
+        `Run 'npm run openapi:generate' to regenerate it and commit the result.\n\n` +
+        `Diff (committed → generated):\n${diff}`,
+    )
+    process.exit(1)
+  }
+
+  // Write mode (default)
+  if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true })
+  fs.writeFileSync(outputPath, generatedYaml, 'utf8')
   console.log(`OpenAPI specification generated at: ${outputPath}`)
 }
 

--- a/src/middleware/metricsAuth.ts
+++ b/src/middleware/metricsAuth.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import { getEnv } from '../config/env.js'
 
-// ── CIDR matcher (no external deps) ──────────────────────────────────────────
+// ── IPv4 CIDR matcher ─────────────────────────────────────────────────────────
 
 function parseCidr(cidr: string): { network: number; bits: number } | null {
   const parts = cidr.split('/')
@@ -21,6 +21,9 @@ function parseCidr(cidr: string): { network: number; bits: number } | null {
 function normalizeIp(raw: string): string {
   // Strip IPv6-mapped IPv4 prefix (::ffff:1.2.3.4 → 1.2.3.4)
   if (raw.startsWith('::ffff:')) return raw.slice(7)
+  // Strip zone ID from IPv6 link-local addresses (fe80::1%eth0 → fe80::1)
+  const zoneIdx = raw.indexOf('%')
+  if (zoneIdx !== -1) return raw.slice(0, zoneIdx)
   return raw
 }
 
@@ -35,13 +38,112 @@ function ipToInt(ip: string): number | null {
   )
 }
 
+// ── IPv6 support ──────────────────────────────────────────────────────────────
+
+/**
+ * Expand an IPv6 address to its full 8-group form.
+ * Returns null if the address is not a valid IPv6 string.
+ */
+function expandIpv6(ip: string): string | null {
+  // Must contain at least one colon and no dots (that would be IPv4-mapped,
+  // already handled by normalizeIp stripping the ::ffff: prefix)
+  if (!ip.includes(':')) return null
+
+  const halves = ip.split('::')
+  if (halves.length > 2) return null // multiple '::' is invalid
+
+  const leftGroups = halves[0] ? halves[0].split(':') : []
+  const rightGroups = halves.length === 2 && halves[1] ? halves[1].split(':') : []
+
+  // Validate every group is a valid 1-4 hex digit token
+  const allGroups = [...leftGroups, ...rightGroups]
+  if (allGroups.some((g) => !/^[0-9a-fA-F]{1,4}$/.test(g))) return null
+
+  const missing = 8 - leftGroups.length - rightGroups.length
+  if (missing < 0) return null
+  if (halves.length === 1 && leftGroups.length !== 8) return null
+
+  const expanded = [
+    ...leftGroups,
+    ...Array<string>(missing).fill('0000'),
+    ...rightGroups,
+  ].map((g) => g.padStart(4, '0'))
+
+  if (expanded.length !== 8) return null
+  return expanded.join(':')
+}
+
+/**
+ * Convert a fully-expanded IPv6 address to a 128-bit value represented as a
+ * pair of 64-bit BigInt halves [high, low].
+ */
+function ipv6ToBigInt(expandedIp: string): bigint | null {
+  const groups = expandedIp.split(':')
+  if (groups.length !== 8) return null
+  try {
+    return groups.reduce<bigint>((acc, g) => (acc << 16n) | BigInt(parseInt(g, 16)), 0n)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse an IPv6 CIDR string (e.g. "2001:db8::/32") into its network address
+ * as a BigInt and prefix length.  Returns null for non-IPv6 or malformed input.
+ */
+function parseIpv6Cidr(cidr: string): { network: bigint; bits: number } | null {
+  const slashIdx = cidr.lastIndexOf('/')
+  if (slashIdx === -1) return null
+  const bits = parseInt(cidr.slice(slashIdx + 1), 10)
+  if (Number.isNaN(bits) || bits < 0 || bits > 128) return null
+  const addr = cidr.slice(0, slashIdx)
+  const expanded = expandIpv6(addr)
+  if (!expanded) return null
+  const network = ipv6ToBigInt(expanded)
+  if (network === null) return null
+  return { network, bits }
+}
+
+/**
+ * Returns true when ip is a plain IPv6 address (no CIDR slash) and equals
+ * the expanded form of the entry, or when it falls within an IPv6 CIDR block.
+ */
+function matchesIpv6Entry(ip: string, entry: string): boolean {
+  const expandedIp = expandIpv6(ip)
+  if (!expandedIp) return false
+  const ipVal = ipv6ToBigInt(expandedIp)
+  if (ipVal === null) return false
+
+  if (!entry.includes('/')) {
+    // Plain IPv6 address comparison — normalise both sides
+    const expandedEntry = expandIpv6(entry)
+    if (!expandedEntry) return false
+    return expandedIp === expandedEntry
+  }
+
+  const parsed = parseIpv6Cidr(entry)
+  if (!parsed) return false
+  const mask = parsed.bits === 0 ? 0n : (~0n << BigInt(128 - parsed.bits)) & ((1n << 128n) - 1n)
+  return (ipVal & mask) === (parsed.network & mask)
+}
+
 function matchesCidr(ip: string, cidr: string): boolean {
+  // Try IPv4 path first
   const parsed = parseCidr(cidr)
-  if (!parsed) return ip === cidr
-  const addr = ipToInt(ip)
-  if (addr === null) return false
-  const mask = ~0 << (32 - parsed.bits)
-  return (addr & mask) >>> 0 === (parsed.network & mask) >>> 0
+  if (parsed) {
+    const addr = ipToInt(ip)
+    if (addr === null) return false
+    const mask = ~0 << (32 - parsed.bits)
+    return (addr & mask) >>> 0 === (parsed.network & mask) >>> 0
+  }
+
+  // Fall through to IPv6
+  if (ip.includes(':') || cidr.includes(':')) {
+    return matchesIpv6Entry(ip, cidr)
+  }
+
+  // Neither IPv4 CIDR nor IPv6 — treat as exact string match
+  return ip === cidr
 }
 
 // ── Allowlist parsing ───────────────────────────────────────────────────────
@@ -146,4 +248,9 @@ export const _test = {
   shouldLog,
   normalizeIp,
   resetThrottle: () => lastLog.clear(),
+  // IPv6 helpers
+  expandIpv6,
+  ipv6ToBigInt,
+  parseIpv6Cidr,
+  matchesIpv6Entry,
 }

--- a/src/routes/milestones.ts
+++ b/src/routes/milestones.ts
@@ -18,6 +18,10 @@ import {
   DuplicateVerifierVoteError,
   getVerifierProfile,
 } from '../services/verifiers.js'
+import {
+  milestoneSchema,
+  flattenZodErrors,
+} from '../services/vaultValidation.js'
 
 import { completeVault, transitionVaultStatus } from '../services/vaultTransitions.js'
 import { getVaultById } from '../services/vaultStore.js'
@@ -39,25 +43,27 @@ milestonesRouter.post('/', authenticate, requireUser, async (req: Request, res: 
     return next(AppError.conflict('Cannot add milestones to a non-active vault'))
   }
 
-  const { description, approvalThreshold = 1 } = req.body as {
-    description?: string
-    approvalThreshold?: number
-  }
-  if (!description?.trim()) {
-    return next(AppError.badRequest('description is required'))
+  // Validate milestone fields using the same schema as vault creation.
+  const parsed = milestoneSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return next(AppError.badRequest('Invalid milestone payload', flattenZodErrors(parsed.error)))
   }
 
+  const { title, description, dueDate, amount } = parsed.data
+
+  const { approvalThreshold = 1 } = req.body as { approvalThreshold?: number }
   if (!Number.isInteger(approvalThreshold) || approvalThreshold < 1) {
     return next(AppError.badRequest('approvalThreshold must be a positive integer'))
   }
 
   const milestone = createMilestoneWithThreshold(
     vaultId,
-    description.trim(),
+    // Use title + optional description as the canonical description stored on the record.
+    description ? `${title}: ${description}` : title,
     approvalThreshold,
     vault.verifier,
   )
-  res.status(201).json(milestone)
+  res.status(201).json({ ...milestone, title, description, dueDate, amount })
 })
 
 // GET /api/vaults/:vaultId/milestones

--- a/src/routes/orgMembers.ts
+++ b/src/routes/orgMembers.ts
@@ -41,6 +41,7 @@ export const orgMembersRouter = Router()
 
 // ─── GET /api/organizations/:orgId/members ────────────────────────────────────
 // Any member can list the org's membership roster.
+// Supports pagination via ?page=<n>&pageSize=<n> (defaults: page=1, pageSize=20, max pageSize=100).
 
 orgMembersRouter.get(
   '/:orgId/members',
@@ -49,8 +50,28 @@ orgMembersRouter.get(
   orgReadRateLimiter,
   async (req: Request, res: Response) => {
     try {
-      const members = await listOrgMemberships(req.params.orgId)
-      res.json({ members })
+      const page = req.query.page !== undefined ? parseInt(String(req.query.page), 10) : 1
+      const pageSize = req.query.pageSize !== undefined ? parseInt(String(req.query.pageSize), 10) : 20
+
+      if (!Number.isFinite(page) || page < 1) {
+        res.status(400).json({ error: 'page must be a positive integer' })
+        return
+      }
+      if (!Number.isFinite(pageSize) || pageSize < 1 || pageSize > 100) {
+        res.status(400).json({ error: 'pageSize must be between 1 and 100' })
+        return
+      }
+
+      const result = await listOrgMemberships(req.params.orgId, { page, pageSize })
+      res.json({
+        members: result.members,
+        pagination: {
+          page: result.page,
+          pageSize: result.pageSize,
+          total: result.total,
+          totalPages: Math.ceil(result.total / result.pageSize),
+        },
+      })
     } catch {
       res.status(500).json({ error: 'Failed to list members.' })
     }

--- a/src/services/membership.ts
+++ b/src/services/membership.ts
@@ -108,10 +108,27 @@ export const listUserMemberships = async (
 
 export const listOrgMemberships = async (
   orgId: string,
-): Promise<Membership[]> => {
-  return db('memberships')
-    .where({ organization_id: orgId, team_id: null })
-    .select('*')
+  options: { page?: number; pageSize?: number } = {},
+): Promise<{ members: Membership[]; total: number; page: number; pageSize: number }> => {
+  const page = Math.max(1, options.page ?? 1)
+  const pageSize = Math.min(100, Math.max(1, options.pageSize ?? 20))
+  const offset = (page - 1) * pageSize
+
+  const [members, countResult] = await Promise.all([
+    db('memberships')
+      .where({ organization_id: orgId, team_id: null })
+      .select('*')
+      .orderBy('created_at', 'asc')
+      .limit(pageSize)
+      .offset(offset),
+    db('memberships')
+      .where({ organization_id: orgId, team_id: null })
+      .count<{ count: string }>('id as count')
+      .first(),
+  ])
+
+  const total = Number(countResult?.count ?? 0)
+  return { members, total, page, pageSize }
 }
 
 export const getUserOrganizationRole = async (

--- a/src/services/vaultValidation.ts
+++ b/src/services/vaultValidation.ts
@@ -111,11 +111,26 @@ const amountStringSchema = z.preprocess(
 
 // ─── Milestone schema ────────────────────────────────────────────────────────
 
-const milestoneSchema = z.object({
+/** Maximum length for milestone title. */
+export const MILESTONE_TITLE_MAX = 200
+
+/** Maximum length for milestone description. */
+export const MILESTONE_DESCRIPTION_MAX = 2000
+
+/**
+ * Canonical milestone field schema shared between vault-creation and the
+ * standalone milestone-creation endpoint.  Both code paths must produce
+ * milestones that satisfy the same invariants.
+ */
+export const milestoneSchema = z.object({
   title: z
     .string({ message: 'is required' })
-    .refine((v) => v.trim().length > 0, 'is required'),
-  description: z.string().optional(),
+    .refine((v) => v.trim().length > 0, 'is required')
+    .refine((v) => v.trim().length <= MILESTONE_TITLE_MAX, `must be at most ${MILESTONE_TITLE_MAX} characters`),
+  description: z
+    .string()
+    .max(MILESTONE_DESCRIPTION_MAX, `must be at most ${MILESTONE_DESCRIPTION_MAX} characters`)
+    .optional(),
   dueDate: utcTimestampSchema,
   amount: amountStringSchema,
 })

--- a/src/tests/orgMembers.e2e.test.ts
+++ b/src/tests/orgMembers.e2e.test.ts
@@ -120,15 +120,16 @@ jest.unstable_mockModule('../services/membership.js', async () => ({
     })
     return { role: input.role ?? 'member' }
   }),
-  listOrgMemberships: jest.fn(async (orgId: string) =>
-    getOrgMembers(orgId).map((m) => ({
+  listOrgMemberships: jest.fn(async (orgId: string) => {
+    const members = getOrgMembers(orgId).map((m) => ({
       id: `${m.orgId}:${m.userId}`,
       user_id: m.userId,
       organization_id: m.orgId,
       team_id: null,
       role: m.role,
-    })),
-  ),
+    }))
+    return { members, total: members.length, page: 1, pageSize: 20 }
+  }),
   removeMembership: jest.fn(),
   changeRole: jest.fn(),
   transferOwnership: jest.fn(),


### PR DESCRIPTION
Closes #1310 
Closes #1311 
Closes #1312 
Closes #1314

#1310 — Unified milestone field validation
milestoneSchema in vaultValidation.ts is now 
exported. Standalone POST /vaults/:id/milestones 
calls milestoneSchema.safeParse(req.body) — enforcing
title (required, ≤200 chars), dueDate (UTC ISO 8601)
, amount (bounds-checked), and description (≤2000 
chars) — identical to vault creation.

#1311 — OpenAPI spec drift CI check
generate-spec.ts gains a --check flag that 
regenerates in memory and exits 1 with a diff if 
docs/openapi.yaml is stale. New openapi:check script 
wired into ci.yml after the typecheck step.

#1312 — IPv6 support in metricsAuth allowlist
Added expandIpv6, ipv6ToBigInt, parseIpv6Cidr, and 
matchesIpv6Entry. matchesCidr falls through to the 
IPv6 path when either the IP or entry contains :, 
supporting plain addresses and CIDR blocks (e.g. 
2001:db8::/32). normalizeIp also strips zone IDs. New
helpers exported via _test.

#1314 — Paginated GET /organizations/:orgId/members
listOrgMemberships accepts { page, pageSize } and 
returns { members, total, page, pageSize } with 
.limit()/.offset() + parallel count. Route responds 
with 
{ members, pagination: { page, pageSize, total, totalPages } }
. Updated e2e test mock to match new shape.
