### PR TITLE
perf: index and query-plan audit for org-scoped list endpoints

### DIFF
--- a/db/migrations/20260727123000_add_org_scoped_list_indexes.cjs
+++ b/db/migrations/20260727123000_add_org_scoped_list_indexes.cjs
@@ -1,0 +1,92 @@
+/**
+ * Issue #754 — audit + add missing composite indexes for hot org-scoped
+ * list endpoints (org vaults, transactions, notifications, audit logs).
+ * 
+ * This migration covers the query shapes that were verifiable against the
+ * repository/service source in this pass.
+ * 
+ * ---------------------------------------------------------------------
+ * audit_logs  (src/lib/auditLogs.ts)
+ * ---------------------------------------------------------------------
+ *   listAuditLogs()                    WHERE organization_id = ?  ORDER BY created_at DESC
+ *   lookupPreviousAuditLogHash()        WHERE organization_id = ?  ORDER BY created_at DESC, id DESC  LIMIT 1
+ *   verifyAuditLogChain()               WHERE organization_id = ?  ORDER BY created_at ASC,  id ASC
+ *   exportAuditLogsForOrganization()    WHERE organization_id = ?  ORDER BY created_at ASC,  id ASC
+ * 
+ *   -> composite (organization_id, created_at, id) covers all four access
+ *      patterns; Postgres can scan a btree in either direction, so ASC and
+ *      DESC orderings both benefit. organization_id may be NULL for system
+ *      actions — Postgres indexes NULLs, so the whereNull() branches used
+ *      by lookupPreviousAuditLogHash/verifyAuditLogChain also hit the index.
+ * 
+ * ---------------------------------------------------------------------
+ * webhook_subscribers  (src/repositories/webhookSubscriberRepository.ts)
+ * ---------------------------------------------------------------------
+ *   findByOrg()     WHERE organization_id = ? AND active = true  ORDER BY created_at ASC
+ *   findByEvent()   same base filter + jsonb containment on events
+ * 
+ *   -> composite (organization_id, active, created_at). The jsonb
+ *      containment check in findByEvent can't use a btree, but the leading
+ *      columns still let Postgres narrow to the org's active subscribers
+ *      before falling back to a filter on events.
+ * 
+ * ---------------------------------------------------------------------
+ * vaults  (src/services/vaultStore.ts)
+ * ---------------------------------------------------------------------
+ *   listOrgVaults()  WHERE organization_id = ? AND deleted_at IS NULL
+ *                    ORDER BY created_at DESC, id DESC  (cursor pagination)
+ * 
+ *   -> composite (organization_id, deleted_at, created_at DESC, id DESC).
+ *      The deleted_at IS NULL filter can be satisfied by an index that
+ *      includes deleted_at. DESC ordering on created_at/id matches the
+ *      ORDER BY clause for optimal keyset pagination.
+ * 
+ * ---------------------------------------------------------------------
+ * notifications  (src/services/notification.ts)
+ * ---------------------------------------------------------------------
+ *   listUserNotifications()  WHERE user_id = ? [archived_at/read_at filters]
+ *                            ORDER BY created_at DESC, id DESC  (cursor pagination)
+ * 
+ *   -> composite (user_id, created_at, id). NOTE: as implemented today this
+ *      table is scoped by user_id, not organization_id — flagged in
+ *      docs/performance-testing.md since the issue lists notifications as
+ *      "org-scoped".
+ * 
+ * ---------------------------------------------------------------------
+ * transactions  (NOTE: deferred — see docs/performance-testing.md)
+ * ---------------------------------------------------------------------
+ *   The transactions table currently lacks an organization_id column and
+ *   appears to be scoped by user_id and vault_id only. If future work
+ *   adds org-scoped transaction queries, an index on
+ *   (organization_id, created_at DESC, id DESC) would be needed.
+ */
+
+exports.up = async function up(knex) {
+  // audit_logs: composite index for org-scoped queries with both ASC and DESC ordering
+  await knex.raw(
+    'CREATE INDEX IF NOT EXISTS idx_audit_logs_org_created_id ON audit_logs (organization_id, created_at, id)',
+  )
+
+  // webhook_subscribers: composite index for active org subscribers, sorted by created_at
+  await knex.raw(
+    'CREATE INDEX IF NOT EXISTS idx_webhook_subscribers_org_active_created ON webhook_subscribers (organization_id, active, created_at)',
+  )
+
+  // vaults: composite DESC index for org-scoped vault listing with cursor pagination
+  await knex.raw(
+    'CREATE INDEX IF NOT EXISTS idx_vaults_org_deleted_created_id_desc ON vaults (organization_id, deleted_at, created_at DESC, id DESC)',
+  )
+
+  // notifications: composite index for user-scoped notification listing
+  // Note: This table is currently user-scoped, not org-scoped
+  await knex.raw(
+    'CREATE INDEX IF NOT EXISTS idx_notifications_user_created_id ON notifications (user_id, created_at, id)',
+  )
+}
+
+exports.down = async function down(knex) {
+  await knex.raw('DROP INDEX IF EXISTS idx_audit_logs_org_created_id')
+  await knex.raw('DROP INDEX IF EXISTS idx_webhook_subscribers_org_active_created')
+  await knex.raw('DROP INDEX IF EXISTS idx_vaults_org_deleted_created_id_desc')
+  await knex.raw('DROP INDEX IF EXISTS idx_notifications_user_created_id')
+}

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -679,3 +679,149 @@ practice.
 - Added smoke tests for vaults, transactions, and analytics endpoints
 - Documented thresholds and best practices
 - Implemented helper utilities with 95% coverage requirement
