### PR TITLE
fix: persist intended role on org invitations to prevent self-assign privilege escalation (#975)

### DIFF
--- a/db/migrations/20260728000000_add_role_to_org_invitations.cjs
+++ b/db/migrations/20260728000000_add_role_to_org_invitations.cjs
@@ -1,0 +1,11 @@
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('org_invitations', (table) => {
+    table.text('role').notNullable().defaultTo('member')
+  })
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('org_invitations', (table) => {
+    table.dropColumn('role')
+  })
+}

--- a/src/routes/orgMembers.ts
+++ b/src/routes/orgMembers.ts
@@ -234,11 +234,14 @@ orgMembersRouter.post(
   orgWriteRateLimiter,
   async (req: Request, res: Response, next: NextFunction) => {
     const { orgId } = req.params
-    const { email } = req.body as { email?: string }
+    const { email, role } = req.body as { email?: string; role?: string }
 
     if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
       return next(AppError.badRequest('A valid email is required.'))
     }
+
+    const validInviteRoles: OrgRole[] = ['owner', 'admin', 'member']
+    const invitedRole: OrgRole = role && validInviteRoles.includes(role as OrgRole) ? (role as OrgRole) : 'member'
 
     const rawToken = crypto.randomBytes(32).toString('hex')
     const tokenHash = hashToken(rawToken)
@@ -246,15 +249,15 @@ orgMembersRouter.post(
 
     try {
       const [invitation] = await db('org_invitations')
-        .insert({ org_id: orgId, email, token_hash: tokenHash, expires_at: expiresAt })
-        .returning(['id', 'org_id', 'email', 'expires_at'])
+        .insert({ org_id: orgId, email, role: invitedRole, token_hash: tokenHash, expires_at: expiresAt })
+        .returning(['id', 'org_id', 'email', 'role', 'expires_at'])
 
       createAuditLog({
         actor_user_id: req.user!.userId,
         action: 'org.invitation.created',
         target_type: 'org_invitation',
         target_id: invitation.id,
-        metadata: { orgId, email },
+        metadata: { orgId, email, role: invitedRole },
       })
 
       // Notify the invitee
@@ -269,6 +272,7 @@ orgMembersRouter.post(
         id: invitation.id,
         orgId: invitation.org_id,
         email: invitation.email,
+        role: invitation.role,
         expiresAt: invitation.expires_at,
         token: rawToken, // returned once — caller delivers this to the recipient
       })
@@ -373,14 +377,14 @@ orgMembersRouter.delete(
 
 // ─── POST /api/organizations/:orgId/invitations/accept ────────────────────────
 // Accept an invitation by submitting the raw token and desired userId.
-// Promotes the recipient to org member.
+// The role is taken from the stored invitation, not from the request body.
 
 orgMembersRouter.post(
   '/:orgId/invitations/accept',
   orgWriteRateLimiter,
   async (req: Request, res: Response, next: NextFunction) => {
     const { orgId } = req.params
-    const { token, userId, role } = req.body as { token?: string; userId?: string; role?: string }
+    const { token, userId } = req.body as { token?: string; userId?: string }
 
     if (!token || !userId) {
       return next(AppError.badRequest('token and userId are required.'))
@@ -399,14 +403,13 @@ orgMembersRouter.post(
       return next(AppError.badRequest('Invalid or expired invitation token.'))
     }
 
-    const validRoles: OrgRole[] = ['owner', 'admin', 'member']
-    const assignedRole: OrgRole = validRoles.includes(role as OrgRole) ? (role as OrgRole) : 'member'
+    const storedRole: OrgRole = invitation.role ?? 'member'
 
     try {
       const membership = await createMembership({
         user_id: userId,
         organization_id: orgId,
-        role: assignedRole,
+        role: storedRole,
       })
 
       await db('org_invitations').where({ id: invitation.id }).update({ accepted_at: new Date() })
@@ -416,7 +419,7 @@ orgMembersRouter.post(
         action: 'org.invitation.accepted',
         target_type: 'org_invitation',
         target_id: invitation.id,
-        metadata: { orgId, userId, role: assignedRole },
+        metadata: { orgId, userId, role: storedRole },
       })
 
       res.status(200).json({ orgId, userId, role: membership.role })

--- a/src/services/membership.ts
+++ b/src/services/membership.ts
@@ -31,6 +31,7 @@ type OrgInvitation = {
   org_id: string
   email: string
   token_hash: string
+  role: string
   expires_at: Date | string
   accepted_at: Date | string | null
   revoked_at?: Date | string | null
@@ -330,7 +331,7 @@ export const resendInvitation = async (
       expires_at: expiresAt,
       revoked_at: null,
     })
-    .returning(['id', 'org_id', 'email', 'expires_at', 'accepted_at', 'revoked_at'])
+    .returning(['id', 'org_id', 'email', 'role', 'expires_at', 'accepted_at', 'revoked_at'])
 
   return updated
 }
@@ -349,7 +350,7 @@ export const revokeInvitation = async (
   const [updated] = await db('org_invitations')
     .where({ id: invitationId, org_id: orgId })
     .update({ revoked_at: revokedAt })
-    .returning(['id', 'org_id', 'email', 'expires_at', 'accepted_at', 'revoked_at'])
+    .returning(['id', 'org_id', 'email', 'role', 'expires_at', 'accepted_at', 'revoked_at'])
 
   return updated
 }

--- a/src/tests/orgInvitations.lifecycle.test.ts
+++ b/src/tests/orgInvitations.lifecycle.test.ts
@@ -13,6 +13,7 @@ type InvitationRow = {
   org_id: string
   email: string
   token_hash: string
+  role: string
   expires_at: Date
   accepted_at: Date | null
   revoked_at: Date | null
@@ -155,6 +156,7 @@ function seedInvitation(overrides: Partial<InvitationRow> = {}) {
     org_id: 'org-abc',
     email: 'invitee@example.com',
     token_hash: overrides.token_hash ?? hashToken(rawToken!),
+    role: 'member',
     expires_at: new Date(Date.now() + 86_400_000),
     accepted_at: null,
     revoked_at: null,

--- a/src/tests/orgInvitations.test.ts
+++ b/src/tests/orgInvitations.test.ts
@@ -45,7 +45,8 @@ jest.unstable_mockModule('../services/membership.js', async () => ({
   listOrgMemberships: jest.fn(),
   createMembership: jest.fn().mockResolvedValue({ role: 'member' }),
   removeMembership: jest.fn(),
-  updateMemberRole: jest.fn(),
+  changeRole: jest.fn(),
+  transferOwnership: jest.fn(),
   resendInvitation: jest.fn(),
   revokeInvitation: jest.fn(),
   InvitationNotFoundError: class InvitationNotFoundError extends Error {},
@@ -94,14 +95,16 @@ app.use(errorHandler)
 
 // ── Helpers ─────────────────────────────────────────────────────────────────--
 
-function seedPendingInvitation(tokenHash: string, orgId = 'org-abc') {
+function seedPendingInvitation(tokenHash: string, orgId = 'org-abc', overrides: Partial<Record<string, unknown>> = {}) {
   dbMock._pending = {
     id: 'inv-1',
     org_id: orgId,
     email: 'invitee@example.com',
     token_hash: tokenHash,
+    role: 'member',
     expires_at: new Date(Date.now() + 86400_000),
     accepted_at: null,
+    ...overrides,
   }
 }
 
@@ -217,7 +220,7 @@ describe('POST /api/organizations/:orgId/invitations/accept', () => {
     expect(res.body.role).toBe('member')
   })
 
-  it('defaults role to member when not specified', async () => {
+  it('defaults role to member when not specified at creation', async () => {
     const rawToken = crypto.randomBytes(32).toString('hex')
     const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex')
     seedPendingInvitation(tokenHash)

--- a/src/tests/orgMembers.e2e.test.ts
+++ b/src/tests/orgMembers.e2e.test.ts
@@ -45,6 +45,7 @@ interface InvitationRow {
   org_id: string
   email: string
   token_hash: string
+  role: string
   expires_at: Date
   accepted_at: Date | null
   revoked_at: Date | null
@@ -204,11 +205,13 @@ afterEach(() => {
 })
 
 // Issues an invitation as an org admin and returns the raw acceptance token.
-async function inviteToAlpha(email = 'erin@example.com'): Promise<string> {
+async function inviteToAlpha(email = 'erin@example.com', role?: string): Promise<string> {
+  const body: Record<string, string> = { email }
+  if (role) body.role = role
   const res = await request(app)
     .post(`/api/organizations/${ORG_ALPHA}/invitations`)
     .set('Authorization', bearer('alice', 'owner'))
-    .send({ email })
+    .send(body)
   expect(res.status).toBe(201)
   expect(res.body.token).toMatch(/^[0-9a-f]{64}$/)
   return res.body.token
@@ -224,7 +227,7 @@ describe('Org-member invitation acceptance — end to end (issue #668)', () => {
     const token = await inviteToAlpha()
     const accept = await request(app)
       .post(`/api/organizations/${ORG_ALPHA}/invitations/accept`)
-      .send({ token, userId: 'erin', role: 'member' })
+      .send({ token, userId: 'erin' })
     expect(accept.status).toBe(200)
     expect(accept.body).toMatchObject({ orgId: ORG_ALPHA, userId: 'erin', role: 'member' })
 
@@ -245,7 +248,7 @@ describe('Org-member invitation acceptance — end to end (issue #668)', () => {
     const token = await inviteToAlpha()
     await request(app)
       .post(`/api/organizations/${ORG_ALPHA}/invitations/accept`)
-      .send({ token, userId: 'erin', role: 'member' })
+      .send({ token, userId: 'erin' })
       .expect(200)
 
     // Accepted into Alpha only — Beta's roster must stay off-limits.
@@ -254,11 +257,11 @@ describe('Org-member invitation acceptance — end to end (issue #668)', () => {
     expect(crossOrg.body.error).toMatch(/not a member/i)
   })
 
-  it('honours the role requested at acceptance time', async () => {
-    const token = await inviteToAlpha()
+  it('honours the role set at invitation creation time', async () => {
+    const token = await inviteToAlpha('frank@example.com', 'admin')
     const accept = await request(app)
       .post(`/api/organizations/${ORG_ALPHA}/invitations/accept`)
-      .send({ token, userId: 'frank', role: 'admin' })
+      .send({ token, userId: 'frank' })
     expect(accept.status).toBe(200)
     expect(accept.body.role).toBe('admin')
     expect(getMemberRole(ORG_ALPHA, 'frank')).toBe('admin')
@@ -268,12 +271,12 @@ describe('Org-member invitation acceptance — end to end (issue #668)', () => {
     const token = await inviteToAlpha()
     await request(app)
       .post(`/api/organizations/${ORG_ALPHA}/invitations/accept`)
-      .send({ token, userId: 'erin', role: 'member' })
+      .send({ token, userId: 'erin' })
       .expect(200)
 
     const replay = await request(app)
       .post(`/api/organizations/${ORG_ALPHA}/invitations/accept`)
-      .send({ token, userId: 'erin', role: 'member' })
+      .send({ token, userId: 'erin' })
     expect(replay.status).toBe(400)
     expect(replay.body.error.message).toMatch(/invalid or expired/i)
     expect(getOrgMembers(ORG_ALPHA).filter((m) => m.userId === 'erin')).toHaveLength(1)
@@ -286,6 +289,7 @@ describe('Org-member invitation acceptance — end to end (issue #668)', () => {
       org_id: ORG_ALPHA,
       email: 'late@example.com',
       token_hash: sha256(rawToken),
+      role: 'member',
       expires_at: new Date(Date.now() - 1000), // already expired
       accepted_at: null,
       revoked_at: null,
@@ -293,7 +297,7 @@ describe('Org-member invitation acceptance — end to end (issue #668)', () => {
 
     const res = await request(app)
       .post(`/api/organizations/${ORG_ALPHA}/invitations/accept`)
-      .send({ token: rawToken, userId: 'erin', role: 'member' })
+      .send({ token: rawToken, userId: 'erin' })
     expect(res.status).toBe(400)
     expect(res.body.error.message).toMatch(/invalid or expired/i)
     expect(getMemberRole(ORG_ALPHA, 'erin')).toBeUndefined()


### PR DESCRIPTION
Closes #975

**Problem:** POST /`:orgId`/invitations never stored the intended `role` in the `org_invitations` row. POST /`:orgId`/invitations/accept read `role` directly from the untrusted request body, letting anyone with a valid token claim any role including `owner`.

**Changes made:**

1. **db/migrations/20260728000000_add_role_to_org_invitations.cjs** — New migration adding a `role` column (defaults `'member'` for existing rows).
2. **src/routes/orgMembers.ts (invitation creation)** — Accept an optional `role` from the request body, validate it against `['owner', 'admin', 'member']`, and persist it in the database.
3. **src/routes/orgMembers.ts (invitation accept)** — No longer destructures `role` from body. Uses `invitation.role` from the stored row instead.
4. **src/services/membership.ts** — `OrgInvitation` type, `resendInvitation`, and `revokeInvitation` now include `role` in their returned columns.
5. **Tests updated** — All test helpers seed `role: 'member'`; accept calls no longer send `role` in the body; the e2e 'honours role' test now sets role at invite-creation time instead of at acceptance.