### PR TITLE
Fix #1384: Require authentication for milestone approval status endpoint

### DIFF
--- a/src/routes/milestones.ts
+++ b/src/routes/milestones.ts
@@ -288,7 +288,7 @@ milestonesRouter.post('/:id/approve', authenticate, requireVerifier, async (req:
 })
 
 // GET /api/vaults/:vaultId/milestones/:id/approval-status
-// Get detailed approval status for a milestone
+// Get detailed approval status for a milestone (requires authentication)
 milestonesRouter.get('/:id/approval-status', authenticate, async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { vaultId, id } = req.params


### PR DESCRIPTION
# Description
This PR addresses issue #1384 by ensuring that the milestone approval status endpoint requires authentication. Note that the `authenticate` middleware was already present in the codebase for `GET /:id/approval-status`, so this PR only updates the inline route documentation for clarity.

Closes #1384

## Changes
- Updated route documentation comment on `GET /:id/approval-status` to explicitly note the authentication requirement.
