### PR TITLE
fix(#1287): scope listVerifications by targetIds instead of full-tabl…

### DIFF
--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -40,12 +40,16 @@ function assertOrgScope(context: GqlContext, resourceOrgId: string | null | unde
 // Batch-fetch verifications by targetId (org-scoped: only load IDs from within the org).
 const createLoaders = (orgVaultIds: Set<string>) => ({
   verificationsLoader: new DataLoader<string, VerificationRecord[]>(async (targetIds) => {
-    const allVerifications = await listVerifications()
+    // Scope the DB fetch to only the targetIds requested in this batch that
+    // also belong to the current org — avoids a full-table scan.
+    const scopedIds = targetIds.filter((id) => orgVaultIds.has(id))
+    const verifications = scopedIds.length > 0
+      ? await listVerifications(scopedIds)
+      : []
     const grouped = new Map<string, VerificationRecord[]>()
     targetIds.forEach(id => grouped.set(id, []))
-    for (const v of allVerifications) {
-      // Only surface verifications whose targetId is a vault/milestone in this org
-      if (grouped.has(v.targetId) && orgVaultIds.has(v.targetId)) {
+    for (const v of verifications) {
+      if (grouped.has(v.targetId)) {
         grouped.get(v.targetId)!.push(v)
       }
     }

--- a/src/services/verifiers.ts
+++ b/src/services/verifiers.ts
@@ -240,8 +240,12 @@ export const recordVerification = async (
   return mapVerificationRow(rec)
 }
 
-export const listVerifications = async (): Promise<VerificationRecord[]> => {
-  const rows = await db('verifications').select('*').orderBy('timestamp', 'desc')
+export const listVerifications = async (targetIds?: string[]): Promise<VerificationRecord[]> => {
+  const query = db('verifications').select('*').orderBy('timestamp', 'desc')
+  if (targetIds && targetIds.length > 0) {
+    query.whereIn('target_id', targetIds)
+  }
+  const rows = await query
   return rows.map(mapVerificationRow)
 }
 


### PR DESCRIPTION
…e scan

The GraphQL verificationsLoader DataLoader batch function was calling listVerifications() with no arguments on every first use, fetching every verification row across the entire system and then filtering in memory. Query cost grew with total system-wide verification volume, not with the requested batch size.

Changes:
- listVerifications() gains an optional targetIds string[] parameter. When provided, a whereIn('target_id', targetIds) clause is appended so the DB returns only rows for the requested targets.
- createLoaders in graphql.ts filters the incoming targetIds to those that belong to the current org (orgVaultIds) before passing them to listVerifications(). When the filtered set is empty the DB call is skipped entirely.

The result set is still grouped into the same Map structure the DataLoader expects, maintaining identical API behaviour while eliminating the unbounded scan.

closes #1287 