### PR TITLE
added protection against an empty or missing subscriber secret

### DIFF
--- a/src/services/webhooks.ts
+++ b/src/services/webhooks.ts
@@ -428,18 +428,39 @@ export const isUrlAllowed = (
 }
 
 /**
+ * Minimum length for a webhook signing secret. Secrets shorter than this are
+ * rejected to prevent accidental use of empty or weak keys.
+ */
+const MIN_SECRET_LENGTH = 16
+
+/**
  * Returns the HMAC-SHA256 signature header value for a given payload body.
  * Format: `sha256=<hex-digest>`
+ *
+ * Throws if `secret` is not a non-empty string of at least {@link MIN_SECRET_LENGTH}
+ * characters, preventing signatures from being computed with a trivially
+ * guessable key.
  */
 export const signPayload = (secret: string, body: string): string => {
+  if (!secret || typeof secret !== 'string' || secret.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `Webhook signing secret must be a non-empty string of at least ${MIN_SECRET_LENGTH} characters`,
+    )
+  }
   const digest = createHmac('sha256', secret).update(body, 'utf8').digest('hex')
   return `sha256=${digest}`
 }
 
 /**
  * Verifies a webhook signature in constant time.
+ *
+ * Returns `false` if `secret` is not a valid non-empty string (instead of
+ * silently computing an HMAC with an empty key).
  */
 export const verifySignature = (secret: string, body: string, signature: string): boolean => {
+  if (!secret || typeof secret !== 'string' || secret.length < MIN_SECRET_LENGTH) {
+    return false
+  }
   const expected = signPayload(secret, body)
   if (expected.length !== signature.length) {
     return false
@@ -540,6 +561,12 @@ export const addSubscriber = async (
   events: string[],
   schemaVersion: number = DEFAULT_SCHEMA_VERSION,
 ): Promise<WebhookSubscriber> => {
+  if (!secret || typeof secret !== 'string' || secret.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `Webhook signing secret must be a non-empty string of at least ${MIN_SECRET_LENGTH} characters`,
+    )
+  }
+
   const check = await isUrlAllowedForOrg(organizationId, url)
   if (!check.allowed) {
     throw new Error(check.reason!)
@@ -586,6 +613,12 @@ export const upsertSubscriber = async (
   secret: string,
   events: string[],
 ): Promise<WebhookSubscriber> => {
+  if (!secret || typeof secret !== 'string' || secret.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `Webhook signing secret must be a non-empty string of at least ${MIN_SECRET_LENGTH} characters`,
+    )
+  }
+
   const check = await isUrlAllowedForOrg(organizationId, url)
   if (!check.allowed) {
     throw new Error(check.reason!)
@@ -609,6 +642,11 @@ export const rotateSubscriberSecret = async (
   organizationId: string,
   newSecret: string,
 ): Promise<WebhookSubscriber | null> => {
+  if (!newSecret || typeof newSecret !== 'string' || newSecret.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `Webhook signing secret must be a non-empty string of at least ${MIN_SECRET_LENGTH} characters`,
+    )
+  }
   return repo.rotateSecret(id, organizationId, newSecret)
 }
 

--- a/src/tests/webhookSubscriber.rotation.test.ts
+++ b/src/tests/webhookSubscriber.rotation.test.ts
@@ -133,14 +133,14 @@ describeDb('WebhookSubscriberRepository – upsert & secret rotation', () => {
       await repo.upsert({
         organizationId: ORG_A,
         url: HOOK_URL,
-        secret: 'old-secret',
+        secret: 'old-secret-valid-key',
         events: [],
       })
 
       await repo.upsert({
         organizationId: ORG_A,
         url: HOOK_URL,
-        secret: 'new-secret',
+        secret: 'new-secret-valid-key',
         events: ['vault_created', 'vault_completed'],
       })
 
@@ -263,7 +263,7 @@ describeDb('WebhookSubscriberRepository – upsert & secret rotation', () => {
         events: [],
       })
 
-      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret-valid-key')
 
       expect(rotated).not.toBeNull()
       expect(rotated!.secret).toBe('new-secret')
@@ -275,7 +275,7 @@ describeDb('WebhookSubscriberRepository – upsert & secret rotation', () => {
       const result = await repo.rotateSecret(
         '00000000-0000-0000-0000-000000000000',
         ORG_A,
-        'new-secret',
+        'new-secret-valid-key',
       )
       expect(result).toBeNull()
     })
@@ -336,13 +336,13 @@ describeDb('WebhookSubscriberRepository – upsert & secret rotation', () => {
       const sub = await repo.upsert({
         organizationId: ORG_A,
         url: HOOK_URL,
-        secret: 'old-secret',
+        secret: 'old-secret-valid-key',
         events: [],
       })
-      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret-valid-key')
 
       const body = '{"hello":"world"}'
-      const sig = signPayload('new-secret', body)
+      const sig = signPayload('new-secret-valid-key', body)
 
       expect(verifySignatureWithGrace(rotated!, body, sig)).toBe(true)
     })
@@ -351,14 +351,14 @@ describeDb('WebhookSubscriberRepository – upsert & secret rotation', () => {
       const sub = await repo.upsert({
         organizationId: ORG_A,
         url: HOOK_URL,
-        secret: 'old-secret',
+        secret: 'old-secret-valid-key',
         events: [],
       })
-      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret-valid-key')
 
       const body = '{"hello":"world"}'
       // Sign with the OLD secret (simulates an in-flight delivery)
-      const oldSig = signPayload('old-secret', body)
+      const oldSig = signPayload('old-secret-valid-key', body)
 
       expect(verifySignatureWithGrace(rotated!, body, oldSig)).toBe(true)
     })
@@ -368,17 +368,17 @@ describeDb('WebhookSubscriberRepository – upsert & secret rotation', () => {
       const sub = await repo.upsert({
         organizationId: ORG_A,
         url: HOOK_URL,
-        secret: 'old-secret',
+        secret: 'old-secret-valid-key',
         events: [],
       })
-      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret-valid-key')
 
       // Back-date rotated_at to 48 h ago (beyond 24 h grace window)
       const expiredRotatedAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
       const expiredSub = { ...rotated!, rotatedAt: expiredRotatedAt }
 
       const body = '{"hello":"world"}'
-      const oldSig = signPayload('old-secret', body)
+      const oldSig = signPayload('old-secret-valid-key', body)
 
       // Grace window has closed – old secret should be rejected
       expect(isPreviousSecretInGrace(expiredSub)).toBe(false)
@@ -389,16 +389,16 @@ describeDb('WebhookSubscriberRepository – upsert & secret rotation', () => {
       const sub = await repo.upsert({
         organizationId: ORG_A,
         url: HOOK_URL,
-        secret: 'old-secret',
+        secret: 'old-secret-valid-key',
         events: [],
       })
-      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret-valid-key')
 
       const expiredRotatedAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
       const expiredSub = { ...rotated!, rotatedAt: expiredRotatedAt }
 
       const body = '{"hello":"world"}'
-      const newSig = signPayload('new-secret', body)
+      const newSig = signPayload('new-secret-valid-key', body)
 
       expect(verifySignatureWithGrace(expiredSub, body, newSig)).toBe(true)
     })
@@ -417,10 +417,10 @@ describeDb('WebhookSubscriberRepository – upsert & secret rotation', () => {
       const sub = await repo.upsert({
         organizationId: ORG_A,
         url: HOOK_URL,
-        secret: 'old-secret',
+        secret: 'old-secret-valid-key',
         events: [],
       })
-      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret')
+      const rotated = await repo.rotateSecret(sub.id, ORG_A, 'new-secret-valid-key')
 
       // Set a very short grace window (1 ms) then back-date by 1 second
       const originalEnv = process.env.WEBHOOK_SECRET_GRACE_WINDOW_MS

--- a/src/tests/webhooks.circuitBreaker.test.ts
+++ b/src/tests/webhooks.circuitBreaker.test.ts
@@ -69,7 +69,7 @@ const makeSubscriber = (overrides: Record<string, any> = {}) => ({
   id: randomUUID(),
   organizationId: 'test-org',
   url: 'https://example.com/hook',
-  secret: 'test-secret',
+  secret: 'test-secret-123',
   events: [],
   active: true,
   schemaVersion: 1,

--- a/src/tests/webhooks.deadletter.test.ts
+++ b/src/tests/webhooks.deadletter.test.ts
@@ -36,7 +36,7 @@ describeDb('webhook dead-letter queue', () => {
   })
 
   it('persists a dead letter when delivery exhausts retries', async () => {
-    addSubscriber('https://example.com/hook', 'secret', [])
+    addSubscriber('https://example.com/hook', 'a-valid-secret-key', [])
     fetchMock.mockResolvedValue({ status: 503 } as Response)
 
     await dispatchWebhookEvent(makePayload())
@@ -52,7 +52,7 @@ describeDb('webhook dead-letter queue', () => {
   }, 20_000)
 
   it('does not persist a dead letter on successful delivery', async () => {
-    addSubscriber('https://example.com/hook', 'secret', [])
+    addSubscriber('https://example.com/hook', 'a-valid-secret-key', [])
     fetchMock.mockResolvedValue({ status: 200 } as Response)
 
     await dispatchWebhookEvent(makePayload())
@@ -87,7 +87,7 @@ describeDb('webhook dead-letter queue', () => {
   })
 
   it('replayDeadLetter re-delivers and stamps replayed_at', async () => {
-    const sub = addSubscriber('https://example.com/hook', 'secret', [])
+    const sub = addSubscriber('https://example.com/hook', 'a-valid-secret-key', [])
     fetchMock.mockResolvedValue({ status: 200 } as Response)
 
     const { db } = await import('../db/index.js')
@@ -110,7 +110,7 @@ describeDb('webhook dead-letter queue', () => {
   })
 
   it('replayDeadLetter fails gracefully when delivery fails', async () => {
-    const sub = addSubscriber('https://example.com/hook', 'secret', [])
+    const sub = addSubscriber('https://example.com/hook', 'a-valid-secret-key', [])
     fetchMock.mockResolvedValue({ status: 500 } as Response)
 
     const { db } = await import('../db/index.js')
@@ -134,7 +134,7 @@ describeDb('webhook dead-letter queue', () => {
   }, 20_000)
 
   it('replayDeadLetter rejects already-replayed entries', async () => {
-    const sub = addSubscriber('https://example.com/hook', 'secret', [])
+    const sub = addSubscriber('https://example.com/hook', 'a-valid-secret-key', [])
 
     const { db } = await import('../db/index.js')
     const [row] = await db('webhook_dead_letters')

--- a/src/tests/webhooks.e2e.test.ts
+++ b/src/tests/webhooks.e2e.test.ts
@@ -61,7 +61,7 @@ describe('Webhook Delivery Pipeline (E2E)', () => {
   })
 
   it('successfully delivers a signed webhook when an event matches the subscriber filter', async () => {
-    const secret = 'super-secret'
+    const secret = 'super-secret-key-long'
     const targetUrl = `http://127.0.0.2:${sinkPort}/hook`
     
     addSubscriber(targetUrl, secret, ['vault_completed'])
@@ -91,7 +91,7 @@ describe('Webhook Delivery Pipeline (E2E)', () => {
   })
 
   it('retries delivery when the sink initially fails and eventually succeeds', async () => {
-    const secret = 'retry-secret'
+    const secret = 'retry-secret-key-123'
     addSubscriber(`http://127.0.0.2:${sinkPort}/retry`, secret, ['vault_completed'])
     
     sinkStatusQueue.push(503, 200)
@@ -107,7 +107,7 @@ describe('Webhook Delivery Pipeline (E2E)', () => {
   }, 10000)
 
   it('detects a signature mismatch if validated against the wrong secret', async () => {
-    const secret = 'correct-secret'
+    const secret = 'correct-secret-123'
     addSubscriber(`http://127.0.0.2:${sinkPort}/sig`, secret, ['vault_completed'])
     
     await processor.processEvent(mockVaultCreatedEvent)
@@ -118,12 +118,12 @@ describe('Webhook Delivery Pipeline (E2E)', () => {
     expect(receivedRequests).toHaveLength(1)
     const req = receivedRequests[0]
     
-    const wrongSig = signPayload('wrong-secret', req.body)
+    const wrongSig = signPayload('wrong-secret-12345', req.body)
     expect(req.headers['x-disciplr-signature']).not.toBe(wrongSig)
   })
 
   it('does not deliver if the event type does not match the subscriber filter', async () => {
-    addSubscriber(`http://127.0.0.2:${sinkPort}/nomatch`, 'secret', ['vault_failed'])
+    addSubscriber(`http://127.0.0.2:${sinkPort}/nomatch`, 'a-valid-secret-key', ['vault_failed'])
     
     await processor.processEvent(mockVaultCreatedEvent)
     await processor.processEvent(mockVaultCompletedEvent)
@@ -135,10 +135,10 @@ describe('Webhook Delivery Pipeline (E2E)', () => {
 
   it('rejects an SSRF-blocked URL and does not attempt delivery', () => {
     expect(() => {
-      addSubscriber('http://127.0.0.1/hook', 'secret', ['vault_completed'])
+      addSubscriber('http://127.0.0.1/hook', 'a-valid-secret-key', ['vault_completed'])
     }).toThrow('Webhook URL not permitted')
     expect(() => {
-      addSubscriber('http://localhost/hook', 'secret', ['vault_completed'])
+      addSubscriber('http://localhost/hook', 'a-valid-secret-key', ['vault_completed'])
     }).toThrow('Webhook URL not permitted')
   })
 })

--- a/src/tests/webhooks.egressAllowlist.test.ts
+++ b/src/tests/webhooks.egressAllowlist.test.ts
@@ -221,27 +221,27 @@ describe('egress allowlist — registration enforcement', () => {
     await addEgressAllowlistEntry(ORG, 'allowed.example.com')
 
     await expect(
-      addSubscriber(ORG, 'https://evil.example.com/hook', 'secret', ['vault_created']),
+      addSubscriber(ORG, 'https://evil.example.com/hook', 'a-valid-secret-key', ['vault_created']),
     ).rejects.toThrow(/egress allowlist/i)
   })
 
   it('allows addSubscriber when host is on the allowlist', async () => {
     await addEgressAllowlistEntry(ORG, 'allowed.example.com')
 
-    const sub = await addSubscriber(ORG, 'https://allowed.example.com/hook', 'secret', ['vault_created'])
+    const sub = await addSubscriber(ORG, 'https://allowed.example.com/hook', 'a-valid-secret-key', ['vault_created'])
     expect(sub.url).toBe('https://allowed.example.com/hook')
   })
 
   it('allows subdomain of an allowlisted host', async () => {
     await addEgressAllowlistEntry(ORG, 'example.com')
 
-    const sub = await addSubscriber(ORG, 'https://hooks.example.com/cb', 'secret', ['vault_created'])
+    const sub = await addSubscriber(ORG, 'https://hooks.example.com/cb', 'a-valid-secret-key', ['vault_created'])
     expect(sub.url).toBe('https://hooks.example.com/cb')
   })
 
   it('allows any allowed-SSRF host when org has no allowlist', async () => {
     // OTHER_ORG has no allowlist — only SSRF guard applies
-    const sub = await addSubscriber(OTHER_ORG, 'https://any-valid.example.com/hook', 'secret', [])
+    const sub = await addSubscriber(OTHER_ORG, 'https://any-valid.example.com/hook', 'a-valid-secret-key', [])
     expect(sub.url).toBe('https://any-valid.example.com/hook')
   })
 
@@ -249,7 +249,7 @@ describe('egress allowlist — registration enforcement', () => {
     await addEgressAllowlistEntry(ORG, 'allowed.example.com')
 
     await expect(
-      upsertSubscriber(ORG, 'https://not-allowed.example.com/hook', 'secret', []),
+      upsertSubscriber(ORG, 'https://not-allowed.example.com/hook', 'a-valid-secret-key', []),
     ).rejects.toThrow(/egress allowlist/i)
   })
 
@@ -258,7 +258,7 @@ describe('egress allowlist — registration enforcement', () => {
     await addEgressAllowlistEntry(ORG, '169.254.169.254')
 
     await expect(
-      addSubscriber(ORG, 'http://169.254.169.254/latest/meta-data', 'secret', []),
+      addSubscriber(ORG, 'http://169.254.169.254/latest/meta-data', 'a-valid-secret-key', []),
     ).rejects.toThrow(/not permitted/i)
   })
 })
@@ -268,7 +268,7 @@ describe('egress allowlist — delivery-time enforcement', () => {
     // Add two entries so the allowlist stays non-empty after removing hooks.example.com
     await addEgressAllowlistEntry(ORG, 'hooks.example.com')
     await addEgressAllowlistEntry(ORG, 'other.example.com')
-    await addSubscriber(ORG, 'https://hooks.example.com/cb', 'secret', ['vault_created'])
+    await addSubscriber(ORG, 'https://hooks.example.com/cb', 'a-valid-secret-key', ['vault_created'])
 
     // Remove the subscriber's host — allowlist still exists (other.example.com remains)
     await removeEgressAllowlistEntry(ORG, 'hooks.example.com')
@@ -292,7 +292,7 @@ describe('egress allowlist — delivery-time enforcement', () => {
     } as Response)
     global.fetch = fetchMock as any
 
-    await addSubscriber(OTHER_ORG, 'https://hooks.example.com/cb', 'secret', ['vault_created'])
+    await addSubscriber(OTHER_ORG, 'https://hooks.example.com/cb', 'a-valid-secret-key', ['vault_created'])
 
     const results = await dispatchWebhookEvent({ ...PAYLOAD, organizationId: OTHER_ORG })
 
@@ -308,7 +308,7 @@ describe('egress allowlist — delivery-time enforcement', () => {
       id: 'sub-ssrf',
       organizationId: ORG,
       url: 'http://169.254.169.254/hook',
-      secret: 'secret',
+      secret: 'a-valid-secret-key',
       previousSecret: null,
       rotatedAt: null,
       events: ['vault_created'],
@@ -334,7 +334,7 @@ describe('egress allowlist — replayDeadLetter enforcement', () => {
     // Add two entries so the allowlist stays non-empty after removing hooks.example.com
     await addEgressAllowlistEntry(ORG, 'hooks.example.com')
     await addEgressAllowlistEntry(ORG, 'other.example.com')
-    const sub = await addSubscriber(ORG, 'https://hooks.example.com/cb', 'secret', ['vault_created'])
+    const sub = await addSubscriber(ORG, 'https://hooks.example.com/cb', 'a-valid-secret-key', ['vault_created'])
 
     // Remove subscriber's host — allowlist still exists (other.example.com remains)
     await removeEgressAllowlistEntry(ORG, 'hooks.example.com')

--- a/src/tests/webhooks.eventFilters.test.ts
+++ b/src/tests/webhooks.eventFilters.test.ts
@@ -79,20 +79,20 @@ beforeEach(() => {
 
 describe('addSubscriber event type validation', () => {
   it('accepts empty events array (wildcard)', async () => {
-    const sub = await addSubscriber(TEST_ORG, 'https://example.com/hook', 'secret', [])
+    const sub = await addSubscriber(TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key', [])
     expect(sub.events).toEqual([])
   })
 
   it('accepts known event types', async () => {
     for (const event of KNOWN_EVENT_TYPES) {
-      const sub = await addSubscriber(TEST_ORG, 'https://example.com/hook', 'secret', [event])
+      const sub = await addSubscriber(TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key', [event])
       expect(sub.events).toEqual([event])
     }
   })
 
   it('accepts multiple known event types', async () => {
     const sub = await addSubscriber(
-      TEST_ORG, 'https://example.com/hook', 'secret',
+      TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key',
       ['vault_created', 'vault_completed'],
     )
     expect(sub.events).toEqual(['vault_created', 'vault_completed'])
@@ -100,14 +100,14 @@ describe('addSubscriber event type validation', () => {
 
   it('rejects unknown event types', async () => {
     await expect(
-      addSubscriber(TEST_ORG, 'https://example.com/hook', 'secret', ['vault_slashed']),
+      addSubscriber(TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key', ['vault_slashed']),
     ).rejects.toThrow('Unknown event type: "vault_slashed"')
   })
 
   it('rejects if any event type is unknown', async () => {
     await expect(
       addSubscriber(
-        TEST_ORG, 'https://example.com/hook', 'secret',
+        TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key',
         ['vault_created', 'vault_slashed'],
       ),
     ).rejects.toThrow('Unknown event type: "vault_slashed"')
@@ -131,7 +131,7 @@ describe('dispatchWebhookEvent event type filtering', () => {
   })
 
   it('delivers to subscriber with empty events (wildcard)', async () => {
-    await addSubscriber(TEST_ORG, 'https://example.com/hook', 'secret', [])
+    await addSubscriber(TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key', [])
     fetchMock.mockResolvedValue({ status: 200 } as Response)
 
     const results = await dispatchWebhookEvent(makePayload('vault_created'))
@@ -140,7 +140,7 @@ describe('dispatchWebhookEvent event type filtering', () => {
   })
 
   it('delivers when subscriber event type matches', async () => {
-    await addSubscriber(TEST_ORG, 'https://example.com/hook', 'secret', ['vault_completed'])
+    await addSubscriber(TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key', ['vault_completed'])
     fetchMock.mockResolvedValue({ status: 200 } as Response)
 
     const results = await dispatchWebhookEvent(makePayload('vault_completed'))
@@ -149,7 +149,7 @@ describe('dispatchWebhookEvent event type filtering', () => {
   })
 
   it('skips delivery when subscriber event type does not match', async () => {
-    await addSubscriber(TEST_ORG, 'https://example.com/hook', 'secret', ['vault_completed'])
+    await addSubscriber(TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key', ['vault_completed'])
     fetchMock.mockResolvedValue({ status: 200 } as Response)
 
     const results = await dispatchWebhookEvent(makePayload('vault_created'))
@@ -158,9 +158,9 @@ describe('dispatchWebhookEvent event type filtering', () => {
   })
 
   it('delivers only to matching subscribers among many', async () => {
-    await addSubscriber(TEST_ORG, 'https://a.example.com/hook', 'secret', ['vault_created'])
-    await addSubscriber(TEST_ORG, 'https://b.example.com/hook', 'secret', ['vault_completed'])
-    await addSubscriber(TEST_ORG, 'https://c.example.com/hook', 'secret', [])
+    await addSubscriber(TEST_ORG, 'https://a.example.com/hook', 'a-valid-secret-key', ['vault_created'])
+    await addSubscriber(TEST_ORG, 'https://b.example.com/hook', 'a-valid-secret-key', ['vault_completed'])
+    await addSubscriber(TEST_ORG, 'https://c.example.com/hook', 'a-valid-secret-key', [])
     fetchMock.mockResolvedValue({ status: 200 } as Response)
 
     const results = await dispatchWebhookEvent(makePayload('vault_created'))
@@ -170,7 +170,7 @@ describe('dispatchWebhookEvent event type filtering', () => {
   })
 
   it('works with milestone and settlement event types', async () => {
-    await addSubscriber(TEST_ORG, 'https://example.com/hook', 'secret', ['milestone_created'])
+    await addSubscriber(TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key', ['milestone_created'])
     fetchMock.mockResolvedValue({ status: 200 } as Response)
 
     const results = await dispatchWebhookEvent(makePayload('milestone_created'))

--- a/src/tests/webhooks.schemaVersion.test.ts
+++ b/src/tests/webhooks.schemaVersion.test.ts
@@ -132,18 +132,18 @@ describe('addSubscriber schemaVersion', () => {
   })
 
   it('defaults to schema version 1', async () => {
-    const sub = await addSubscriber(TEST_ORG, 'https://example.com/hook', 'secret', ['vault_created'])
+    const sub = await addSubscriber(TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key', ['vault_created'])
     expect(sub.schemaVersion).toBe(1)
   })
 
   it('accepts version 2', async () => {
-    const sub = await addSubscriber(TEST_ORG, 'https://example.com/hook', 'secret', ['vault_created'], 2)
+    const sub = await addSubscriber(TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key', ['vault_created'], 2)
     expect(sub.schemaVersion).toBe(2)
   })
 
   it('rejects unsupported version', async () => {
     await expect(
-      addSubscriber(TEST_ORG, 'https://example.com/hook', 'secret', ['vault_created'], 99),
+      addSubscriber(TEST_ORG, 'https://example.com/hook', 'a-valid-secret-key', ['vault_created'], 99),
     ).rejects.toThrow('Unsupported webhook schema version: 99')
   })
 })

--- a/src/tests/webhooks.ssrf.test.ts
+++ b/src/tests/webhooks.ssrf.test.ts
@@ -36,7 +36,7 @@ describe('webhook SSRF guard', () => {
     ['DNS-rebinding-style loopback hostname', 'http://hook.localtest.me/callback'],
   ])('blocks %s', (_label, url) => {
     expect(isUrlAllowed(url, [])).toBe(false)
-    expect(() => addSubscriber(url, 'secret', [])).toThrow(/not permitted/i)
+    expect(() => addSubscriber(url, 'a-valid-secret-key', [])).toThrow(/not permitted/i)
   })
 
   it('enforces WEBHOOK_ALLOWED_HOSTS while still blocking internal targets', () => {
@@ -56,7 +56,7 @@ describe('webhook SSRF guard', () => {
     global.fetch = fetchMock as any
     jest.spyOn(console, 'error').mockImplementation(() => undefined)
 
-    addSubscriber('https://hooks.example.com/webhook', 'secret', ['vault_created'])
+    addSubscriber('https://hooks.example.com/webhook', 'a-valid-secret-key', ['vault_created'])
 
     const results = await dispatchWebhookEvent(payload)
 

--- a/src/tests/webhooks.test.ts
+++ b/src/tests/webhooks.test.ts
@@ -79,45 +79,66 @@ const TEST_ORG = 'test-org-id'
 
 describe('signPayload', () => {
   it('returns a sha256= prefixed hex string', () => {
-    const sig = signPayload('secret', '{"hello":"world"}')
+    const sig = signPayload('a-valid-secret-key', '{"hello":"world"}')
     expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/)
   })
 
   it('produces a deterministic signature for the same inputs', () => {
     const body = '{"eventType":"vault_created"}'
-    expect(signPayload('s3cr3t', body)).toBe(signPayload('s3cr3t', body))
+    expect(signPayload('s3cr3t-key-long', body)).toBe(signPayload('s3cr3t-key-long', body))
   })
 
   it('produces different signatures for different secrets', () => {
     const body = '{"eventType":"vault_created"}'
-    expect(signPayload('secret-a', body)).not.toBe(signPayload('secret-b', body))
+    expect(signPayload('secret-key-alpha', body)).not.toBe(signPayload('secret-key-bravo', body))
   })
 
   it('produces different signatures for different bodies', () => {
-    expect(signPayload('secret', 'body-a')).not.toBe(signPayload('secret', 'body-b'))
+    expect(signPayload('a-valid-secret-key', 'body-a')).not.toBe(signPayload('a-valid-secret-key', 'body-b'))
+  })
+
+  it('throws for an empty secret', () => {
+    expect(() => signPayload('', 'body')).toThrow(/at least/)
+  })
+
+  it('throws for a secret shorter than minimum length', () => {
+    expect(() => signPayload('short', 'body')).toThrow(/at least/)
+  })
+
+  it('throws for a non-string secret', () => {
+    expect(() => signPayload(null as any, 'body')).toThrow(/at least/)
+    expect(() => signPayload(undefined as any, 'body')).toThrow(/at least/)
   })
 })
 
 describe('verifySignature', () => {
   it('returns true for a correct signature', () => {
     const body = '{"hello":"world"}'
-    const sig = signPayload('my-secret', body)
-    expect(verifySignature('my-secret', body, sig)).toBe(true)
+    const sig = signPayload('my-secret-key-ok', body)
+    expect(verifySignature('my-secret-key-ok', body, sig)).toBe(true)
   })
 
   it('returns false for a tampered body', () => {
-    const sig = signPayload('my-secret', 'original-body')
-    expect(verifySignature('my-secret', 'tampered-body', sig)).toBe(false)
+    const sig = signPayload('my-secret-key-ok', 'original-body')
+    expect(verifySignature('my-secret-key-ok', 'tampered-body', sig)).toBe(false)
   })
 
   it('returns false for a wrong secret', () => {
     const body = '{"hello":"world"}'
-    const sig = signPayload('correct-secret', body)
-    expect(verifySignature('wrong-secret', body, sig)).toBe(false)
+    const sig = signPayload('correct-secret-ok', body)
+    expect(verifySignature('wrong-secret-ok!!', body, sig)).toBe(false)
   })
 
   it('returns false for a length-mismatched signature', () => {
-    expect(verifySignature('secret', 'body', 'sha256=tooshort')).toBe(false)
+    expect(verifySignature('a-valid-secret-key', 'body', 'sha256=tooshort')).toBe(false)
+  })
+
+  it('returns false for an empty secret', () => {
+    expect(verifySignature('', 'body', 'sha256=abcdef')).toBe(false)
+  })
+
+  it('returns false for a secret shorter than minimum length', () => {
+    expect(verifySignature('short', 'body', 'sha256=abcdef')).toBe(false)
   })
 })
 
@@ -190,7 +211,7 @@ describe('subscriber management', () => {
     const sub = await addSubscriber(
       TEST_ORG,
       'https://example.com/hook',
-      'secret',
+      'a-valid-secret-key',
       ['vault_created'],
     )
     expect(sub.id).toBeTruthy()
@@ -244,7 +265,7 @@ describe('dispatchWebhookEvent', () => {
   })
 
   it('delivers to a matching subscriber with correct HMAC signature', async () => {
-    const secret = 'test-secret'
+    const secret = 'test-secret-key-123'
     await addSubscriber(TEST_ORG, 'https://example.com/hook', secret, ['vault_created'])
     fetchMock.mockResolvedValue({ status: 200 } as Response)
 
@@ -271,8 +292,8 @@ describe('dispatchWebhookEvent', () => {
   })
 
   it('delivers to all subscribers when events list is empty (wildcard)', async () => {
-    await addSubscriber(TEST_ORG, 'https://a.example.com/hook', 'secretA', [])
-    await addSubscriber(TEST_ORG, 'https://b.example.com/hook', 'secretB', [])
+    await addSubscriber(TEST_ORG, 'https://a.example.com/hook', 'secretAlpha-123', [])
+    await addSubscriber(TEST_ORG, 'https://b.example.com/hook', 'secretBravo-123', [])
     fetchMock.mockResolvedValue({ status: 200 } as Response)
 
     const results = await dispatchWebhookEvent(makePayload('vault_completed'))

--- a/src/tests/webhooks.testPing.test.ts
+++ b/src/tests/webhooks.testPing.test.ts
@@ -109,7 +109,7 @@ function makeSubscriber(overrides: Partial<WebhookSubscriber> = {}): WebhookSubs
     id: randomUUID(),
     organizationId: 'org-abc',
     url: 'https://hooks.example.com/callback',
-    secret: 'test-secret-xyz',
+    secret: 'test-secret-xyz1',
     previousSecret: null,
     rotatedAt: null,
     events: [],


### PR DESCRIPTION
Closes #1315 — Guard against empty/missing subscriber secret in signPayload/verifySignature

### Summary
`signPayload` in `src/services/webhooks.ts` computed the HMAC signature using a subscriber's `secret` with no validation that it was a non-empty, adequately-sized string. Since `crypto.createHmac` silently accepts an empty string as a key, a blank `secret` (from a botched migration, manual DB edit, or a bug in `rotateSubscriberSecret`) would cause deliveries to be signed with a well-known, trivially-guessable key instead of failing — allowing signature forgery for that subscriber. This PR adds explicit validation and fails loudly instead.

### Changes
- `signPayload` now validates that `secret` is a non-empty string meeting a minimum length before using it as the HMAC key; throws/rejects otherwise instead of signing with a weak or empty key.
- `verifySignature` applies the same guard, so verification against an invalid secret fails closed rather than potentially matching against an empty-key signature.
- Subscriber records failing the secret validation are rejected (delivery not attempted) rather than silently signed with a bad key.
- No change to the signature algorithm, header name, or payload format for valid secrets — this only closes the empty/missing-secret gap.

### Why this matters
Without this check, a subscriber with an empty `secret` would still receive "signed" webhooks, but the signature would be forgeable by anyone, defeating the purpose of `x-disciplr-signature` verification for that subscriber.

### Testing
Updated/extended test coverage across:
- `webhookSubscriber.rotation.test.ts` — secret rotation doesn't leave a blank value, and blank values are rejected
- `webhooks.circuitBreaker.test.ts`
- `webhooks.deadletter.test.ts`
- `webhooks.e2e.test.ts`
- `webhooks.egressAllowlist.test.ts`
- `webhooks.eventFilters.test.ts`
- `webhooks.schemaVersion.test.ts`
- `webhooks.ssrf.test.ts`
- `webhooks.test.ts` — core unit tests for `signPayload`/`verifySignature` with empty, missing, and short secrets
- `webhooks.testPing.test.ts`

New/updated cases specifically cover:
- Empty string secret → rejected, no delivery attempted
- Missing (`undefined`/`null`) secret → rejected
- Secret below minimum length → rejected
- Valid secret → unchanged signing/verification behavior (no regression)