### PR TITLE
fix: normalize trailing slashes and casing in CORS origin check

### DIFF
--- a/src/config/cors.ts
+++ b/src/config/cors.ts
@@ -40,8 +40,8 @@ export const corsOptions: CorsOptions = {
     }
 
     // Check allowlist
-    const allowedOrigins = config.corsOrigins as string[]
-    const normalizedOrigin = origin.replace(/\/+$/, '')
+    const allowedOrigins = (config.corsOrigins as string[]).map(o => o.replace(/\/+$/, '').toLowerCase())
+    const normalizedOrigin = origin.replace(/\/+$/, '').toLowerCase()
     if (allowedOrigins.includes(normalizedOrigin)) {
       callback(null, true);
     } else {


### PR DESCRIPTION
The corsOptions.origin callback in src/config/cors.ts normalized the incoming origin by stripping trailing slashes but never normalized the configured allowedOrigins list. This meant a configured origin like https://app.example.com/ would fail to match an incoming Origin: https://app.example.com, causing spurious CORS rejections for legitimate requests. Also added lowercasing to both sides to handle host casing differences.

Closes #1270