### PR TITLE
fix: preserve empty-string milestone descriptions in embedding text

### DIFF
--- a/src/services/evidenceReindex.ts
+++ b/src/services/evidenceReindex.ts
@@ -52,8 +52,8 @@ const defaultSleep = (ms: number): Promise<void> =>
     setTimeout(resolve, ms)
   })
 
-const buildEmbeddingText = (milestone: { title: string; description: string | null }): string =>
-  [milestone.title, milestone.description].filter(Boolean).join('\n')
+export const buildEmbeddingText = (milestone: { title: string; description: string | null }): string =>
+  [milestone.title, milestone.description].filter((part): part is string => part != null).join('\n')
 
 /**
  * Process a single bounded page of the milestones table, (re)generating any

--- a/src/tests/evidence.reindex.test.ts
+++ b/src/tests/evidence.reindex.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals'
 import {
   reindexEvidenceBatch,
   runReindexBatches,
+  buildEmbeddingText,
   EMBEDDING_REINDEX_JOB_NAME,
   type MilestoneEmbeddingSource,
   type ReindexCursorStore,
@@ -73,6 +74,22 @@ const makeMilestones = (count: number): FakeMilestoneRow[] =>
   }))
 
 const provider = new DeterministicEmbeddingProvider('v1')
+
+// ── buildEmbeddingText ───────────────────────────────────────────────────────
+
+describe('buildEmbeddingText', () => {
+  it('joins title and description on separate lines', () => {
+    expect(buildEmbeddingText({ title: 'Title', description: 'Description' })).toBe('Title\nDescription')
+  })
+
+  it('omits the description line when it is null', () => {
+    expect(buildEmbeddingText({ title: 'Title', description: null })).toBe('Title')
+  })
+
+  it('preserves an explicitly empty description rather than dropping it like a null one', () => {
+    expect(buildEmbeddingText({ title: 'Title', description: '' })).toBe('Title\n')
+  })
+})
 
 // ── reindexEvidenceBatch ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `buildEmbeddingText` used `.filter(Boolean)`, which treats an explicitly empty `description` (`''`) the same as `null`/absent, silently excluding it from the embedding text.
- Filters on nullishness (`part != null`) instead, so an empty-string description still contributes a line, distinguishing it from a genuinely absent one.

Closes #1295

## Test plan
- [x] Added unit tests for `buildEmbeddingText` covering: title+description, null description (omitted), and empty-string description (preserved as a blank line)
- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js src/tests/evidence.reindex.test.ts` — all new/existing tests pass except one pre-existing failing test (`embeddings.reindex job handler`) confirmed to fail identically on `main` prior to this change