### PR TITLE
fix: allow deactivated verifier to be reinstated to approved (#1275)

### DIFF
--- a/0001-fix-1275-reinstate-deactivated-approved.patch
+++ b/0001-fix-1275-reinstate-deactivated-approved.patch
@@ -1,0 +1,89 @@
+From 2886468d98980616ff321a2978afb5bf48d14e4a Mon Sep 17 00:00:00 2001
+From: You <you@example.com>
+Date: Wed, 29 Jul 2026 11:29:05 +0000
+Subject: [PATCH 1/2] fix: allow deactivated verifier to be reinstated to
+ approved (#1275)
+
+transitionMatrix only permitted deactivated -> pending, so the
+POST /:userId/reinstate handler's documented behavior (restore a
+previously-approved verifier straight back to 'approved') always
+threw InvalidVerifierStatusTransitionError for that exact case.
+
+Add 'approved' as a valid transition target from 'deactivated' so
+canTransition allows it. statusAction() already resolves to
+'verifier.approved' for any to === 'approved' transition (checked
+before the deactivated-specific branch), so no change needed there.
+---
+ src/services/verifiers.ts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/services/verifiers.ts b/src/services/verifiers.ts
+index 82beb1b..679a689 100644
+--- a/src/services/verifiers.ts
++++ b/src/services/verifiers.ts
+@@ -49,7 +49,7 @@ const transitionMatrix: Record<VerifierStatus, VerifierStatus[]> = {
+   pending: ['pending', 'approved', 'deactivated'],
+   approved: ['approved', 'suspended', 'deactivated'],
+   suspended: ['suspended', 'approved', 'deactivated'],
+-  deactivated: ['deactivated', 'pending'],
++  deactivated: ['deactivated', 'pending', 'approved'],
+ }
+ 
+ export const canTransition = (from: VerifierStatus, to: VerifierStatus): boolean =>
+-- 
+2.43.0
+
+
+From 204584ea56738e24b73a202d6cd097aab3e135b1 Mon Sep 17 00:00:00 2001
+From: You <you@example.com>
+Date: Wed, 29 Jul 2026 11:29:22 +0000
+Subject: [PATCH 2/2] test: cover deactivated -> approved reinstate transition
+ (#1275)
+
+---
+ .../verifiers.transitionMatrix.test.ts        | 33 +++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+ create mode 100644 src/services/__tests__/verifiers.transitionMatrix.test.ts
+
+diff --git a/src/services/__tests__/verifiers.transitionMatrix.test.ts b/src/services/__tests__/verifiers.transitionMatrix.test.ts
+new file mode 100644
+index 0000000..fd77aa5
+--- /dev/null
++++ b/src/services/__tests__/verifiers.transitionMatrix.test.ts
+@@ -0,0 +1,33 @@
++import { canTransition } from '../verifiers.js'
++
++// Regression test for #1275: POST /:userId/reinstate computes
++// nextStatus = verifier.approvedAt ? 'approved' : 'pending', but the
++// transition matrix rejected deactivated -> approved, so a previously
++// approved verifier could never actually be reinstated to 'approved' --
++// the endpoint's own documented primary use case.
++describe('canTransition (verifier status matrix)', () => {
++  it('allows a deactivated verifier to be reinstated straight to approved', () => {
++    expect(canTransition('deactivated', 'approved')).toBe(true)
++  })
++
++  it('still allows deactivated -> pending (reactivate flow)', () => {
++    expect(canTransition('deactivated', 'pending')).toBe(true)
++  })
++
++  it('still allows deactivated -> deactivated (no-op / idempotent)', () => {
++    expect(canTransition('deactivated', 'deactivated')).toBe(true)
++  })
++
++  it('does not allow deactivated -> suspended', () => {
++    expect(canTransition('deactivated', 'suspended')).toBe(false)
++  })
++
++  it('leaves the other rows of the matrix unchanged', () => {
++    expect(canTransition('pending', 'approved')).toBe(true)
++    expect(canTransition('pending', 'suspended')).toBe(false)
++    expect(canTransition('approved', 'suspended')).toBe(true)
++    expect(canTransition('approved', 'pending')).toBe(false)
++    expect(canTransition('suspended', 'approved')).toBe(true)
++    expect(canTransition('suspended', 'pending')).toBe(false)
++  })
++})
+-- 
+2.43.0
+

--- a/src/services/__tests__/verifiers.transitionMatrix.test.ts
+++ b/src/services/__tests__/verifiers.transitionMatrix.test.ts
@@ -1,0 +1,33 @@
+import { canTransition } from '../verifiers.js'
+
+// Regression test for #1275: POST /:userId/reinstate computes
+// nextStatus = verifier.approvedAt ? 'approved' : 'pending', but the
+// transition matrix rejected deactivated -> approved, so a previously
+// approved verifier could never actually be reinstated to 'approved' --
+// the endpoint's own documented primary use case.
+describe('canTransition (verifier status matrix)', () => {
+  it('allows a deactivated verifier to be reinstated straight to approved', () => {
+    expect(canTransition('deactivated', 'approved')).toBe(true)
+  })
+
+  it('still allows deactivated -> pending (reactivate flow)', () => {
+    expect(canTransition('deactivated', 'pending')).toBe(true)
+  })
+
+  it('still allows deactivated -> deactivated (no-op / idempotent)', () => {
+    expect(canTransition('deactivated', 'deactivated')).toBe(true)
+  })
+
+  it('does not allow deactivated -> suspended', () => {
+    expect(canTransition('deactivated', 'suspended')).toBe(false)
+  })
+
+  it('leaves the other rows of the matrix unchanged', () => {
+    expect(canTransition('pending', 'approved')).toBe(true)
+    expect(canTransition('pending', 'suspended')).toBe(false)
+    expect(canTransition('approved', 'suspended')).toBe(true)
+    expect(canTransition('approved', 'pending')).toBe(false)
+    expect(canTransition('suspended', 'approved')).toBe(true)
+    expect(canTransition('suspended', 'pending')).toBe(false)
+  })
+})

--- a/src/services/verifiers.ts
+++ b/src/services/verifiers.ts
@@ -49,7 +49,7 @@ const transitionMatrix: Record<VerifierStatus, VerifierStatus[]> = {
   pending: ['pending', 'approved', 'deactivated'],
   approved: ['approved', 'suspended', 'deactivated'],
   suspended: ['suspended', 'approved', 'deactivated'],
-  deactivated: ['deactivated', 'pending'],
+  deactivated: ['deactivated', 'pending', 'approved'],
 }
 
 export const canTransition = (from: VerifierStatus, to: VerifierStatus): boolean =>


### PR DESCRIPTION
## Summary
Fixes `POST /:userId/reinstate` so it can actually restore a previously-approved, now-deactivated verifier back to `approved`, as the endpoint's own doc comment describes.

## Root cause
`transitionMatrix` in `src/services/verifiers.ts` only allowed `deactivated -> pending`, with no `deactivated -> approved` edge. The reinstate handler computes `nextStatus = verifier.approvedAt ? 'approved' : 'pending'`, so for the exact scenario the endpoint documents (an approved verifier who was later deactivated), `nextStatus` resolves to `'approved'` and `transitionVerifier` always threw `InvalidVerifierStatusTransitionError`.

## Changes
- Added `'approved'` as a valid transition target from `'deactivated'` in `transitionMatrix`
- Verified `statusAction()` needs no change — it already resolves `to === 'approved'` to `'verifier.approved'` before reaching the `deactivated`-specific branch, so audit logging is correct for this new transition
- Added focused, DB-free unit tests on `canTransition` covering:
  - `deactivated -> approved` now succeeds (the regression case)
  - `deactivated -> pending` and `deactivated -> deactivated` still work
  - `deactivated -> suspended` still correctly rejected
  - other matrix rows unchanged

## Testing
- [ ] `npm test -- verifiers.transitionMatrix`
- [ ] Manually verified `POST /:userId/reinstate` on a verifier with `approvedAt` set and status `deactivated` now returns 200 with `status: 'approved'` instead of 409

Closes #1275