### PR TITLE
fix(quota): scope async mutex by key and add timeout to prevent unbou…

### DIFF
--- a/src/services/exportQuota.ts
+++ b/src/services/exportQuota.ts
@@ -31,14 +31,24 @@ const utcDateString = (d = new Date()): string => d.toISOString().slice(0, 10)
 
 const createInMemoryOrgQuotaRepository = (): OrgQuotaRepository => {
   const store = new Map<string, OrgQuotaEntry>()
-  const mutex = new AsyncMutex()
+  const mutexes = new Map<string, AsyncMutex>()
   const key = (orgId: string, date: string, metric: string) => `${orgId}:${date}:${metric}`
+
+  const getMutex = (k: string) => {
+    let mutex = mutexes.get(k)
+    if (!mutex) {
+      mutex = new AsyncMutex()
+      mutexes.set(k, mutex)
+    }
+    return mutex
+  }
 
   return {
     async increment(orgId, date, metric, dailyLimit) {
+      const k = key(orgId, date, metric)
+      const mutex = getMutex(k)
       // Atomically read, check, and increment under mutex
       return mutex.runExclusive(() => {
-        const k = key(orgId, date, metric)
         const existing = store.get(k)
         const entry: OrgQuotaEntry = {
           orgId,
@@ -49,6 +59,7 @@ const createInMemoryOrgQuotaRepository = (): OrgQuotaRepository => {
           updatedAt: new Date().toISOString(),
         }
         store.set(k, entry)
+        
         return { ...entry }
       })
     },
@@ -58,6 +69,7 @@ const createInMemoryOrgQuotaRepository = (): OrgQuotaRepository => {
     },
     async reset() {
       store.clear()
+      mutexes.clear()
     },
   }
 }

--- a/src/utils/asyncMutex.ts
+++ b/src/utils/asyncMutex.ts
@@ -14,14 +14,29 @@ export class AsyncMutex {
   private locked = false
   private readonly waitQueue: ((value?: unknown) => void)[] = []
 
-  /**
-   * Acquire the lock, run `fn` exclusively, then release the lock.
-   * Returns the value produced by `fn`, or re-throws if `fn` throws.
-   */
-  async runExclusive<T>(fn: () => Promise<T> | T): Promise<T> {
+  async runExclusive<T>(fn: () => Promise<T> | T, timeoutMs: number = 15000): Promise<T> {
     // Wait until unlocked
     while (this.locked) {
-      await new Promise<void>((resolve) => this.waitQueue.push(resolve as () => void))
+      await new Promise<void>((resolve, reject) => {
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+        const resolveWrapper = () => {
+          if (timeoutId) clearTimeout(timeoutId);
+          resolve();
+        };
+
+        this.waitQueue.push(resolveWrapper);
+
+        if (timeoutMs > 0) {
+          timeoutId = setTimeout(() => {
+            const index = this.waitQueue.indexOf(resolveWrapper);
+            if (index !== -1) {
+              this.waitQueue.splice(index, 1);
+            }
+            reject(new Error(`AsyncMutex wait timeout after ${timeoutMs}ms`));
+          }, timeoutMs);
+        }
+      })
     }
     this.locked = true
 


### PR DESCRIPTION
 --body "Resolves #1285

**Changes:**
- Scoped the \`AsyncMutex\` in \`src/services/exportQuota.ts\` to use a \`Map\` keyed by \`(orgId, date, metric)\` instead of a single global lock. This ensures that a stuck DB connection for one organization won't block the quota checks for all other organizations indefinitely.
- Added a \`timeoutMs\` parameter (defaulting to 15s) to \`AsyncMutex.runExclusive\` in \`src/utils/asyncMutex.ts\`. Waiters that remain in the queue longer than the timeout will automatically be removed and rejected with an error, preventing indefinite queuing and failing fast."
```

---

Alternatively, if you are creating the PR **in the GitHub Web UI** by following the link `https://github.com/Derekwalter999/Disciplr-backend/pull/new/fix/async-mutex-queue-1285`, here is the text you can copy and paste:

**Title:**
> Fix: Scope AsyncMutex and add timeout (#1285)

**Description:**
> Resolves #1285
> 
> **Changes:**
> - Scoped the `AsyncMutex` in `src/services/exportQuota.ts` to use a `Map` keyed by `(orgId, date, metric)` instead of a single global lock. This ensures that a stuck DB connection for one organization won't block the quota checks for all other organizations indefinitely.
> - Added a `timeoutMs` parameter (defaulting to 15s) to `AsyncMutex.runExclusive` in `src/utils/asyncMutex.ts`. Waiters that remain in the queue longer than the timeout will automatically be removed and rejected with an error, preventing indefinite queuing and failing fast.