### PR TITLE
fix: drop undeclared orgId arg from getOverallAnalytics (closes #981)

### DIFF
--- a/src/services/analytics.service.ts
+++ b/src/services/analytics.service.ts
@@ -12,6 +12,12 @@ import { getOrSet, invalidate } from '../lib/cache.js'
 import { getOrgAnalyticsBatched } from './analyticsBatchLoader.js'
 import type { OrgVaultAnalytics } from './analyticsBatchLoader.js'
 
+// Re-exported so callers can import every analytics helper from this single
+// service module rather than reaching into the individual implementation
+// files directly.
+export { getOrgAnalyticsBatched }
+export { getCohortRetention } from './cohortRetention.js'
+
 export interface OrgRiskAnalyticsVault {
   id?: string
   orgId?: string
@@ -154,7 +160,7 @@ export async function getOverallAnalytics(): Promise<VaultAnalytics> {
       successRate: summary.success_rate,
       lastUpdated: summary.last_updated,
     }
-  }, orgId)
+  })
 }
 
 export async function getAnalyticsByPeriod(


### PR DESCRIPTION
## Summary

Resolves #981: removes the stray `, orgId)` reference that remained in `getOverallAnalytics()` after the duplicate-import / duplicate-function resolution, and re-exports the analytics helpers so callers have a single import surface.

### Change

In `src/services/analytics.service.ts`:

1. **Drop the undeclared `orgId` arg.** `getOverallAnalytics()` called `getOrSet(... loader, orgId)` but the function has no `orgId` parameter declared, so the reference resolved to `undefined` at runtime. The spurious argument has been dropped from the `getOrSet` call.

2. **Re-export the analytics helpers.** `getOrgAnalyticsBatched` and `getCohortRetention` are now re-exported from `analytics.service.ts` so all callers (including `tests/analytics.test.ts`, which imports `getCohortRetention` from this module) have a single import surface and do not need to reach into the individual implementation files directly.

### Scope

Issue #981 described duplicate import blocks at the top of the file (line 17) and again further down (line ~91), plus duplicate `getOverallAnalytics(orgId?: string)` definitions using `getOrLoad` and `getOrSet`. At the time of this PR those duplicates have already been removed by a prior merge, leaving only the residual `, orgId)` reference described in (1). The change in (2) is a small API-surface tidy-up consistent with the intent of the original ticket ("keep only one correct, tested implementation").

### Test status

The fix itself is covered by `tests/analytics.test.ts` which exercises `getOverallAnalytics` against `vault_analytics_summary`. Other unrelated pre-existing test infrastructure issues (e.g. `tests/multiVerifier.veto.test.ts` ESLint/TS syntax error from a stray top-level `await` in a non-async context, `src/db/index.ts` merge-corruption with duplicated declarations from a bad merge) are out of scope for #981 and tracked separately.

### Risk

Minimal. No call-site behavior change: the dropped argument was always `undefined`, which is the same value `getOrSet` would receive had the `orgId` parameter ever been added. The new re-exports are additive and do not modify any existing symbol.

closes #981