### PR TITLE
fix: wrap hardDeleteUser in a Prisma  and add audit-log entry

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -781,7 +781,7 @@ adminRouter.delete(
     let result: DeleteResult | null
 
     if (hard) {
-      result = await userService.hardDeleteUser(req.params.id)
+      result = await userService.hardDeleteUser(req.params.id, req.user!.userId)
     } else {
       result = await userService.softDeleteUser(req.params.id)
     }
@@ -797,22 +797,26 @@ adminRouter.delete(
       })
     }
 
-    const auditLog = await createAuditLog({
-      actor_user_id: req.user!.userId,
-      action: hard ? 'user.hard_delete' : 'user.soft_delete',
-      target_type: 'user',
-      target_id: req.params.id,
-      metadata: {
-        deletion_type: result.deletionType,
-        deleted_at: result.deletedAt,
-        target_email: targetUser.email
-      },
-    })
+    let auditLog
+
+    if (!hard) {
+      auditLog = await createAuditLog({
+        actor_user_id: req.user!.userId,
+        action: 'user.soft_delete',
+        target_type: 'user',
+        target_id: req.params.id,
+        metadata: {
+          deletion_type: result.deletionType,
+          deleted_at: result.deletedAt,
+          target_email: targetUser.email
+        },
+      })
+    }
 
     res.status(200).json({
       message: hard ? 'User permanently deleted' : 'User soft-deleted',
       result,
-      auditLogId: auditLog.id
+      ...(auditLog ? { auditLogId: auditLog.id } : {})
     })
   } catch (error) {
     res.status(500).json({ error: 'Internal server error' })

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -1,6 +1,7 @@
 import db from '../db/index.js'
 import { UserRole, UserStatus, User } from '../types/user.js'
 import { getPrisma } from '../lib/prismaScope.js'
+import { createAuditLog } from '../lib/audit-logs.js'
 
 export interface UserFilters {
   role?: UserRole
@@ -179,26 +180,35 @@ export class UserService {
     }
   }
 
-  async hardDeleteUser(id: string): Promise<DeleteResult | null> {
+  async hardDeleteUser(id: string, actorUserId?: string): Promise<DeleteResult | null> {
     const user = await this.getUserById(id, true)
     if (!user) {
       return null
     }
 
-    await getPrisma().refreshToken.deleteMany({
-      where: { userId: id }
+    await getPrisma().$transaction(async (tx) => {
+      await tx.refreshToken.deleteMany({
+        where: { userId: id }
+      })
+
+      await tx.vault.deleteMany({
+        where: { creatorId: id }
+      })
+
+      const deleted = await tx.$executeRaw`DELETE FROM "users" WHERE id = ${id}`
+      if (Number(deleted) === 0) {
+        throw new Error('User not found during deletion')
+      }
     })
 
-    await getPrisma().vault.deleteMany({
-      where: { creatorId: id }
-    })
-
-    const deleted = await db('users')
-      .where('id', id)
-      .del()
-
-    if (deleted === 0) {
-      return null
+    if (actorUserId) {
+      await createAuditLog({
+        actor_user_id: actorUserId,
+        action: 'user.hard_delete',
+        target_type: 'user',
+        target_id: id,
+        metadata: { deleted_user_email: user.email }
+      })
     }
 
     return {


### PR DESCRIPTION
- Wrap the three unguarded deletes (refreshToken, vault, users) in a single Prisma interactive  so that a crash between any two steps no longer leaves partially-deleted, inconsistent state.
- Use tx. for the users table delete (the User model is managed via Knex, not Prisma) and throw on zero affected rows to trigger a rollback.
- Add an optional actorUserId parameter and call createAuditLog with action 'user.hard_delete' when provided, matching the pattern used by changeRole in membership.ts.
- Update the admin route to pass req.user!.userId and remove the duplicate route-level audit log for hard deletes (the service now owns it). Soft-delete audit logging remains in the route.

Close #1083