### PR TITLE
fix: resolve redundant isHealthy check and spoofable clientIp (#1247,…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1140,6 +1140,48 @@ EXPORT_SIGNED_URL_TTL_S=7200
 
 ---
 
+## Trust Proxy
+
+### TRUST_PROXY
+
+| Property | Value |
+|----------|-------|
+| **Type** | String |
+| **Default** | `false` |
+| **Required** | No |
+| **Sensitive** | No |
+
+Controls Express's `trust proxy` setting, which determines how `req.ip` is resolved when the application sits behind a reverse proxy.
+
+**Why this matters:** `req.ip` (and `req.ips`) is derived from `X-Forwarded-For` only when `trust proxy` is enabled. If the setting is left at `false` (the default), Express ignores `X-Forwarded-For` and uses the direct TCP peer address instead. Enabling it too broadly (e.g. `true`) without network-level controls lets any client forge their IP by setting their own `X-Forwarded-For` header, corrupting IP-based audit logs and rate-limiting.
+
+**Accepted values:**
+
+| Value | Behaviour |
+|-------|-----------|
+| `false` | Disable trust proxy. `req.ip` = TCP peer address. Use when the app is exposed directly to the internet. |
+| `true` | Trust all proxy hops. Use only inside a fully-controlled network where only your proxy can reach the app. |
+| `loopback` | Trust proxies on `127.0.0.0/8` and `::1` only. |
+| `linklocal` | Trust proxies on `169.254.0.0/16` and `fe80::/10`. |
+| `uniquelocal` | Trust proxies on `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `fc00::/7`. |
+| `1` (or any integer) | Trust the given number of leftmost hops in `X-Forwarded-For`. |
+| `10.0.0.0/8` (or a comma-separated list of CIDRs/IPs) | Trust only proxies whose IP is in the listed ranges. |
+
+```bash
+# Disabled (default) — direct-to-internet deployment
+TRUST_PROXY=false
+
+# Trust only the local proxy on the same host
+TRUST_PROXY=loopback
+
+# Trust a specific internal CIDR range (e.g. AWS VPC)
+TRUST_PROXY=10.0.0.0/8
+```
+
+> **Security note:** Prefer the most restrictive value that matches your deployment topology. If you add a load balancer or reverse proxy in front of the service, set `TRUST_PROXY` to its IP/CIDR rather than using `true`.
+
+---
+
 ## Logging
 
 ### MAX_JSON_BODY_SIZE

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,26 @@ import webhookRouter from './routes/webhooks.js'
 import { errorHandler } from './middleware/errorHandler.js'
 
 export const app = express()
+
+// ── Trust proxy ────────────────────────────────────────────────────────────
+// Must be set before any middleware that reads req.ip so that Express
+// resolves the real client IP from the correct X-Forwarded-For position.
+// The value is controlled by the TRUST_PROXY env var (default: "false").
+// See docs/configuration.md for the full list of accepted values and the
+// security implications of each.
+{
+  const raw = config.trustProxy
+  // Convert the string to the type Express expects:
+  //   "true"/"false" → boolean, a numeric string → number, else keep as string.
+  let trustProxyValue: string | number | boolean = raw
+  if (raw === 'true') trustProxyValue = true
+  else if (raw === 'false') trustProxyValue = false
+  else {
+    const asNumber = Number(raw)
+    if (!isNaN(asNumber) && String(asNumber) === raw) trustProxyValue = asNumber
+  }
+  app.set('trust proxy', trustProxyValue)
+}
 app.use(httpMetricsMiddleware);
 app.use(tracingMiddleware);
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -222,6 +222,28 @@ export const envSchema = z
     HORIZON_LAG_THRESHOLD: nonNegativeInt(10),
     HORIZON_SHUTDOWN_TIMEOUT_MS: positiveInt(30_000),
 
+    // ── Trust proxy ─────────────────────────────────────────
+    // Controls Express's "trust proxy" setting.
+    //
+    // Accepted values (passed verbatim to app.set('trust proxy', ...)):
+    //   - "false"  (default) – trust proxy disabled; req.ip is the direct
+    //     TCP peer.  Use this when the server is exposed directly to the
+    //     internet with no reverse proxy in front of it.
+    //   - "true"   – trust any forwarded header (leftmost IP wins).  Only
+    //     safe inside a fully-controlled network where only your proxy can
+    //     reach the app.
+    //   - "loopback" | "linklocal" | "uniquelocal" – trust only proxies
+    //     whose IP falls in the named subnet.
+    //   - A number (e.g. "1") – trust the given hop count of leftmost IPs.
+    //   - A comma-separated list of CIDR ranges / IP addresses, e.g.
+    //     "10.0.0.0/8,172.16.0.0/12".
+    //
+    // Security note: setting this too broadly allows clients to spoof their
+    // IP address via x-forwarded-for, which would corrupt IP-based auditing
+    // and rate-limiting.  Prefer the most restrictive value that matches your
+    // deployment topology (e.g. "loopback" or a specific CIDR).
+    TRUST_PROXY: z.string().default("false"),
+
     // ── Webhooks ────────────────────────────────────────────
     WEBHOOK_INBOUND_SECRET: z.string().optional(),
     WEBHOOK_INBOUND_SKEW_MS: positiveInt(300_000),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -42,6 +42,7 @@ export type AppConfig = {
   maxJsonBodySize: string
   nodeEnv: string
   logLevel: string
+  trustProxy: string
 }
 
 const _env = process.env.NODE_ENV ?? 'development'
@@ -75,5 +76,11 @@ export const config: AppConfig = {
       if (err.message === 'Env not initialized') return process.env.MAX_JSON_BODY_SIZE ?? '500kb';
       throw err;
     }
-  }
+  },
+  get trustProxy() {
+    try { return getEnv().TRUST_PROXY } catch (err: any) {
+      if (err.message === 'Env not initialized') return process.env.TRUST_PROXY ?? 'false';
+      throw err;
+    }
+  },
 }

--- a/src/middleware/apiKeyAuth.ts
+++ b/src/middleware/apiKeyAuth.ts
@@ -11,7 +11,11 @@ export const authenticateApiKey = (requiredScopes: ApiScope[] = []): RequestHand
       return
     }
 
-    const clientIp = (req.ip || req.header('x-forwarded-for') || 'unknown') as string
+    // Use only req.ip, which Express resolves from the trusted proxy chain
+    // (controlled by the TRUST_PROXY setting in app.ts).  Never fall back to
+    // reading x-forwarded-for directly — a direct client can forge that header
+    // and corrupt IP-based auditing / abuse-detection keyed on clientIp.
+    const clientIp = req.ip ?? 'unknown'
     const validation = await validateApiKey(apiKey, requiredScopes, clientIp)
     if (!validation.valid) {
       if (validation.reason === 'forbidden') {

--- a/src/services/dbMetrics.ts
+++ b/src/services/dbMetrics.ts
@@ -74,7 +74,9 @@ export function getDBHealthMetrics(pgPool: Pool): DBHealthMetrics {
     warnings.push(`High number of slow queries detected (${slowQueries.length})`)
   }
 
-  const isHealthy = warnings.length === 0 && poolMetrics.availableConnections > 0
+  // availableConnections === 0 already pushes a warning above, so
+  // warnings.length === 0 is the single, non-redundant health gate.
+  const isHealthy = warnings.length === 0
 
   return {
     pool: poolMetrics,


### PR DESCRIPTION
… #1258)

#1247 — dbMetrics: simplify isHealthy expression
- Remove redundant  from the isHealthy expression in getDBHealthMetrics (src/services/dbMetrics.ts).
- The availableConnections === 0 branch already unconditionally pushes a warning, so warnings.length === 0 is the single correct health gate. The duplicated condition created a false impression of a stricter check without providing any additional signal.

#1258 — apiKeyAuth: eliminate spoofable x-forwarded-for clientIp fallback
- Remove the raw req.header('x-forwarded-for') fallback in apiKeyAuth.ts. clientIp now uses only req.ip, which Express resolves through the configured trust proxy chain.
- Add TRUST_PROXY env var to the Zod schema in src/config/env.ts (default: 'false'). Accepted values mirror Express trust proxy semantics: boolean strings, hop-count integers, named subnets (loopback/linklocal/ uniquelocal), and CIDR ranges.
- Wire TRUST_PROXY into src/app.ts via app.set('trust proxy', ...) before any middleware that reads req.ip.
- Expose trustProxy getter in src/config/index.ts (AppConfig).
- Add TRUST_PROXY documentation section to docs/configuration.md, including a table of accepted values and security guidance.
closes #1247 
closes #1258 