### PR TITLE
fix: resolve clientIp spoofing vulnerability (#1391)

### DIFF
--- a/src/security/abuse-monitor.ts
+++ b/src/security/abuse-monitor.ts
@@ -369,17 +369,9 @@ function maybeCleanupIdleIpStates(now: number): void {
 }
 
 function getClientIp(req: Request): string {
-  const forwardedFor = req.headers['x-forwarded-for']
-
-  if (typeof forwardedFor === 'string' && forwardedFor.length > 0) {
-    return forwardedFor.split(',')[0].trim()
-  }
-
-  if (Array.isArray(forwardedFor) && forwardedFor.length > 0) {
-    return forwardedFor[0].split(',')[0].trim()
-  }
-
-  return req.socket.remoteAddress ?? 'unknown'
+  // Rely on Express's trust proxy configuration instead of directly reading
+  // x-forwarded-for to prevent spoofing by direct clients.
+  return req.ip ?? 'unknown'
 }
 
 function isFailedLoginAttempt(path: string, status: number): boolean {


### PR DESCRIPTION
### Description
Closes #1391

This PR resolves a vulnerability where a direct client could spoof their IP address by manually setting the `x-forwarded-for` header.

The `getClientIp` function in `src/security/abuse-monitor.ts` has been updated to rely on `req.ip` instead of reading the `x-forwarded-for` header directly. By using `req.ip`, we correctly defer to Express's `trust proxy` configuration settings (configured in `src/app.ts`), ensuring that the application securely resolves the true client IP from the trusted proxy chain rather than a raw spoofable header. 

Note: Similar fixes were previously applied to `src/middleware/apiKeyAuth.ts` and this change ensures that the IP-based auditing and abuse-detection logic across the application remains secure.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

### How Has This Been Tested?
- Verified that the Express configuration natively handles proxy chains securely when `trust proxy` is set.
- Ensured tests run successfully and there are no regressions.
