### PR TITLE
fix: validate time format in parseTimeToMinutes (#1294)

### DIFF
--- a/src/utils/quietHours.ts
+++ b/src/utils/quietHours.ts
@@ -11,8 +11,12 @@ export interface QuietHoursConfig {
 
 /**
  * Parses HH:MM time string to minutes since midnight.
+ * Throws an error if the input is not a valid HH:MM format.
  */
 export function parseTimeToMinutes(time: string): number {
+  if (!isValidTimeFormat(time)) {
+    throw new Error(`Invalid time format: ${time}. Expected HH:MM.`);
+  }
   const [hours, minutes] = time.split(':').map(Number)
   return hours * 60 + minutes
 }


### PR DESCRIPTION
## Description
Resolves #1294 

Currently, `parseTimeToMinutes` assumes its input is well-formed and computes nonsensical minute values (or `NaN`) when given unvalidated or malformed time strings (such as `'24:00'` or arbitrary text). 

This PR introduces an explicit validation check using the existing `isValidTimeFormat` utility. `parseTimeToMinutes` will now fail loudly by throwing an error if it receives a malformed time string, preventing the system from silently computing and relying on incorrect quiet-hours windows.

## Changes Made
- Added a validation guard in `src/utils/quietHours.ts` within `parseTimeToMinutes`
- Throws a descriptive `Error` if `isValidTimeFormat` returns false