### PR TITLE
fix(#1282): reject active webhook subscriber with no event types

### DIFF
--- a/src/types/webhook.ts
+++ b/src/types/webhook.ts
@@ -1,26 +1,37 @@
 import { z } from 'zod'
 import { KNOWN_EVENT_TYPES } from '../services/webhooks.js'
 
-export const webhookCreateSchema = z.object({
-  url: z.string().trim().min(1, 'url is required').url('url must be a valid URL'),
-  events: z
-    .array(
-      z
-        .string()
-        .trim()
-        .min(1)
-        .superRefine((e, ctx) => {
-          if (!KNOWN_EVENT_TYPES.has(e)) {
-            ctx.addIssue({
-              code: 'custom',
-              message: `Unknown event type: "${e}". Known types: ${[...KNOWN_EVENT_TYPES].join(', ')}`,
-            })
-          }
-        }),
-    )
-    .default([]),
-  active: z.boolean().optional().default(true),
-})
+export const webhookCreateSchema = z
+  .object({
+    url: z.string().trim().min(1, 'url is required').url('url must be a valid URL'),
+    events: z
+      .array(
+        z
+          .string()
+          .trim()
+          .min(1)
+          .superRefine((e, ctx) => {
+            if (!KNOWN_EVENT_TYPES.has(e)) {
+              ctx.addIssue({
+                code: 'custom',
+                message: `Unknown event type: "${e}". Known types: ${[...KNOWN_EVENT_TYPES].join(', ')}`,
+              })
+            }
+          }),
+      )
+      .default([]),
+    active: z.boolean().optional().default(true),
+  })
+  .superRefine((data, ctx) => {
+    if (data.active && data.events.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['events'],
+        message:
+          'An active webhook subscriber must include at least one event type. Either provide events or set active to false.',
+      })
+    }
+  })
 
 export const webhookRotateSchema = z.object({}).strict()
 


### PR DESCRIPTION
webhookCreateSchema allowed a subscriber to be created with active:true and an empty events array (the default). Such a subscriber would never receive any delivery but nothing in the schema or POST handler flagged it as a mistake, leaving operators confused.

A .superRefine cross-field validator is added at the schema level:
- If active is true (or defaults to true) and events is empty, a validation error is returned on the events field with a clear message.
- Callers that intentionally want an inactive placeholder can set active:false and leave events empty — that combination is still accepted.

No changes to the route handler or service layer are required; Zod rejects the payload before it reaches the handler.
 

closes #1282 