### PR TITLE
fix(#1292): memoize getSubmitRetryConfig to avoid re-parsing env on e…

### DIFF
--- a/src/services/soroban.ts
+++ b/src/services/soroban.ts
@@ -58,13 +58,19 @@ const positiveIntFromEnv = (key: string, fallback: number): number => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
-const getSubmitRetryConfig = (): RetryConfig => ({
-  maxAttempts: positiveIntFromEnv('RETRY_MAX_ATTEMPTS', DEFAULT_SUBMIT_RETRY_MAX_ATTEMPTS),
-  initialBackoffMs: positiveIntFromEnv('RETRY_BACKOFF_MS', DEFAULT_SUBMIT_RETRY_BACKOFF_MS),
-  maxBackoffMs: positiveIntFromEnv('SOROBAN_SUBMIT_RETRY_MAX_BACKOFF_MS', DEFAULT_SUBMIT_RETRY_MAX_BACKOFF_MS),
-  backoffMultiplier: DEFAULT_SUBMIT_RETRY_BACKOFF_MULTIPLIER,
-  jitterFactor: DEFAULT_SUBMIT_RETRY_JITTER_FACTOR,
-})
+let _cachedSubmitRetryConfig: RetryConfig | null = null
+
+const getSubmitRetryConfig = (): RetryConfig => {
+  if (_cachedSubmitRetryConfig) return _cachedSubmitRetryConfig
+  _cachedSubmitRetryConfig = {
+    maxAttempts: positiveIntFromEnv('RETRY_MAX_ATTEMPTS', DEFAULT_SUBMIT_RETRY_MAX_ATTEMPTS),
+    initialBackoffMs: positiveIntFromEnv('RETRY_BACKOFF_MS', DEFAULT_SUBMIT_RETRY_BACKOFF_MS),
+    maxBackoffMs: positiveIntFromEnv('SOROBAN_SUBMIT_RETRY_MAX_BACKOFF_MS', DEFAULT_SUBMIT_RETRY_MAX_BACKOFF_MS),
+    backoffMultiplier: DEFAULT_SUBMIT_RETRY_BACKOFF_MULTIPLIER,
+    jitterFactor: DEFAULT_SUBMIT_RETRY_JITTER_FACTOR,
+  }
+  return _cachedSubmitRetryConfig
+}
 
 /**
  * Returns the Soroban config only when ALL required env vars are present.


### PR DESCRIPTION
…very call

getSubmitRetryConfig() was a plain function that called positiveIntFromEnv() for RETRY_MAX_ATTEMPTS, RETRY_BACKOFF_MS, and SOROBAN_SUBMIT_RETRY_MAX_BACKOFF_MS on every invocation. It is called by getSorobanConfig() on each Soroban submission attempt, so the env-parsing work was duplicated unnecessarily.

Retry configuration is operationally static: env vars don't change at runtime. A module-level _cachedSubmitRetryConfig variable is added. getSubmitRetryConfig returns the cached value on all subsequent calls after the first, eliminating redundant parseInt work without changing any observable behaviour.

closes #1292