### PR TITLE
fix: adapt AnalyticsBatchLoader DbLike interface for pg.Pool compatibility

### DIFF
--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -9,6 +9,8 @@ import {
 import type { VaultAnalytics, VaultAnalyticsWithPeriod } from '../types/vault.js'
 import { parseAndNormalizeToUTC, utcNow } from '../utils/timestamps.js'
 import { getOrSet, invalidate } from '../lib/cache.js'
+import { getOrgAnalyticsBatched } from './analyticsBatchLoader.js'
+import type { OrgVaultAnalytics } from './analyticsBatchLoader.js'
 
 export interface OrgRiskAnalyticsVault {
   id?: string
@@ -256,13 +258,13 @@ export async function updateAnalyticsSummary(orgId?: string): Promise<void> {
  * Render a point-in-time analytics snapshot for a single org.
  * Pulls vault IDs from the in-memory vaults store so it works without a DB.
  */
-export function renderOrgAnalyticsSnapshot(orgId: string): OrgVaultAnalytics & { orgId: string; snapshotAt: string } {
+export async function renderOrgAnalyticsSnapshot(orgId: string): Promise<OrgVaultAnalytics & { orgId: string; snapshotAt: string }> {
   // Import lazily to avoid circular deps and to stay hermetic in tests
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { vaults } = require('../routes/vaults.js') as { vaults: Array<{ id: string; orgId?: string }> }
   const orgVaultIds = vaults
     .filter((v) => v.orgId === orgId)
     .map((v) => v.id)
-  const analytics = getOrgAnalyticsBatched(orgVaultIds)
+  const analytics = await getOrgAnalyticsBatched(orgVaultIds)
   return { ...analytics, orgId, snapshotAt: utcNow() }
 }

--- a/src/services/analyticsBatchLoader.ts
+++ b/src/services/analyticsBatchLoader.ts
@@ -15,11 +15,21 @@ export interface MilestoneAggregate {
   pendingMilestones: number
 }
 
-// Minimal subset of the better-sqlite3 Database interface used by the loader.
+export interface OrgVaultAnalytics {
+  totalVaults: number
+  activeVaults: number
+  completedVaults: number
+  failedVaults: number
+  totalLockedCapital: string
+  successRate: number
+  totalMilestones: number
+  completedMilestones: number
+}
+
+// Async query interface compatible with pg.Pool.
+// pg.Pool.query(text, params) returns Promise<{ rows }> — this matches.
 export interface DbLike {
-  prepare(sql: string): {
-    all(...params: unknown[]): unknown[]
-  }
+  query(sql: string, params?: unknown[]): Promise<{ rows: unknown[] }>
 }
 
 /**
@@ -54,15 +64,14 @@ export class AnalyticsBatchLoader {
    * Load vault aggregates for a set of vault IDs in one query.
    * Deduplicates keys; already-cached keys do not trigger additional queries.
    */
-  loadVaults(vaultIds: string[]): Map<string, VaultAggregate> {
+  async loadVaults(vaultIds: string[]): Promise<Map<string, VaultAggregate>> {
     const unique = [...new Set(vaultIds)]
     const uncached = unique.filter((id) => !this.vaultCache.has(id))
 
     if (uncached.length > 0) {
-      const placeholders = uncached.map(() => '?').join(',')
-      const rows = this.db
-        .prepare(
-          `SELECT
+      const placeholders = uncached.map((_, i) => `$${i + 1}`).join(',')
+      const { rows } = await this.db.query(
+        `SELECT
             v.id          AS vaultId,
             v.status,
             v.amount,
@@ -72,18 +81,12 @@ export class AnalyticsBatchLoader {
           LEFT JOIN milestones m ON m.vault_id = v.id
           WHERE v.id IN (${placeholders})
           GROUP BY v.id, v.status, v.amount`,
-        )
-        .all(...uncached) as {
-          vaultId: string
-          status: string
-          amount: string
-          milestoneCount: number
-          completedMilestones: number
-        }[]
+        uncached,
+      )
 
       this._queryCount++
 
-      for (const row of rows) {
+      for (const row of rows as VaultAggregate[]) {
         this.vaultCache.set(row.vaultId, {
           vaultId: row.vaultId,
           status: row.status,
@@ -105,15 +108,14 @@ export class AnalyticsBatchLoader {
   /**
    * Load milestone aggregates grouped by vault for a set of vault IDs in one query.
    */
-  loadMilestones(vaultIds: string[]): Map<string, MilestoneAggregate> {
+  async loadMilestones(vaultIds: string[]): Promise<Map<string, MilestoneAggregate>> {
     const unique = [...new Set(vaultIds)]
     const uncached = unique.filter((id) => !this.milestoneCache.has(id))
 
     if (uncached.length > 0) {
-      const placeholders = uncached.map(() => '?').join(',')
-      const rows = this.db
-        .prepare(
-          `SELECT
+      const placeholders = uncached.map((_, i) => `$${i + 1}`).join(',')
+      const { rows } = await this.db.query(
+        `SELECT
             vault_id      AS vaultId,
             COUNT(*)      AS milestoneCount,
             SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completedMilestones,
@@ -121,17 +123,12 @@ export class AnalyticsBatchLoader {
           FROM milestones
           WHERE vault_id IN (${placeholders})
           GROUP BY vault_id`,
-        )
-        .all(...uncached) as {
-          vaultId: string
-          milestoneCount: number
-          completedMilestones: number
-          pendingMilestones: number
-        }[]
+        uncached,
+      )
 
       this._queryCount++
 
-      for (const row of rows) {
+      for (const row of rows as MilestoneAggregate[]) {
         this.milestoneCache.set(row.vaultId, {
           vaultId: row.vaultId,
           milestoneCount: Number(row.milestoneCount),
@@ -160,6 +157,67 @@ export class AnalyticsBatchLoader {
       if (hit) result.set(id, hit)
     }
     return result
+  }
+}
+
+/**
+ * Compute a point-in-time analytics snapshot for a set of vault IDs
+ * using the batch loader. Uses Postgres-compatible parameterised queries.
+ */
+export async function getOrgAnalyticsBatched(
+  vaultIds: string[],
+  db?: DbLike,
+): Promise<OrgVaultAnalytics> {
+  if (vaultIds.length === 0) {
+    return {
+      totalVaults: 0,
+      activeVaults: 0,
+      completedVaults: 0,
+      failedVaults: 0,
+      totalLockedCapital: '0',
+      successRate: 0,
+      totalMilestones: 0,
+      completedMilestones: 0,
+    }
+  }
+
+  const loader = new AnalyticsBatchLoader(db)
+  const vaults = await loader.loadVaults(vaultIds)
+  const milestones = await loader.loadMilestones(vaultIds)
+
+  let totalVaults = 0
+  let activeVaults = 0
+  let completedVaults = 0
+  let failedVaults = 0
+  let totalLockedCapital = 0
+  let totalMilestones = 0
+  let completedMilestones = 0
+
+  for (const v of vaults.values()) {
+    totalVaults++
+    if (v.status === 'active') activeVaults++
+    else if (v.status === 'completed') completedVaults++
+    else if (v.status === 'failed') failedVaults++
+    totalLockedCapital += Number(v.amount)
+  }
+
+  for (const m of milestones.values()) {
+    totalMilestones += m.milestoneCount
+    completedMilestones += m.completedMilestones
+  }
+
+  const resolvedVaults = completedVaults + failedVaults
+  const successRate = resolvedVaults > 0 ? completedVaults / resolvedVaults : 0
+
+  return {
+    totalVaults,
+    activeVaults,
+    completedVaults,
+    failedVaults,
+    totalLockedCapital: totalLockedCapital.toString(),
+    successRate,
+    totalMilestones,
+    completedMilestones,
   }
 }
 

--- a/src/tests/performance/analyticsBatch.perf.test.ts
+++ b/src/tests/performance/analyticsBatch.perf.test.ts
@@ -11,14 +11,35 @@
 import Database from 'better-sqlite3'
 import { AnalyticsBatchLoader } from '../../services/analyticsBatchLoader.js'
 import { getOrgAnalyticsBatched } from '../../services/analytics.service.js'
+import type { DbLike } from '../../services/analyticsBatchLoader.js'
+
+// ---------------------------------------------------------------------------
+// Adapter: wraps synchronous better-sqlite3 into the async DbLike interface
+// so the same production code path can be exercised in unit tests.
+// ---------------------------------------------------------------------------
+
+class SqliteDbAdapter implements DbLike {
+  private db: Database.Database
+
+  constructor(db: Database.Database) {
+    this.db = db
+  }
+
+  async query(sql: string, params?: unknown[]): Promise<{ rows: unknown[] }> {
+    const stmt = this.db.prepare(sql)
+    const rows = stmt.all(...(params ?? []))
+    return { rows }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // In-memory SQLite DB shared across tests in this file.
 // ---------------------------------------------------------------------------
 
-const testDb = new Database(':memory:')
+const rawDb = new Database(':memory:')
+const testDb: DbLike = new SqliteDbAdapter(rawDb)
 
-testDb.exec(`
+rawDb.exec(`
   CREATE TABLE IF NOT EXISTS vaults (
     id TEXT PRIMARY KEY,
     status TEXT NOT NULL,
@@ -39,20 +60,20 @@ testDb.exec(`
 let milestoneSeq = 0
 
 function seedVault(id: string, status: string, amount: string, orgId: string): void {
-  testDb.prepare('INSERT OR IGNORE INTO vaults (id, status, amount, org_id) VALUES (?, ?, ?, ?)').run(
+  rawDb.prepare('INSERT OR IGNORE INTO vaults (id, status, amount, org_id) VALUES (?, ?, ?, ?)').run(
     id, status, amount, orgId,
   )
 }
 
 function seedMilestone(vaultId: string, status: string): void {
-  testDb
+  rawDb
     .prepare('INSERT INTO milestones (id, vault_id, status) VALUES (?, ?, ?)')
     .run(`m-${++milestoneSeq}`, vaultId, status)
 }
 
 function clearTables(): void {
-  testDb.prepare('DELETE FROM milestones').run()
-  testDb.prepare('DELETE FROM vaults').run()
+  rawDb.prepare('DELETE FROM milestones').run()
+  rawDb.prepare('DELETE FROM vaults').run()
   milestoneSeq = 0
 }
 
@@ -72,33 +93,33 @@ describe('AnalyticsBatchLoader', () => {
   // ── deduplication ─────────────────────────────────────────────────────────
 
   describe('key deduplication', () => {
-    it('issues exactly one vault query when the same key is requested multiple times', () => {
+    it('issues exactly one vault query when the same key is requested multiple times', async () => {
       seedVault('v1', 'active', '100', 'org-a')
 
       const loader = makeLoader()
 
       // First load with repeated keys
-      const first = loader.loadVaults(['v1', 'v1', 'v1'])
+      const first = await loader.loadVaults(['v1', 'v1', 'v1'])
       expect(first.size).toBe(1)
       expect(loader.queries).toBe(1)
 
       // Second call with same key — hits intra-request cache, no new query
-      const second = loader.loadVaults(['v1'])
+      const second = await loader.loadVaults(['v1'])
       expect(second.size).toBe(1)
       expect(loader.queries).toBe(1)
     })
 
-    it('issues exactly one milestone query for duplicate vault IDs', () => {
+    it('issues exactly one milestone query for duplicate vault IDs', async () => {
       seedVault('v1', 'active', '100', 'org-a')
       seedMilestone('v1', 'completed')
 
       const loader = makeLoader()
 
-      loader.loadMilestones(['v1', 'v1', 'v1'])
+      await loader.loadMilestones(['v1', 'v1', 'v1'])
       expect(loader.queries).toBe(1)
 
       // Cached — no extra query
-      loader.loadMilestones(['v1'])
+      await loader.loadMilestones(['v1'])
       expect(loader.queries).toBe(1)
     })
   })
@@ -106,7 +127,7 @@ describe('AnalyticsBatchLoader', () => {
   // ── query-count reduction ─────────────────────────────────────────────────
 
   describe('query-count reduction', () => {
-    it('fetches N vault aggregates with exactly 1 query', () => {
+    it('fetches N vault aggregates with exactly 1 query', async () => {
       const ids: string[] = []
       for (let i = 0; i < 20; i++) {
         const id = `v-batch-${i}`
@@ -115,13 +136,13 @@ describe('AnalyticsBatchLoader', () => {
       }
 
       const loader = makeLoader()
-      const result = loader.loadVaults(ids)
+      const result = await loader.loadVaults(ids)
 
       expect(result.size).toBe(20)
       expect(loader.queries).toBe(1) // single IN-clause query, not 20
     })
 
-    it('fetches N milestone aggregates with exactly 1 query', () => {
+    it('fetches N milestone aggregates with exactly 1 query', async () => {
       const ids: string[] = []
       for (let i = 0; i < 20; i++) {
         const id = `v-ms-${i}`
@@ -132,21 +153,21 @@ describe('AnalyticsBatchLoader', () => {
       }
 
       const loader = makeLoader()
-      const result = loader.loadMilestones(ids)
+      const result = await loader.loadMilestones(ids)
 
       expect(result.size).toBe(20)
       expect(loader.queries).toBe(1)
     })
 
-    it('loading vaults then milestones for same IDs costs exactly 2 total queries', () => {
+    it('loading vaults then milestones for same IDs costs exactly 2 total queries', async () => {
       const ids = ['v-x', 'v-y']
       seedVault('v-x', 'active', '200', 'org-c')
       seedVault('v-y', 'completed', '300', 'org-c')
       seedMilestone('v-x', 'completed')
 
       const loader = makeLoader()
-      loader.loadVaults(ids)
-      loader.loadMilestones(ids)
+      await loader.loadVaults(ids)
+      await loader.loadMilestones(ids)
 
       expect(loader.queries).toBe(2)
     })
@@ -155,15 +176,15 @@ describe('AnalyticsBatchLoader', () => {
   // ── result parity ─────────────────────────────────────────────────────────
 
   describe('result parity', () => {
-    it('vault aggregate matches individually-computed values', () => {
+    it('vault aggregate matches individually-computed values', async () => {
       seedVault('v-p1', 'active', '500', 'org-d')
       seedMilestone('v-p1', 'completed')
       seedMilestone('v-p1', 'completed')
       seedMilestone('v-p1', 'pending')
 
       const loader = makeLoader()
-      const vaults = loader.loadVaults(['v-p1'])
-      const milestones = loader.loadMilestones(['v-p1'])
+      const vaults = await loader.loadVaults(['v-p1'])
+      const milestones = await loader.loadMilestones(['v-p1'])
 
       const v = vaults.get('v-p1')!
       expect(v.status).toBe('active')
@@ -177,11 +198,11 @@ describe('AnalyticsBatchLoader', () => {
       expect(m.pendingMilestones).toBe(1)
     })
 
-    it('vaults with no milestones return zero milestone counts', () => {
+    it('vaults with no milestones return zero milestone counts', async () => {
       seedVault('v-nomile', 'active', '100', 'org-d')
 
       const loader = makeLoader()
-      const milestones = loader.loadMilestones(['v-nomile'])
+      const milestones = await loader.loadMilestones(['v-nomile'])
 
       const m = milestones.get('v-nomile')!
       expect(m.milestoneCount).toBe(0)
@@ -189,9 +210,9 @@ describe('AnalyticsBatchLoader', () => {
       expect(m.pendingMilestones).toBe(0)
     })
 
-    it('returns empty map for unknown vault IDs', () => {
+    it('returns empty map for unknown vault IDs', async () => {
       const loader = makeLoader()
-      const vaults = loader.loadVaults(['does-not-exist'])
+      const vaults = await loader.loadVaults(['does-not-exist'])
       expect(vaults.size).toBe(0)
     })
   })
@@ -199,7 +220,7 @@ describe('AnalyticsBatchLoader', () => {
   // ── getOrgAnalyticsBatched ─────────────────────────────────────────────────
 
   describe('getOrgAnalyticsBatched', () => {
-    it('aggregates multiple vaults correctly', () => {
+    it('aggregates multiple vaults correctly', async () => {
       seedVault('org1-v1', 'active', '1000', 'org-1')
       seedVault('org1-v2', 'completed', '2000', 'org-1')
       seedVault('org1-v3', 'failed', '500', 'org-1')
@@ -207,7 +228,7 @@ describe('AnalyticsBatchLoader', () => {
       seedMilestone('org1-v1', 'pending')
       seedMilestone('org1-v2', 'completed')
 
-      const result = getOrgAnalyticsBatched(
+      const result = await getOrgAnalyticsBatched(
         ['org1-v1', 'org1-v2', 'org1-v3'],
         testDb,
       )
@@ -222,8 +243,8 @@ describe('AnalyticsBatchLoader', () => {
       expect(result.completedMilestones).toBe(2)
     })
 
-    it('returns zero-value result for empty vault list', () => {
-      const result = getOrgAnalyticsBatched([], testDb)
+    it('returns zero-value result for empty vault list', async () => {
+      const result = await getOrgAnalyticsBatched([], testDb)
       expect(result.totalVaults).toBe(0)
       expect(result.successRate).toBe(0)
       expect(result.totalLockedCapital).toBe('0')
@@ -233,15 +254,15 @@ describe('AnalyticsBatchLoader', () => {
   // ── tenant isolation ───────────────────────────────────────────────────────
 
   describe('tenant isolation', () => {
-    it('separate loader instances share no cached state', () => {
+    it('separate loader instances share no cached state', async () => {
       seedVault('t1-v1', 'active', '100', 'tenant-1')
       seedVault('t2-v1', 'completed', '200', 'tenant-2')
 
       const loaderA = makeLoader()
       const loaderB = makeLoader()
 
-      const resultA = loaderA.loadVaults(['t1-v1'])
-      const resultB = loaderB.loadVaults(['t2-v1'])
+      const resultA = await loaderA.loadVaults(['t1-v1'])
+      const resultB = await loaderB.loadVaults(['t2-v1'])
 
       // Each loader only sees its own requested vaults
       expect(resultA.has('t2-v1')).toBe(false)
@@ -252,25 +273,25 @@ describe('AnalyticsBatchLoader', () => {
       expect(loaderB.queries).toBe(1)
     })
 
-    it('loading tenant-A IDs does not expose tenant-B data', () => {
+    it('loading tenant-A IDs does not expose tenant-B data', async () => {
       seedVault('ta-v1', 'active', '999', 'tenant-a')
       seedVault('tb-v1', 'active', '1', 'tenant-b')
 
       const loader = makeLoader()
-      const result = loader.loadVaults(['ta-v1'])
+      const result = await loader.loadVaults(['ta-v1'])
 
       expect(result.has('tb-v1')).toBe(false)
       expect(result.get('ta-v1')?.amount).toBe('999')
     })
 
-    it('a loader primed with tenant-A IDs cannot retrieve tenant-B data on a second call', () => {
+    it('a loader primed with tenant-A IDs cannot retrieve tenant-B data on a second call', async () => {
       seedVault('p-v1', 'active', '50', 'org-p')
       seedVault('q-v1', 'active', '75', 'org-q')
 
       const loader = makeLoader()
-      loader.loadVaults(['p-v1'])
+      await loader.loadVaults(['p-v1'])
 
-      const second = loader.loadVaults(['q-v1'])
+      const second = await loader.loadVaults(['q-v1'])
       expect(second.size).toBe(1)
       expect(second.has('p-v1')).toBe(false)
     })

--- a/src/tests/performance/cacheReads.perf.test.ts
+++ b/src/tests/performance/cacheReads.perf.test.ts
@@ -25,6 +25,26 @@ import Database from 'better-sqlite3'
 import { getOrSet, closeCache } from '../../lib/cache.js'
 import { AnalyticsBatchLoader } from '../../services/analyticsBatchLoader.js'
 import { getOrgAnalyticsBatched } from '../../services/analytics.service.js'
+import type { DbLike } from '../../services/analyticsBatchLoader.js'
+
+// ---------------------------------------------------------------------------
+// Adapter: wraps synchronous better-sqlite3 into the async DbLike interface
+// so the same production code path can be exercised in unit tests.
+// ---------------------------------------------------------------------------
+
+class SqliteDbAdapter implements DbLike {
+  private db: Database.Database
+
+  constructor(db: Database.Database) {
+    this.db = db
+  }
+
+  async query(sql: string, params?: unknown[]): Promise<{ rows: unknown[] }> {
+    const stmt = this.db.prepare(sql)
+    const rows = stmt.all(...(params ?? []))
+    return { rows }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Budget constants
@@ -58,9 +78,10 @@ async function timed<T>(fn: () => Promise<T>): Promise<[T, number]> {
 // In-memory SQLite DB for the vault read path tests
 // ---------------------------------------------------------------------------
 
-const testDb = new Database(':memory:')
+const rawDb = new Database(':memory:')
+const testDb: DbLike = new SqliteDbAdapter(rawDb)
 
-testDb.exec(`
+rawDb.exec(`
   CREATE TABLE IF NOT EXISTS vaults (
     id      TEXT PRIMARY KEY,
     status  TEXT NOT NULL,
@@ -77,13 +98,13 @@ testDb.exec(`
 let milestoneSeq = 0
 
 function seedVault(id: string, status: string, amount: string): void {
-  testDb
+  rawDb
     .prepare('INSERT OR IGNORE INTO vaults (id, status, amount, org_id) VALUES (?, ?, ?, ?)')
     .run(id, status, amount, 'org-bench')
 }
 
 function seedMilestone(vaultId: string, status: string): void {
-  testDb
+  rawDb
     .prepare('INSERT INTO milestones (id, vault_id, status) VALUES (?, ?, ?)')
     .run(`m-bench-${++milestoneSeq}`, vaultId, status)
 }
@@ -292,10 +313,10 @@ describe('Cache read benchmark — hit ratio and latency', () => {
   // ── vault read path ──────────────────────────────────────────────────────
 
   describe('vault read path — getOrgAnalyticsBatched + cache', () => {
-    it('cold-cache vault read issues exactly 2 DB queries (vault batch + milestone batch)', () => {
+    it('cold-cache vault read issues exactly 2 DB queries (vault batch + milestone batch)', async () => {
       const loader = new AnalyticsBatchLoader(testDb)
-      loader.loadVaults(BENCH_VAULT_IDS)
-      loader.loadMilestones(BENCH_VAULT_IDS)
+      await loader.loadVaults(BENCH_VAULT_IDS)
+      await loader.loadMilestones(BENCH_VAULT_IDS)
 
       // Two IN-clause queries — one per entity type, never N per vault
       expect(loader.queries).toBe(2)


### PR DESCRIPTION
AnalyticsBatchLoader (`src/services/analyticsBatchLoader.ts`) declares `constructor(db: DbLike = defaultDb)` where `defaultDb` is imported as `{ db as defaultDb }` from `../db/database.js`, and `db/database.ts` exports `export const db = getPool()` — a raw `pg.Pool` (or `null`, per `getPgPool()` return type). The `DbLike` interface previously required a better-sqlite3-style `prepare(sql): { all(...params): unknown[] }` method, which `pg.Pool` does not implement at all — `tsc --noEmit` reports `TS2741: Property 'prepare' is missing in type 'Pool' but required in type 'DbLike'`. Concretely, `getOrgAnalyticsBatched` in `src/services/analytics.service.ts` calls `createAnalyticsBatchLoader(dbOverride)` where `dbOverride` is typically `undefined` in production, meaning the loader falls back to this incompatible `defaultDb` and would throw `this.db.prepare is not a function` the moment `loadVaults`/`loadMilestones` runs. This N+1-elimination batch loader is effectively non-functional against the real Postgres backend.

### Changes

- **DbLike interface**: Replaced `prepare().all()` with `query(sql, params)` matching `pg.Pool.query()` signature (async, returns `{ rows }`)
- **SQL placeholders**: Changed from `?` (sqlite) to `$N` (Postgres) for parameterised queries
- **loadVaults / loadMilestones**: Made async to support the Promise-based pg.Pool API
- **getOrgAnalyticsBatched**: Added function in `analyticsBatchLoader.ts` that computes an analytics snapshot using the batch loader. Exported along with the `OrgVaultAnalytics` type for use by `analytics.service.ts`
- **renderOrgAnalyticsSnapshot**: Made async to accommodate the now-async `getOrgAnalyticsBatched`
- **Tests**: Added `SqliteDbAdapter` that wraps synchronous better-sqlite3 into the async `DbLike` interface, keeping tests hermetic while exercising the same production code path

Closes #1005