+
+
+## Issue #754: Database Index and Query-Plan Audit for Hot Org-Scoped List Endpoints
+
+**Audit Date**: July 27, 2026  
+**Migration**: `20260727123000_add_org_scoped_list_indexes.cjs`  
+**Test File**: `src/tests/performance/orgListPlans.perf.test.ts`
+
+### Audit Scope
+
+The audit examined hot org-scoped list endpoints to ensure every paginated query uses a covering composite index, preventing sequential scans as data grows.
+
+### Tables and Indexes Added
+
+#### 1. **audit_logs**
+- **Existing Index**: `idx_audit_logs_organization_created` (created_at DESC only)
+- **New Index**: `idx_audit_logs_org_created_id` (organization_id, created_at, id)
+- **Covered Queries**:
+  - `listAuditLogs()` - WHERE organization_id = ? ORDER BY created_at DESC
+  - `lookupPreviousAuditLogHash()` - WHERE organization_id = ? ORDER BY created_at DESC, id DESC LIMIT 1
+  - `verifyAuditLogChain()` - WHERE organization_id = ? ORDER BY created_at ASC, id ASC
+  - `exportAuditLogsForOrganization()` - WHERE organization_id = ? ORDER BY created_at ASC, id ASC
+
+#### 2. **webhook_subscribers**
+- **Previous Index**: None for composite org-scoped queries
+- **New Index**: `idx_webhook_subscribers_org_active_created` (organization_id, active, created_at)
+- **Covered Queries**:
+  - `findByOrg()` - WHERE organization_id = ? AND active = true ORDER BY created_at ASC
+  - `findByEvent()` - Same base filter + JSONB containment on events
+
+#### 3. **vaults** ⭐ **CRITICAL ADDITION**
+- **Existing Index**: `idx_vaults_organization_id` (single column only)
+- **New Index**: `idx_vaults_org_deleted_created_id_desc` (organization_id, deleted_at, created_at DESC, id DESC)
+- **Covered Queries**:
+  - `listOrgVaults()` - WHERE organization_id = ? AND deleted_at IS NULL ORDER BY created_at DESC, id DESC
+  - **Cursor Pagination**: Supports keyset pagination with `(created_at, id) < (?, ?)` conditions
+
+#### 4. **notifications**
+- **Existing Index**: `idx_notifications_user_archived_created_id` (covers archived_at filter)
+- **New Index**: `idx_notifications_user_created_id` (user_id, created_at, id)
+- **Note**: This table is user-scoped, not org-scoped. The issue listing was updated to reflect this.
+
+#### 5. **transactions** ⚠️ **DEFERRED**
+- **Current State**: No organization_id column exists in transactions table
+- **Existing Indexes**: 
+  - `idx_transactions_stellar_timestamp`
+  - `idx_transactions_type_created_at`
+  - `idx_transactions_user_vault_type_created`
+- **Action**: If future work adds org-scoped transaction queries, an index on `(organization_id, created_at DESC, id DESC)` would be needed.
+
+### EXPLAIN-Based Regression Test
+
+**Test File**: `src/tests/performance/orgListPlans.perf.test.ts`
+
+The test verifies:
+1. **No Sequential Scans**: Each hot query uses an index scan, not seq scan
+2. **Large Dataset**: 6,000 rows per table with skewed distribution (1:50 ratio)
+3. **Multiple Query Patterns**: Tests both ASC and DESC ordering
+4. **Cursor Pagination**: Validates keyset pagination for vaults
+5. **Rollback Verification**: Ensures indexes can be cleanly removed
+
+**Test Coverage**:
+- ✅ audit_logs: Organization-scoped lookups with DESC/ASC ordering
+- ✅ webhook_subscribers: Active org subscribers sorted by created_at
+- ✅ vaults: Org-scoped vault listing with cursor pagination
+- ✅ notifications: User-scoped notification listing
+- ✅ Rollback: All four indexes can be cleanly removed and restored
+
+### Migration Details
+
+**File**: `db/migrations/20260727123000_add_org_scoped_list_indexes.cjs`
+
+The migration:
+1. Uses `CREATE INDEX IF NOT EXISTS` for idempotency
+2. Creates composite indexes matching actual query patterns
+3. Includes DESC ordering where queries use DESC sorting
+4. Handles NULL values (organization_id may be NULL for system actions)
+5. Provides complete `down()` function for rollback
+
+### Performance Impact
+
+#### Expected Improvements:
+
+1. **Vaults List Endpoint**:
+   - Before: Single column index `organization_id` only, requires sort on 2 columns
+   - After: Composite index `(organization_id, deleted_at, created_at DESC, id DESC)` covers WHERE, ORDER BY, and LIMIT
+
+2. **Audit Logs**:
+   - Before: Index on `(organization_id, created_at DESC)` only, missing id for tie-breaking
+   - After: Composite index `(organization_id, created_at, id)` covers all ASC/DESC patterns
+
+3. **Webhook Subscribers**:
+   - Before: No composite index for active org subscribers
+   - After: Index `(organization_id, active, created_at)` covers base filter and sort
+
+#### Query Plan Verification:
+
+Run the regression test:
+```bash
+npm test -- src/tests/performance/orgListPlans.perf.test.ts
+```
+
+Check index usage manually:
+```sql
+-- For vaults
+EXPLAIN (ANALYZE, BUFFERS) 
+SELECT * FROM vaults 
+WHERE organization_id = 'org-uuid' 
+  AND deleted_at IS NULL
+ORDER BY created_at DESC, id DESC 
+LIMIT 20;
+
+-- Look for: Index Scan using idx_vaults_org_deleted_created_id_desc
+-- Not: Seq Scan on vaults
+```
+
+### Monitoring Recommendations
+
+1. **Query Performance**: Monitor `pg_stat_user_indexes` for index usage
+2. **Scan Types**: Alert on sequential scans on large tables
+3. **Index Size**: Track growth of composite indexes
+4. **Query Latency**: Compare before/after response times for org-scoped lists
+
+### Future Considerations
+
+1. **Transactions Table**: If org-scoping is added, create `(organization_id, created_at DESC, id DESC)` index
+2. **Partial Indexes**: Consider `WHERE deleted_at IS NULL` for vaults if deletion rate is low
+3. **Index-only Scans**: Ensure SELECT clauses are covered by indexes where possible
+4. **Regular Audits**: Schedule quarterly index audits for new endpoints
+
+### Rollback Safety
+
+The migration is fully reversible:
+- `down()` function removes all four indexes
+- Uses `DROP INDEX IF EXISTS` for safety
+- No data loss (indexes only)
+
+### Test Data Requirements
+
+The EXPLAIN test requires:
+- **Large enough dataset**: 6,000+ rows to make index scans cheaper than seq scans
+- **Skewed distribution**: 1:50 ratio to simulate realistic org/user distributions
+- **Realistic timestamps**: Spread created_at values to simulate real data
+- **Cleanup**: All test data removed after tests complete
+
+This audit ensures that as the system grows, org-scoped list endpoints will maintain predictable performance without degrading to sequential scans.

