### PR TITLE
fix(audit-logs): clamp limit/offset and guard against NaN (#1100)

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -427,8 +427,10 @@ adminRouter.get(
   }),
   async (req, res) => {
     try {
-      const limit = getStringQuery(req.query.limit) ? Number(getStringQuery(req.query.limit)) : undefined
-      const offset = getStringQuery(req.query.offset) ? Number(getStringQuery(req.query.offset)) : undefined
+      const rawLimit = getStringQuery(req.query.limit) ? Number(getStringQuery(req.query.limit)) : undefined
+      const rawOffset = getStringQuery(req.query.offset) ? Number(getStringQuery(req.query.offset)) : undefined
+      const limit = rawLimit !== undefined && Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(100, Math.floor(rawLimit)) : undefined
+      const offset = rawOffset !== undefined && Number.isFinite(rawOffset) && rawOffset >= 0 ? Math.floor(rawOffset) : undefined
 
       const logs = await listAuditLogs({
         organization_id: (req.filters as any)?.organization_id,
@@ -690,12 +692,14 @@ adminRouter.post('/vaults/:id/auto-repair', requireStepUp(), async (req, res) =>
 // User Management Endpoints
 adminRouter.get('/users', async (req, res) => {
   try {
+    const rawLimit = getStringQuery(req.query.limit) ? Number(getStringQuery(req.query.limit)) : undefined
+    const rawOffset = getStringQuery(req.query.offset) ? Number(getStringQuery(req.query.offset)) : undefined
     const filters = {
       role: getStringQuery(req.query.role) as UserRole | undefined,
       status: getStringQuery(req.query.status) as UserStatus | undefined,
       search: getStringQuery(req.query.search),
-      limit: getStringQuery(req.query.limit) ? Number(getStringQuery(req.query.limit)) : undefined,
-      offset: getStringQuery(req.query.offset) ? Number(getStringQuery(req.query.offset)) : undefined,
+      limit: rawLimit !== undefined && Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(100, Math.floor(rawLimit)) : undefined,
+      offset: rawOffset !== undefined && Number.isFinite(rawOffset) && rawOffset >= 0 ? Math.floor(rawOffset) : undefined,
       includeDeleted: req.query.includeDeleted === 'true',
     }
 


### PR DESCRIPTION
Closes #1100

## Problem

`GET /audit-logs` in `src/routes/admin.ts` parsed `limit` and `offset` via bare `Number()` with no upper-bound clamp or NaN guard. A caller supplying `?limit=999999999` or a non-numeric value that coerces to `NaN` reached the query layer unvalidated.

## Fix

Added `Number.isFinite` NaN guard and `Math.min(100, ...)` upper-bound clamp — the same pattern used in `src/routes/transactions.ts` and `src/routes/orgVaults.ts`:

- `limit`: rejects NaN, negatives; clamps to max 100
- `offset`: rejects NaN, negatives; passes through as-is

Also applied the same validation to `GET /users` which had the identical unguarded pattern.

## Changes

- `src/routes/admin.ts`: Added `Number.isFinite` + `Math.min(100, ...)` validation for `limit` and `offset` in both `/audit-logs` and `/users` endpoints