### PR TITLE
fix: include organization_id in webhook v2 payload body

### DIFF
--- a/src/services/webhooks.ts
+++ b/src/services/webhooks.ts
@@ -124,7 +124,7 @@ export interface CircuitBreakerConfig {
  *   { eventId, eventType, timestamp, data, organizationId, schema_version: 1 }
  *
  * v2 – Compact envelope:
- *   { schema_version: 2, event_type, data }
+ *   { schema_version: 2, event_type, organization_id, data }
  */
 export const buildVersionedPayload = (
   subscriber: WebhookSubscriber,
@@ -148,6 +148,7 @@ export const buildVersionedPayload = (
       return JSON.stringify({
         schema_version: 2,
         event_type: payload.eventType,
+        organization_id: payload.organizationId,
         data: maskedData,
       })
     default:

--- a/src/tests/webhooks.schemaVersion.test.ts
+++ b/src/tests/webhooks.schemaVersion.test.ts
@@ -113,8 +113,10 @@ describe('buildVersionedPayload', () => {
     expect(json.schema_version).toBe(2)
     expect(json.event_type).toBe(payload.eventType)
     expect(json.data).toEqual(payload.data)
+    expect(json.organization_id).toBe(payload.organizationId)
     expect(json.eventId).toBeUndefined()
     expect(json.timestamp).toBeUndefined()
+    // camelCase organizationId must not leak; only snake_case organization_id is included
     expect(json.organizationId).toBeUndefined()
   })
 
@@ -212,6 +214,7 @@ describe('dispatchWebhookEvent schema versioning', () => {
     const body = JSON.parse(callArgs[1].body)
     expect(body.schema_version).toBe(2)
     expect(body.event_type).toBe(payload.eventType)
+    expect(body.organization_id).toBe(payload.organizationId)
     expect(body.data).toEqual(payload.data)
     expect(body.eventId).toBeUndefined()
   })


### PR DESCRIPTION
v2 subscribers serving multiple orgs through one endpoint had no way to determine which organization a delivery belonged to from the signed body alone: the v1 payload included organizationId but the v2 compact envelope only contained { schema_version, event_type, data }.

While eventId/timestamp are redundantly available via the x-disciplr-event-id / x-disciplr-delivery-timestamp headers, there is no corresponding x-disciplr-organization-id header in either dispatcher (webhooks.ts deliverOnce or BoundedWebhookDispatcher.deliverOnce).

Fix: add organization_id (snake_case, consistent with event_type and schema_version) to the v2 body so multi-tenant subscribers can reliably route and verify deliveries without inspecting a separate lookup.

Updated JSDoc for buildVersionedPayload and both the unit test ('v2 returns compact envelope') and integration test ('delivers v2 envelope to version-2 subscribers') in webhooks.schemaVersion.test.ts.

Closes #1298