### PR TITLE
fix: skip bad retired keys in resolveKeys instead of aborting entirely

### DIFF
--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -101,6 +101,16 @@ const decodeKey = (kid: string, raw: string): Buffer => {
  *   - If neither is set, EncryptionKeyError is thrown (fail closed): an
  *     encryption helper with no keys is a misconfiguration, never a no-op.
  *
+ * Per-entry validation:
+ *   - A malformed or invalid entry at index 0 (the active key) is always fatal:
+ *     encrypting new data would be impossible without a valid active key.
+ *   - A malformed or invalid entry at any later index (a retired/rotation key)
+ *     is skipped with a console.warn rather than aborting entirely. A single
+ *     operator typo in a low-priority retired key must not break field
+ *     encryption/decryption for the active key that is otherwise valid.
+ *     The skipped entry's kid is never added to the duplicate-id set, so a
+ *     bad retired entry cannot trigger a spurious duplicate error.
+ *
  * Duplicate key ids are rejected so a typo cannot make a retired key
  * unexpectedly shadow the active one.
  */
@@ -123,20 +133,43 @@ export const resolveKeys = (): FieldEncryptionKey[] => {
         'FIELD_ENCRYPTION_KEYS must be a non-empty JSON array of { kid, key } objects',
       )
     }
-    keys = parsed.map((entry, i) => {
+    keys = []
+    for (let i = 0; i < parsed.length; i++) {
+      const entry = parsed[i]
+      const isActive = i === 0
+
+      // Shape validation
       if (
         typeof entry !== 'object' ||
         entry === null ||
         typeof (entry as any).kid !== 'string' ||
         typeof (entry as any).key !== 'string'
       ) {
-        throw new EncryptionKeyError(
-          `FIELD_ENCRYPTION_KEYS[${i}] must be an object with string "kid" and "key" fields`,
-        )
+        const msg =
+          `FIELD_ENCRYPTION_KEYS[${i}] must be an object with string "kid" and "key" fields`
+        if (isActive) {
+          throw new EncryptionKeyError(msg)
+        }
+        console.warn(`[encryption] Skipping malformed retired key at index ${i}: ${msg}`)
+        continue
       }
+
       const kid = (entry as any).kid as string
-      return { kid, key: decodeKey(kid, (entry as any).key as string) }
-    })
+      let keyBuf: Buffer
+      try {
+        keyBuf = decodeKey(kid, (entry as any).key as string)
+      } catch (e) {
+        if (isActive) {
+          throw e
+        }
+        console.warn(
+          `[encryption] Skipping invalid retired key "${kid}" at index ${i}: ${(e as Error).message}`,
+        )
+        continue
+      }
+
+      keys.push({ kid, key: keyBuf })
+    }
   } else if (singleKey && singleKey.trim() !== '') {
     keys = [{ kid: DEFAULT_KEY_ID, key: decodeKey(DEFAULT_KEY_ID, singleKey) }]
   }

--- a/src/tests/encryption.test.ts
+++ b/src/tests/encryption.test.ts
@@ -13,7 +13,7 @@
  * fresh on every call, so each test sets the exact key set it needs.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals'
 import { randomBytes } from 'node:crypto'
 import {
   encryptField,
@@ -291,6 +291,66 @@ describe('key configuration validation', () => {
       { kid: 'dup', key },
     ])
     expect(() => resolveKeys()).toThrow(/Duplicate field encryption key id "dup"/)
+  })
+
+  it('skips a malformed retired key (index > 0) and warns, without affecting the active key', () => {
+    const activeKey = genKey()
+    delete process.env.FIELD_ENCRYPTION_KEY
+    // Index 1 is missing the "key" field — should be skipped with a warning.
+    process.env.FIELD_ENCRYPTION_KEYS = JSON.stringify([
+      { kid: 'active', key: activeKey },
+      { kid: 'bad-retired' }, // missing key field
+    ])
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    let resolved: ReturnType<typeof resolveKeys> | undefined
+    expect(() => { resolved = resolveKeys() }).not.toThrow()
+    expect(resolved).toHaveLength(1)
+    expect(resolved![0].kid).toBe('active')
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping malformed retired key at index 1'),
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('skips a retired key with an invalid base64/length value and warns', () => {
+    const activeKey = genKey()
+    delete process.env.FIELD_ENCRYPTION_KEY
+    // Index 1 has a key that is only 16 bytes — too short.
+    process.env.FIELD_ENCRYPTION_KEYS = JSON.stringify([
+      { kid: 'active', key: activeKey },
+      { kid: 'short-retired', key: randomBytes(16).toString('base64') },
+    ])
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    let resolved: ReturnType<typeof resolveKeys> | undefined
+    expect(() => { resolved = resolveKeys() }).not.toThrow()
+    expect(resolved).toHaveLength(1)
+    expect(resolved![0].kid).toBe('active')
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping invalid retired key "short-retired"'),
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('still throws fatally when the active key (index 0) is malformed', () => {
+    delete process.env.FIELD_ENCRYPTION_KEY
+    // Index 0 is missing the "key" field — must throw, not skip.
+    process.env.FIELD_ENCRYPTION_KEYS = JSON.stringify([
+      { kid: 'bad-active' }, // missing key field — active key
+      { kid: 'ok-retired', key: genKey() },
+    ])
+    expect(() => resolveKeys()).toThrow(EncryptionKeyError)
+    expect(() => resolveKeys()).toThrow(/string "kid" and "key"/)
+  })
+
+  it('still throws fatally when the active key (index 0) has invalid key material', () => {
+    delete process.env.FIELD_ENCRYPTION_KEY
+    // Active key is only 16 bytes — must throw.
+    process.env.FIELD_ENCRYPTION_KEYS = JSON.stringify([
+      { kid: 'short-active', key: randomBytes(16).toString('base64') },
+      { kid: 'ok-retired', key: genKey() },
+    ])
+    expect(() => resolveKeys()).toThrow(EncryptionKeyError)
+    expect(() => resolveKeys()).toThrow(/must decode to 32 bytes/)
   })
 
   it('prefers FIELD_ENCRYPTION_KEYS over FIELD_ENCRYPTION_KEY when both are set', () => {


### PR DESCRIPTION
resolveKeys() used Array.map() over all FIELD_ENCRYPTION_KEYS entries, so a single malformed or mis-sized retired rotation key (index > 0) threw EncryptionKeyError and aborted field encryption/decryption for the whole application — including the currently-active key that was otherwise perfectly valid.

Fix: replace the .map() with an explicit loop that applies different failure policies per entry:

  - index 0 (active key): any shape or key-material error is still fatal (EncryptionKeyError), because encrypting new data would be impossible without a valid active key.
  - index > 0 (retired/rotation keys): a bad entry emits console.warn and is skipped. The skipped entry's kid is never added to the duplicate-id set, so a bad retired entry cannot also trigger a spurious duplicate- key error.

The overall fail-closed guarantee is preserved:
  - Missing or all-invalid config still throws.
  - A bad active key still throws.
  - The duplicate-id check still runs over all successfully loaded keys.

Tests added (4 new cases in 'key configuration validation'):
  - Skips a retired key missing the 'key' field, warns, returns the active key.
  - Skips a retired key with too-short base64 material, warns.
  - Still throws fatally when the active key (index 0) is missing fields.
  - Still throws fatally when the active key (index 0) has invalid material.

Also adds 'jest' to the @jest/globals import (needed for spyOn).

Closes #1300