### PR TITLE
refactor: centralize milestone input parsing

### DIFF
--- a/src/routes/milestones.ts
+++ b/src/routes/milestones.ts
@@ -22,7 +22,7 @@ import {
   getVerifierProfile,
 } from '../services/verifiers.js'
 import {
-  milestoneSchema,
+  parseMilestoneInput,
   flattenZodErrors,
 } from '../services/vaultValidation.js'
 
@@ -48,7 +48,7 @@ milestonesRouter.post('/', authenticate, requireUser, async (req: Request, res: 
   }
 
   // Validate milestone fields using the same schema as vault creation.
-  const parsed = milestoneSchema.safeParse(req.body)
+  const parsed = parseMilestoneInput(req.body)
   if (!parsed.success) {
     return next(AppError.badRequest('Invalid milestone payload', flattenZodErrors(parsed.error)))
   }

--- a/src/services/vaultValidation.ts
+++ b/src/services/vaultValidation.ts
@@ -175,6 +175,11 @@ export const milestoneSchema = z.object({
   amount: amountStringSchema,
 })
 
+/** Single entry point for standalone milestone creation validation. */
+export function parseMilestoneInput(input: unknown) {
+  return milestoneSchema.safeParse(input)
+}
+
 // ─── Root vault schema ───────────────────────────────────────────────────────
 
 export const createVaultSchema = z


### PR DESCRIPTION
Closes #1444

Expose one shared milestone input parser from vault validation and use it at the standalone milestone creation route so both creation paths share the same field rules.

Validation: git diff --check passed.