### PR TITLE
fix: wire Knex org quota repository at startup

### DIFF
--- a/src/app-bootstrap.ts
+++ b/src/app-bootstrap.ts
@@ -10,6 +10,7 @@ import { analyticsRouter } from './routes/analytics.js'
 import { authRateLimiter, healthRateLimiter, vaultsRateLimiter } from './middleware/rateLimiter.js'
 import { createExportRouter } from './routes/exports.js'
 import { configureExportJobRepository, configureDlqRepository, createKnexExportJobRepository, createKnexDlqRepository } from './services/exportQueue.js'
+import { configureOrgQuotaRepository, createKnexOrgQuotaRepository } from './services/exportQuota.js'
 import { db } from './db/index.js'
 import { transactionsRouter } from './routes/transactions.js'
 import { privacyRouter, privacyAbuseMonitor } from './routes/privacy.js'
@@ -54,6 +55,7 @@ export function bootstrapApp(options: BootstrapOptions = {}) {
   const jobSystem = new BackgroundJobSystem(notificationService);
   configureExportJobRepository(createKnexExportJobRepository(db))
   configureDlqRepository(createKnexDlqRepository(db))
+  configureOrgQuotaRepository(createKnexOrgQuotaRepository(db))
 
   app.use(securityMetricsMiddleware);
   app.use(securityRateLimitMiddleware);


### PR DESCRIPTION
src/services/exportQuota.ts defines a fully working, DB-backed createKnexOrgQuotaRepository (lines 90-131) with a correct atomic INSERT ... ON CONFLICT ... DO UPDATE SET count = count + 1 upsert, and an accompanying configureOrgQuotaRepository setter (lines 135-137) to swap the default let orgQuotaRepository: OrgQuotaRepository = createInMemoryOrgQuotaRepository() (line 133) for it — exactly the same pattern src/services/exportQueue.ts uses for its job repository, which app-bootstrap.ts correctly wires at startup (configureExportJobRepository(createKnexExportJobRepository(db)), line 54). A repo-wide search shows configureOrgQuotaRepository is never called anywhere in production code. This means checkAndIncrementExportQuota — consulted by enforceExportQuota in src/routes/exports.ts on every export request — always uses the in-memory repository: the daily export quota resets on every restart/redeploy and is not shared across horizontally-scaled instances, making the configured EXPORT_DAILY_QUOTA_LIMIT trivially bypassable (each replica enforces its own independent counter) in any multi-instance deployment. Call configureOrgQuotaRepository(createKnexOrgQuotaRepository(db)) at startup alongside the export job repository.

closes #1269 