### PR TITLE
fix(#1274): wrap transformHorizonOperation in arrow function at call …

### DIFF
--- a/src/services/transactionETL.ts
+++ b/src/services/transactionETL.ts
@@ -134,7 +134,7 @@ export class TransactionETLService {
       }
       
       const response = await builder.call()
-      return response.records.map(this.transformHorizonOperation)
+      return response.records.map((record) => this.transformHorizonOperation(record))
     } catch (error) {
       console.error('Error fetching Horizon operations:', error)
       throw error
@@ -441,7 +441,7 @@ export class TransactionETLService {
       
       const vaultOperations = operations.records
         .filter(op => new Date(op.created_at) >= from && new Date(op.created_at) <= to)
-        .map(this.transformHorizonOperation)
+        .map((record) => this.transformHorizonOperation(record))
       
       const transactions = await this.filterAndTransformOperations(vaultOperations)
       


### PR DESCRIPTION
…sites

Array.prototype.map() invokes callbacks with no bound receiver. Passing this.transformHorizonOperation as a bare reference worked by coincidence today because the method doesn't reference 'this', but would silently break the moment any instance state is accessed inside it.

Both call sites — fetchHorizonOperations and processAccountTransactions — are now wrapped with an explicit arrow function:
  .map((record) => this.transformHorizonOperation(record))

This guarantees the correct 'this' binding regardless of future edits to the method body.


closes #1274 