### PR TITLE
ci: check OpenAPI spec drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Typecheck OpenAPI docs
         run: npm run openapi:typecheck
 
+      - name: Verify generated OpenAPI is committed
+        run: npm run openapi:check
+
       - name: Apply migrations
         run: npm run migrate:latest
 


### PR DESCRIPTION
Closes #1445

Run the existing OpenAPI drift checker in CI after typechecking so generated docs cannot silently diverge from the route registry.

Validation: git diff --check passed.