### PR TITLE
Fix #1383: Reuse milestone record in approve endpoint

### DIFF
--- a/src/routes/milestones.ts
+++ b/src/routes/milestones.ts
@@ -221,7 +221,7 @@ milestonesRouter.post('/:id/approve', authenticate, requireVerifier, async (req:
       return next(AppError.conflict('Verifier has already voted on this milestone'))
     }
 
-    // Reject late votes on already-settled milestones
+    // Reject late votes on already-settled milestones (using cached milestone)
     const approvalThreshold = (milestone as any)?.approvalThreshold || 1
     const totalVerifiers = (milestone as any)?.totalVerifiers as number | undefined
 


### PR DESCRIPTION
# Description
This PR addresses issue #1383 by ensuring that the milestone `POST /:id/approve` route reuses the initial `getMilestoneById(id)` lookup rather than querying the data store a second time. Note that the codebase already reuses the `milestone` object, so this PR only clarifies the intent by explicitly documenting the cached object reuse where the approval threshold is read.

Closes #1383

## Changes
- Added an inline code comment confirming the reuse of the cached `milestone` object when retrieving the milestone `approvalThreshold` and `totalVerifiers`.
