### PR TITLE
Fix #1280: Distinguish decode failures from burn addresses

### DIFF
--- a/src/services/vaultValidation.ts
+++ b/src/services/vaultValidation.ts
@@ -31,22 +31,62 @@ export function getClassicAddress(address: string): string {
   return address
 }
 
-export function isUnsafeAddress(address: string): boolean {
+/**
+ * Result of checking whether an address is unsafe or has decode errors.
+ * - isBurnAddress: true if the address is all-zero or all-ones (burn address)
+ * - decodeError: true if the SDK failed to decode for reasons other than validation
+ */
+export interface UnsafeAddressResult {
+  isBurnAddress: boolean
+  decodeError: boolean
+}
+
+/**
+ * Checks if an address is a burn address (all-zero or all-ones bytes).
+ * Returns an object distinguishing between genuine burn addresses and decode failures.
+ */
+export function checkAddressSafety(address: string): UnsafeAddressResult {
+  // First, validate the address format
+  const isValidEd = StrKey.isValidEd25519PublicKey(address)
+  const isValidMed = StrKey.isValidMed25519PublicKey(address)
+  
+  if (!isValidEd && !isValidMed) {
+    // Not a valid format, but this is not a decode error - just invalid
+    return { isBurnAddress: false, decodeError: false }
+  }
+
   try {
     let pubkey: Buffer
-    if (StrKey.isValidEd25519PublicKey(address)) {
+    if (isValidEd) {
       pubkey = StrKey.decodeEd25519PublicKey(address)
-    } else if (StrKey.isValidMed25519PublicKey(address)) {
-      pubkey = StrKey.decodeMed25519PublicKey(address).slice(0, 32)
     } else {
-      return false
+      pubkey = StrKey.decodeMed25519PublicKey(address).slice(0, 32)
     }
+    
     const allZeros = pubkey.every((b) => b === 0x00)
     const allOnes = pubkey.every((b) => b === 0xff)
-    return allZeros || allOnes
-  } catch {
-    return true
+    
+    return {
+      isBurnAddress: allZeros || allOnes,
+      decodeError: false
+    }
+  } catch (error) {
+    // An unexpected decode error occurred despite validation passing
+    return {
+      isBurnAddress: false,
+      decodeError: true
+    }
   }
+}
+
+/**
+ * Legacy function for backward compatibility.
+ * Returns true if the address is unsafe (burn address OR decode error).
+ * @deprecated Use checkAddressSafety() for more granular error handling
+ */
+export function isUnsafeAddress(address: string): boolean {
+  const result = checkAddressSafety(address)
+  return result.isBurnAddress || result.decodeError
 }
 
 // Checks SEP-29: returns true if the account has set config.memo_required=1
@@ -214,18 +254,33 @@ export const createVaultSchema = z
       }
     }
 
-    // Reject unsafe success/failure destination addresses
-    if (isUnsafeAddress(data.destinations.success)) {
+    // Reject unsafe success/failure destination addresses with specific error messages
+    const successSafety = checkAddressSafety(data.destinations.success)
+    if (successSafety.isBurnAddress) {
       ctx.addIssue({
         code: 'custom',
-        message: 'Destination address cannot be a zero, burn, or unsafe address',
+        message: 'Destination address cannot be a zero or burn address (all-zero or all-ones bytes)',
+        path: ['destinations', 'success'],
+      })
+    } else if (successSafety.decodeError) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Failed to decode destination address - unexpected SDK error',
         path: ['destinations', 'success'],
       })
     }
-    if (isUnsafeAddress(data.destinations.failure)) {
+    
+    const failureSafety = checkAddressSafety(data.destinations.failure)
+    if (failureSafety.isBurnAddress) {
       ctx.addIssue({
         code: 'custom',
-        message: 'Destination address cannot be a zero, burn, or unsafe address',
+        message: 'Destination address cannot be a zero or burn address (all-zero or all-ones bytes)',
+        path: ['destinations', 'failure'],
+      })
+    } else if (failureSafety.decodeError) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Failed to decode destination address - unexpected SDK error',
         path: ['destinations', 'failure'],
       })
     }


### PR DESCRIPTION
## Summary
Fixes #1280

This PR addresses the issue where `isUnsafeAddress` in `src/services/vaultValidation.ts` treats decode failures identically to genuinely unsafe burn addresses, leading to misleading error messages for users.

## Changes Made

### 1. New `checkAddressSafety` function
- Created a new function that returns granular results via `UnsafeAddressResult` interface
- Distinguishes between:
  - **Burn addresses**: Addresses with all-zero or all-ones bytes (genuine security risk)
  - **Decode errors**: Unexpected SDK failures unrelated to address safety

### 2. Updated validation with specific error messages
- **Burn address error**: `'Destination address cannot be a zero or burn address (all-zero or all-ones bytes)'`
- **Decode error**: `'Failed to decode destination address - unexpected SDK error'`

### 3. Backward compatibility
- Kept `isUnsafeAddress` as a deprecated legacy function for any existing code that depends on it
- The function now internally uses `checkAddressSafety`

## Impact

Before this change, a legitimate valid address that triggered an unrelated decode exception (e.g., due to stricter validation in a future SDK version) would be rejected with the same message as an actual burn address: `'cannot be a zero, burn, or unsafe address'`.

After this change:
- Users with actual burn addresses get a clear, accurate error message
- Users whose addresses fail to decode get a different message indicating an SDK issue
- Developers can distinguish between security rejections and technical failures

## Testing

The changes maintain backward compatibility while providing better error granularity. The validation logic flow remains the same, but error messages are now more precise and helpful.

Closes #1280