--- a/src/tests/performance/orgListPlans.perf.test.ts
+++ b/src/tests/performance/orgListPlans.perf.test.ts
@@ -1,0 +1,243 @@
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals'
+import { randomUUID } from 'crypto'
+import type { Knex } from 'knex'
+import { db } from '../../db/knex.js'
+
+/**
+ * Issue #754 — EXPLAIN regression test.
+ * 
+ * Seeds enough rows per organization/user that the planner has a real
+ * reason to prefer an index scan over a sequential one, then asserts the
+ * plan for each hot query does NOT contain a Seq Scan on the target table.
+ * 
+ * A tiny table will happily get seq-scanned even with a perfectly good
+ * index (cheaper for the planner), so row counts here are deliberately
+ * large enough (5k+ per table, skewed toward one org/user so the filtered
+ * row count is still small relative to the table) to make the index the
+ * cheaper choice — this is what makes the test meaningful rather than
+ * tautological.
+ */
+
+const ORG_A = randomUUID()
+const ORG_B = randomUUID()
+const USER_A = randomUUID()
+const ROWS_PER_TABLE = 6000
+
+type PlanNode = {
+  'Node Type'?: string
+  'Relation Name'?: string
+  Plans?: PlanNode[]
+}
+
+function collectNodes(node: PlanNode, acc: PlanNode[] = []): PlanNode[] {
+  acc.push(node)
+  for (const child of node.Plans ?? []) collectNodes(child, acc)
+  return acc
+}
+
+async function explain(query: Knex.QueryBuilder | { toSQL: () => { sql: string; bindings: any[] } }): Promise<PlanNode> {
+  const { sql, bindings } = (query as any).toSQL()
+  const result = await db.raw(`EXPLAIN (FORMAT JSON) ${sql}`, bindings)
+  return result.rows[0]['QUERY PLAN'][0].Plan as PlanNode
+}
+
+function assertNoSeqScan(plan: PlanNode, table: string) {
+  const nodes = collectNodes(plan)
+  const seqScanOnTable = nodes.find(
+    (n) => n['Node Type'] === 'Seq Scan' && n['Relation Name'] === table,
+  )
+  expect(seqScanOnTable).toBeUndefined()
+}
+
+beforeAll(async () => {
+  // First, ensure our migration has run to create the indexes
+  // This assumes the test database is fresh or migrations are up to date
+  
+  // audit_logs
+  const auditRows = Array.from({ length: ROWS_PER_TABLE }, (_, i) => ({
+    id: randomUUID(),
+    actor_user_id: randomUUID(),
+    organization_id: i % 50 === 0 ? ORG_A : ORG_B,
+    action: 'test.action',
+    target_type: 'test_target',
+    target_id: randomUUID(),
+    metadata: JSON.stringify({}),
+    created_at: new Date(Date.now() - i * 1000).toISOString(),
+    prev_hash: '0'.repeat(64),
+    row_hash: randomUUID().replace(/-/g, '').padEnd(64, '0'),
+  }))
+  await db.batchInsert('audit_logs', auditRows, 500)
+
+  // webhook_subscribers
+  const webhookRows = Array.from({ length: ROWS_PER_TABLE }, (_, i) => ({
+    id: randomUUID(),
+    organization_id: i % 50 === 0 ? ORG_A : ORG_B,
+    url: `https://example.test/hook/${i}`,
+    secret: 'plaintext-secret-for-test',
+    events: JSON.stringify([]),
+    active: true,
+    schema_version: 1,
+    field_policy: JSON.stringify({}),
+  }))
+  await db.batchInsert('webhook_subscribers', webhookRows, 500)
+
+  // vaults (need to create organizations first for FK)
+  await db('organizations').insert([
+    { id: ORG_A, name: 'Test Org A', slug: 'test-org-a', metadata: {} },
+    { id: ORG_B, name: 'Test Org B', slug: 'test-org-b', metadata: {} },
+  ])
+
+  const vaultRows = Array.from({ length: ROWS_PER_TABLE }, (_, i) => ({
+    id: `vault-test-${i}`,
+    creator: `creator-${i}`,
+    amount: '100.0',
+    start_timestamp: new Date(Date.now() - i * 2000).toISOString(),
+    end_timestamp: new Date(Date.now() + 86400000).toISOString(),
+    success_destination: 'success',
+    failure_destination: 'failure',
+    status: 'active',
+    created_at: new Date(Date.now() - i * 1000).toISOString(),
+    organization_id: i % 50 === 0 ? ORG_A : ORG_B,
+    deleted_at: i % 100 === 0 ? new Date().toISOString() : null, // Some deleted
+  }))
+  await db.batchInsert('vaults', vaultRows, 500)
+
+  // notifications
+  const notificationRows = Array.from({ length: ROWS_PER_TABLE }, (_, i) => ({
+    id: randomUUID(),
+    user_id: i % 50 === 0 ? USER_A : randomUUID(),
+    type: 'test.type',
+    title: 'test title',
+    message: 'test message',
+    data: null,
+    created_at: new Date(Date.now() - i * 1000).toISOString(),
+  }))
+  await db.batchInsert('notifications', notificationRows, 500)
+})
+
+afterAll(async () => {
+  await db('audit_logs').where({ action: 'test.action' }).del()
+  await db('webhook_subscribers').where({ url: db.raw("url like 'https://example.test/hook/%'") }).del()
+  await db('vaults').where({ id: db.raw("id like 'vault-test-%'") }).del()
+  await db('notifications').where({ type: 'test.type' }).del()
+  await db('organizations').whereIn('id', [ORG_A, ORG_B]).del()
+  await db.destroy()
+})
+
+describe('org-scoped list query plans (issue #754)', () => {
+  it('uses an index for listAuditLogs-style organization_id lookups', async () => {
+    const query = db('audit_logs')
+      .select('*')
+      .where('organization_id', ORG_A)
+      .orderBy('created_at', 'desc')
+      .limit(100)
+    const plan = await explain(query)
+    assertNoSeqScan(plan, 'audit_logs')
+  })
+
+  it('uses an index for the audit chain-head lookup (created_at desc, id desc)', async () => {
+    const query = db('audit_logs')
+      .where('organization_id', ORG_A)
+      .orderBy('created_at', 'desc')
+      .orderBy('id', 'desc')
+      .limit(1)
+    const plan = await explain(query)
+    assertNoSeqScan(plan, 'audit_logs')
+  })
+
+  it('uses an index for chain verification / export (created_at asc, id asc)', async () => {
+    const query = db('audit_logs')
+      .select('*')
+      .where('organization_id', ORG_A)
+      .orderBy('created_at', 'asc')
+      .orderBy('id', 'asc')
+    const plan = await explain(query)
+    assertNoSeqScan(plan, 'audit_logs')
+  })
+
+  it('uses an index for findByOrg-style webhook_subscribers lookups', async () => {
+    const query = db('webhook_subscribers')
+      .where({ organization_id: ORG_A, active: true })
+      .orderBy('created_at', 'asc')
+    const plan = await explain(query)
+    assertNoSeqScan(plan, 'webhook_subscribers')
+  })
+
+  it('uses an index for org-scoped vaults list with cursor pagination', async () => {
+    // Test non-cursor query (first page)
+    const query1 = db('vaults')
+      .where({ organization_id: ORG_A })
+      .whereNull('deleted_at')
+      .orderBy('created_at', 'desc')
+      .orderBy('id', 'desc')
+      .limit(20)
+    const plan1 = await explain(query1)
+    assertNoSeqScan(plan1, 'vaults')
+
+    // Test cursor pagination query (simulating second page)
+    // Using a timestamp from the middle of our test data
+    const midTimestamp = new Date(Date.now() - (ROWS_PER_TABLE / 2) * 1000).toISOString()
+    const midId = `vault-test-${Math.floor(ROWS_PER_TABLE / 2)}`
+    
+    const query2 = db('vaults')
+      .where({ organization_id: ORG_A })
+      .whereNull('deleted_at')
+      .where(function() {
+        this.where('created_at', '<', midTimestamp)
+          .orWhere(function() {
+            this.where('created_at', '=', midTimestamp)
+              .andWhere('id', '<', midId)
+          })
+      })
+      .orderBy('created_at', 'desc')
+      .orderBy('id', 'desc')
+      .limit(20)
+    const plan2 = await explain(query2)
+    assertNoSeqScan(plan2, 'vaults')
+  })
+
+  it('uses an index for listUserNotifications-style user_id lookups', async () => {
+    const query = db('notifications')
+      .where({ user_id: USER_A })
+      .whereNull('archived_at')
+      .orderBy('created_at', 'desc')
+      .orderBy('id', 'desc')
+      .limit(20)
+    const plan = await explain(query)
+    assertNoSeqScan(plan, 'notifications')
+  })
+
+  it('rolls back cleanly and removes all four indexes', async () => {
+    // Use the actual migration name
+    const migrationName = '20260727123000_add_org_scoped_list_indexes.cjs'
+    
+    // Rollback the migration
+    await db.migrate.down({ name: migrationName } as any)
+    
+    // Check indexes are removed
+    const remaining = await db('pg_indexes')
+      .whereIn('indexname', [
+        'idx_audit_logs_org_created_id',
+        'idx_webhook_subscribers_org_active_created',
+        'idx_vaults_org_deleted_created_id_desc',
+        'idx_notifications_user_created_id',
+      ])
+      .andWhere('schemaname', '=', 'public')
+    
+    expect(remaining.length).toBe(0)
+
+    // Restore for any subsequent tests / suite re-runs
+    await db.migrate.up({ name: migrationName } as any)
+    
+    const restored = await db('pg_indexes')
+      .whereIn('indexname', [
+        'idx_audit_logs_org_created_id',
+        'idx_webhook_subscribers_org_active_created',
+        'idx_vaults_org_deleted_created_id_desc',
+        'idx_notifications_user_created_id',
+      ])
+      .andWhere('schemaname', '=', 'public')
+    
+    expect(restored.length).toBe(4)
+  })
+})


### PR DESCRIPTION
Fixes #754

Adds missing composite indexes for hot org-scoped list endpoints to prevent sequential scans as data grows.

### Changes:

1. **Migration**: Added 4 composite indexes:
   - `idx_audit_logs_org_created_id` - Audit logs org-scoped queries
   - `idx_webhook_subscribers_org_active_created` - Active org subscribers  
   - `idx_vaults_org_deleted_created_id_desc` - Critical: Vaults org-scoped cursor pagination
   - `idx_notifications_user_created_id` - User-scoped notifications

2. **Test**: `orgListPlans.perf.test.ts` - EXPLAIN regression test verifying no sequential scans
   - 6k+ rows per table, skewed distribution
   - Tests all query patterns (ASC/DESC, cursor pagination)
   - Verifies rollback safety

3. **Docs**: Updated `performance-testing.md` with audit findings

### Impact:

- Prevents sequential scans on org-scoped list endpoints
- Optimizes vaults cursor pagination with DESC-ordered composite index
- No breaking changes (`IF NOT EXISTS`, full rollback)
