### PR TITLE
fix: wire AbuseMonitor.cleanup() into recurring job scheduler (#1094)

### DIFF
--- a/src/app-bootstrap.ts
+++ b/src/app-bootstrap.ts
@@ -51,7 +51,7 @@ export function bootstrapApp(options: BootstrapOptions = {}) {
         process.env.NOTIFICATION_PROVIDER ??
         "console",
     );
-  const jobSystem = new BackgroundJobSystem(notificationService);
+  const jobSystem = new BackgroundJobSystem(notificationService, undefined, privacyAbuseMonitor);
   configureExportJobRepository(createKnexExportJobRepository(db))
   configureDlqRepository(createKnexDlqRepository(db))
 

--- a/src/jobs/system.ts
+++ b/src/jobs/system.ts
@@ -13,6 +13,7 @@ import {
   createNotificationService,
   type NotificationService,
 } from '../services/notifications/factory.js'
+import type { AbuseMonitor } from '../services/abuse-monitor.js'
 import db from '../db/index.js'
 import { getPgPool } from '../db/pool.js'
 import { MilestoneRepository } from '../repositories/milestoneRepository.js'
@@ -167,12 +168,14 @@ class SchedulerRegistry {
 export class BackgroundJobSystem {
   private readonly queue: InMemoryJobQueue
   private readonly schedulerRegistry: SchedulerRegistry
+  private readonly abuseMonitor?: AbuseMonitor
   private started = false
   private shuttingDown = false
 
   constructor(
     notificationService?: NotificationService,
     embeddingReindex?: EmbeddingReindexDependencies,
+    abuseMonitor?: AbuseMonitor,
   ) {
     this.queue = new InMemoryJobQueue({
       concurrency: parsePositiveInteger(process.env.JOB_WORKER_CONCURRENCY, 2),
@@ -181,6 +184,7 @@ export class BackgroundJobSystem {
       staleLeaseMs: parsePositiveInteger(process.env.JOB_STALE_LEASE_MS, 300_000),
     })
     this.schedulerRegistry = new SchedulerRegistry()
+    this.abuseMonitor = abuseMonitor
 
     const resolvedNotificationService =
       notificationService ?? createNotificationService(process.env.NOTIFICATION_PROVIDER ?? 'console')
@@ -454,5 +458,22 @@ export class BackgroundJobSystem {
         this.enqueue('analytics.report.generate', {})
       },
     })
+
+    if (this.abuseMonitor) {
+      const abuseMonitorCleanupIntervalMs = parsePositiveInteger(
+        process.env.ABUSE_MONITOR_CLEANUP_INTERVAL_MS,
+        300_000, // 5 minutes
+      )
+
+      this.schedulerRegistry.registerJob({
+        name: 'abuse-monitor.cleanup',
+        intervalMs: abuseMonitorCleanupIntervalMs,
+        immediate: false,
+        initialDelayMs: 30_000,
+        execute: () => {
+          this.abuseMonitor!.cleanup()
+        },
+      })
+    }
   }
 }


### PR DESCRIPTION
Closes #1094 
Here's a summary of the three changes:
1. src/jobs/system.ts — Added import type { AbuseMonitor } (line 16), a private abuseMonitor? field (line 171), an optional third constructor parameter (line 178), and a scheduled job abuse-monitor.cleanup (lines 462-477) that calls this.abuseMonitor!.cleanup() every 5 minutes (configurable via ABUSE_MONITOR_CLEANUP_INTERVAL_MS), starting after a 30-second initial delay.
2. src/app-bootstrap.ts — Passes privacyAbuseMonitor as the third argument to new BackgroundJobSystem(notificationService, undefined, privacyAbuseMonitor) (line 54).
Now cleanup() runs periodically, purging entries whose lastSeen exceeds the 1-hour TTL, so the 10,000-entry cap acts as a true sliding window instead of a permanent ceiling.