### PR TITLE
fix: wrap recordMilestoneApproval in transaction, catch unique constraint violation

### DIFF
--- a/src/services/verifiers.ts
+++ b/src/services/verifiers.ts
@@ -415,27 +415,39 @@ export const recordMilestoneApproval = async (
   verifierUserId: string,
   approvalStatus: MilestoneApprovalStatus,
 ): Promise<MilestoneApproval> => {
-  // Check if verifier has already voted
-  const existing = await db('milestone_approvals')
-    .where({
-      milestone_id: milestoneId,
-      verifier_user_id: verifierUserId,
-    })
-    .first()
+  return db.transaction(async (trx) => {
+    const existing = await trx('milestone_approvals')
+      .where({
+        milestone_id: milestoneId,
+        verifier_user_id: verifierUserId,
+      })
+      .first()
 
-  if (existing) {
-    throw new DuplicateVerifierVoteError(milestoneId, verifierUserId)
-  }
+    if (existing) {
+      throw new DuplicateVerifierVoteError(milestoneId, verifierUserId)
+    }
 
-  const [record] = await db('milestone_approvals')
-    .insert({
-      milestone_id: milestoneId,
-      verifier_user_id: verifierUserId,
-      approval_status: approvalStatus,
-    })
-    .returning('*')
+    try {
+      const [record] = await trx('milestone_approvals')
+        .insert({
+          milestone_id: milestoneId,
+          verifier_user_id: verifierUserId,
+          approval_status: approvalStatus,
+        })
+        .returning('*')
 
-  return mapMilestoneApprovalRow(record)
+      return mapMilestoneApprovalRow(record)
+    } catch (err) {
+      const maybeErr = err as { code?: string; message?: string }
+      if (
+        maybeErr.code === '23505'
+        || maybeErr.message?.toLowerCase().includes('unique') === true
+      ) {
+        throw new DuplicateVerifierVoteError(milestoneId, verifierUserId)
+      }
+      throw err
+    }
+  })
 }
 
 /**

--- a/tests/multiVerifier.test.ts
+++ b/tests/multiVerifier.test.ts
@@ -45,6 +45,14 @@ function buildQuery(table: string) {
     return null
   }
   q.insert = (data: any) => {
+    const dup = store.find(r =>
+      r.milestone_id === data.milestone_id && r.verifier_user_id === data.verifier_user_id
+    )
+    if (dup) {
+      const err: any = new Error('duplicate key value violates unique constraint "idx_milestone_approvals_unique"')
+      err.code = '23505'
+      throw err
+    }
     const row = { ...makeRow(data.milestone_id, data.verifier_user_id, data.approval_status), ...data }
     store.push(row)
     q._inserted = [row]

--- a/tests/multiVerifier.veto.test.ts
+++ b/tests/multiVerifier.veto.test.ts
@@ -38,6 +38,14 @@ function buildQuery(table: string) {
     return null
   }
   q.insert = (data: any) => {
+    const dup = store.find(r =>
+      r.milestone_id === data.milestone_id && r.verifier_user_id === data.verifier_user_id
+    )
+    if (dup) {
+      const err: any = new Error('duplicate key value violates unique constraint "idx_milestone_approvals_unique"')
+      err.code = '23505'
+      throw err
+    }
     const row = { ...makeRow(data.milestone_id, data.verifier_user_id, data.approval_status), ...data }
     store.push(row)
     q._inserted = [row]


### PR DESCRIPTION
## Summary

Fix race condition in `recordMilestoneApproval` (src/services/verifiers.ts) where the SELECT-before-INSERT duplicate-vote check was not atomic with the INSERT, allowing two concurrent approval requests from the same verifier for the same milestone to both pass the existence check before either commit — resulting in duplicate approval rows that directly undermine the M-of-N approval-threshold logic in `allMilestonesMetThreshold`.

## Changes

- **Wrap check-and-insert in a transaction**: `recordMilestoneApproval` now uses `db.transaction(async (trx) => { ... })` so the existence check and INSERT execute atomically at the database level, preventing TOCTOU race conditions
- **Catch unique constraint violations as backstop**: The INSERT is wrapped in a try/catch that converts PostgreSQL 23505 / unique-constraint errors into `DuplicateVerifierVoteError`, matching the existing error contract
- **Test mocks updated**: Both `tests/multiVerifier.test.ts` and `tests/multiVerifier.veto.test.ts` now simulate constraint violations on duplicate inserts, exercising the transaction + constraint backstop path

## Database constraint

The unique constraint on `(milestone_id, verifier_user_id)` already exists in migration `20260429000000_add_multi_verifier_support.cjs:36`. No additional migration is needed.

Close #1111